### PR TITLE
Update MXNet example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,15 +258,12 @@ loss_fn = ...
 for epoch in range(num_epoch):
     train_data.reset()
     for nbatch, batch in enumerate(train_data, start=1):
-        data = gluon.utils.split_and_load(batch.data[0], ctx_list=[context],
-                                          batch_axis=0)
-        label = gluon.utils.split_and_load(batch.label[0], ctx_list=[context],
-                                           batch_axis=0)
+        data = batch.data[0].as_in_context(context)
+        label = batch.label[0].as_in_context(context)
         with autograd.record():
-            outputs = [model(x.astype(dtype, copy=False)) for x in data]
-            loss = [loss_fn(yhat, y) for yhat, y in zip(outputs, label)]
-        for l in loss:
-            l.backward()
+            output = model(data.astype(dtype, copy=False))
+            loss = loss_fn(output, label)
+        loss.backward()
         trainer.step(batch_size)
 ```
 

--- a/examples/mxnet_imagenet_resnet50.py
+++ b/examples/mxnet_imagenet_resnet50.py
@@ -150,10 +150,8 @@ def get_data_rec(rec_train, rec_train_idx, rec_val, rec_val_idx, batch_size,
     mean_rgb = [123.68, 116.779, 103.939]
 
     def batch_fn(batch, ctx):
-        data = gluon.utils.split_and_load(batch.data[0], ctx_list=ctx,
-                                          batch_axis=0)
-        label = gluon.utils.split_and_load(batch.label[0], ctx_list=ctx,
-                                           batch_axis=0)
+        data = batch.data[0].as_in_context(ctx)
+        label = batch.label[0].as_in_context(ctx)
         return data, label
 
     train_data = mx.io.ImageRecordIter(
@@ -303,10 +301,10 @@ def train_gluon():
         acc_top1 = mx.metric.Accuracy()
         acc_top5 = mx.metric.TopKAccuracy(5)
         for _, batch in enumerate(val_data):
-            data, label = batch_fn(batch, [context])
-            outputs = [net(x.astype(args.dtype, copy=False)) for x in data]
-            acc_top1.update(label, outputs)
-            acc_top5.update(label, outputs)
+            data, label = batch_fn(batch, context)
+            output = net(data.astype(args.dtype, copy=False))
+            acc_top1.update([label], [output])
+            acc_top5.update([label], [output])
 
         top1_name, top1_acc = acc_top1.get()
         top5_name, top5_acc = acc_top5.get()
@@ -336,15 +334,14 @@ def train_gluon():
 
         btic = time.time()
         for nbatch, batch in enumerate(train_data, start=1):
-            data, label = batch_fn(batch, [context])
+            data, label = batch_fn(batch, context)
             with autograd.record():
-                outputs = [net(x.astype(args.dtype, copy=False)) for x in data]
-                loss = [loss_fn(yhat, y) for yhat, y in zip(outputs, label)]
-            for l in loss:
-                l.backward()
+                output = net(data.astype(args.dtype, copy=False))
+                loss = loss_fn(output, label)
+            loss.backward()
             trainer.step(batch_size)
 
-            metric.update(label, outputs)
+            metric.update([label], [output])
             if args.log_interval and nbatch % args.log_interval == 0:
                 name, acc = metric.get()
                 logging.info('Epoch[%d] Rank[%d] Batch[%d]\t%s=%f\tlr=%f',


### PR DESCRIPTION
No need to call `split_and_load `, which is meant for splitting data when the number of context is greater than 1. Calling `as_in_context` should be sufficient. Also I made the training loop simpler. 