### PR TITLE
Revert "PyTorch 1.0: Switch to new way to initialize CPU tensors"

### DIFF
--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -139,7 +139,8 @@ int DoAllgatherCudaOnCPU(at::Tensor tensor, at::Tensor output,
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
   auto ready_event = RecordReadyEvent(device);
 
-  auto cpu_output = at::CPU(cpu_tensor.type().scalarType()).tensor({});
+  auto cpu_output =
+      at::tensor(cpu_tensor.type()).to(at::Device(at::DeviceType::CPU));
   auto hvd_cpu_output = std::make_shared<TorchTensor>(cpu_output);
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);


### PR DESCRIPTION
This way of initialization creates `Tensor` rather than `Variable`, which fails at `copy()`.
```
  auto cpu_output = at::CPU(cpu_tensor.type().scalarType()).tensor({});
```

Reverts uber/horovod#555