### PR TITLE
Implicit dim for  log_softmax  is deprecated.

### DIFF
--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -81,7 +81,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 
 model = Net()


### PR DESCRIPTION
Replace
``` return F.log_softmax(x)  ``` 
with 
``` return F.log_softmax(x, dim=1) ```
