### PR TITLE
MXNet: support broadcasting deferred initialization parameters in Gluon

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -30,6 +30,7 @@ from horovod.mxnet.mpi_ops import size, local_size, rank, local_rank
 from horovod.mxnet.mpi_ops import mpi_threads_supported
 
 import mxnet as mx
+import types
 
 
 # This is where Horovod's DistributedOptimizer wrapper for MXNet goes
@@ -68,19 +69,14 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
         self._optimizer.set_wd_mult(args_wd_mult)
 
 
-# DistributedInitializer wraps MXNet Initializer which initializes and broadcasts parameter.
-class DistributedInitializer(mx.initializer.Initializer):
-    def __init__(self, init, root_rank=0):
-        self._init = init
-        self._root_rank = root_rank
-
-    def __call__(self, desc, arr):
-        self._init(desc, arr)
-        broadcast_(arr, self._root_rank, desc)
-        arr.wait_to_read()
-
-    def _init_weight(self, name, arr):
-        self._init._init_weight(name, arr)
+# Wrapper to inject Horovod broadcast after parameter initialization
+def _append_broadcast_init(param, root_rank):
+    init_impl = getattr(param, '_init_impl')
+    def wrapped_init_impl(self, *args, **kwargs):
+        init_impl(*args, **kwargs)
+        broadcast_(self.data(), root_rank=root_rank)
+        self.data().wait_to_read()
+    return wrapped_init_impl
 
 
 def broadcast_parameters(params, root_rank=0):
@@ -104,8 +100,10 @@ def broadcast_parameters(params, root_rank=0):
             try:
                 tensors.append(p.data())
             except mx.gluon.parameter.DeferredInitializationError:
-                # skip broadcasting deferred init param
-                pass
+                # Inject wrapper method with post-initialization broadcast to
+                # handle parameters with deferred initialization
+                new_init = _append_broadcast_init(p, root_rank)
+                p._init_impl = types.MethodType(new_init, p)
     else:
         raise ValueError('invalid params of type: %s' % type(params))
 


### PR DESCRIPTION
Fixes #895 

In Gluon, we defer initialization for some parameters until their shapes are known during the first forward pass. This makes it difficult for us to sync parameters among workers when we train with different random seeds for workers.

To solve the issue, we inject broadcast into init_impl of deferred initialized Gluon Parameter. Thanks @romerojosh for suggesting this idea.