### PR TITLE
Switch Horovod Shutdown to OutOfRange error

### DIFF
--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -36,6 +36,10 @@ Status Status::UnknownError(std::string message) {
   return Status(StatusType::UNKNOWN_ERROR, message);
 }
 
+Status Status::OutOfRangeError(std::string message){
+  return Status(StatusType::OUT_OF_RANGE_ERROR, message);
+}
+
 Status Status::PreconditionError(std::string message) {
   return Status(StatusType::PRECONDITION_ERROR, message);
 }

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -30,7 +30,8 @@ namespace common {
 // List of supported frameworks.
 enum Framework { TENSORFLOW, PYTORCH };
 
-enum StatusType { OK, UNKNOWN_ERROR, PRECONDITION_ERROR, ABORTED, INVALID_ARGUMENT };
+enum StatusType { OK, UNKNOWN_ERROR, OUT_OF_RANGE_ERROR, PRECONDITION_ERROR,
+    ABORTED, INVALID_ARGUMENT };
 
 enum DeviceType { CPU, GPU };
 
@@ -39,6 +40,7 @@ public:
   Status();
   static Status OK();
   static Status UnknownError(std::string message);
+  static Status OutOfRangeError(std::string message);
   static Status PreconditionError(std::string message);
   static Status Aborted(std::string message);
   static Status InvalidArgument(std::string message);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -255,7 +255,7 @@ HorovodGlobalState horovod_global;
 const Status NOT_INITIALIZED_ERROR = Status::PreconditionError(
     "Horovod has not been initialized; use hvd.init().");
 
-const Status SHUT_DOWN_ERROR = Status::UnknownError(
+const Status SHUT_DOWN_ERROR = Status::OutOfRangeError(
     "Horovod has been shut down. This was caused by an exception on one of the "
     "ranks or an attempt to allreduce, allgather or broadcast a tensor after "
     "one of the ranks finished execution. If the shutdown was caused by an "

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -46,6 +46,8 @@ Status ConvertStatus(const common::Status& status) {
     return Status::OK();
   case common::UNKNOWN_ERROR:
     return errors::Unknown(status.reason());
+  case common::OUT_OF_RANGE_ERROR:
+    return errors::OutOfRange(status.reason());
   case common::PRECONDITION_ERROR:
     return errors::FailedPrecondition(status.reason());
   case common::ABORTED:

--- a/horovod/torch/adapter.cc
+++ b/horovod/torch/adapter.cc
@@ -146,7 +146,9 @@ void ThrowIfError(Status status) {
     throw std::runtime_error(status.reason());
   case StatusType::INVALID_ARGUMENT:
     throw std::invalid_argument(status.reason());
-  default: // Includes UNKNOWN_ERROR and OUT_OF_RANGE_ERROR
+  case StatusType::OUT_OF_RANGE_ERROR:
+    throw std::runtime_error(status.reason());
+  default: // Includes UNKNOWN_ERROR
     throw std::runtime_error(status.reason());
   }
 }

--- a/horovod/torch/adapter.cc
+++ b/horovod/torch/adapter.cc
@@ -146,7 +146,7 @@ void ThrowIfError(Status status) {
     throw std::runtime_error(status.reason());
   case StatusType::INVALID_ARGUMENT:
     throw std::invalid_argument(status.reason());
-  default: // Includes UNKNOWN_ERROR
+  default: // Includes UNKNOWN_ERROR and OUT_OF_RANGE_ERROR
     throw std::runtime_error(status.reason());
   }
 }

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -110,7 +110,7 @@ void ThrowIfError(Status status) {
     throw std::runtime_error(status.reason());
   case StatusType::INVALID_ARGUMENT:
     throw std::invalid_argument(status.reason());
-  default: // Includes UNKNOWN_ERROR
+  default: // Includes UNKNOWN_ERROR and OUT_OF_RANGE_ERROR
     throw std::runtime_error(status.reason());
   }
 }

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -110,7 +110,9 @@ void ThrowIfError(Status status) {
     throw std::runtime_error(status.reason());
   case StatusType::INVALID_ARGUMENT:
     throw std::invalid_argument(status.reason());
-  default: // Includes UNKNOWN_ERROR and OUT_OF_RANGE_ERROR
+  case StatusType::OUT_OF_RANGE_ERROR:
+    throw std::runtime_error(status.reason());
+  default: // Includes UNKNOWN_ERROR
     throw std::runtime_error(status.reason());
   }
 }


### PR DESCRIPTION
If one worker processes fewer batches than the other workers or equivalently if it finishes the training with a smaller number of steps than the others, a SHUT_DOWN_ERROR will be raised in rank 0. translating this error into a `tf.error.UnknownError` causes the `tf.estimator.Estimator.train` function to finish prematurely without checkpointing the final model.  As specified here https://github.com/tensorflow/tensorflow/blob/a6d8ffae097d0132989ae4688d224121ec6d8f35/tensorflow/python/estimator/estimator.py#L303, `tf.estimator.Estimator.train` catches `tf.errors.OutOfRange` and can safely store the final model before terminating the process. Changing the error type solves this problem. 

The down side of this approach is that the rank 0 output does not print any error messages or exceptions. In the case that the SHUT_DOWN_ERROR was caused by another issue, like an internal bug or an MPI related problem, this would prevent the error from being propagated properly to the output. One potential way to address this point is to print an error message on rank 0 when a SHUT_DOWN_ERROR is raised. 

@alsrgv any thoughts?