### PR TITLE
Fix Python 3.6 by migrating to Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ install:
   # Keras & dependencies
   - docker exec ${CONTAINER} /bin/sh -c "pip install ${KERAS_PACKAGE} h5py scipy pandas"
 
-  # typing for PyTorch
-  - docker exec ${CONTAINER} /bin/sh -c "pip install typing"
+  # PyTorch dependencies
+  - docker exec ${CONTAINER} /bin/sh -c "pip install future typing"
 
   # PyTorch
   - |


### PR DESCRIPTION
debian:stretch has Python 3.5, while debian:buster has Python 3.7.  There's no Debian distribution with Python 3.6, but frameworks like TensorFlow don't have Python 3.7 builds yet.