### PR TITLE
Dockerfile: install  libibverbs-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION} \
         libnccl-dev=${NCCL_VERSION} \
+        libibverbs-dev \
         libjpeg-dev \
         libpng-dev \
         python${PYTHON_VERSION} \


### PR DESCRIPTION
When trying to execute the Docker container, the application starts printing warning about the inability of NCCL of finding libibverbs.so

This PR updates the Dockerfile installing the missing requirement