### PR TITLE
Use os.setsid() instead of os.setpgid()

### DIFF
--- a/horovod/spark/util/safe_shell_exec.py
+++ b/horovod/spark/util/safe_shell_exec.py
@@ -78,7 +78,7 @@ def execute(command, env=None, stdout=None, stderr=None):
     if middleman_pid == 0:
         # Close unused file descriptors to enforce PIPE behavior.
         os.close(w)
-        os.setpgid(0, 0)
+        os.setsid()
 
         executor_shell = subprocess.Popen(command, shell=True, env=env,
                                           stdout=stdout_w, stderr=stderr_w)


### PR DESCRIPTION
We've encountered an issue with launching ssh inside safe_shell_exec.
OpenSSH makes use of tcsetattr() to set terminal properties, which gets
propagated to whole process group.  setsid() provides better isolation
of newly spawned process.

Additional reading: https://en.wikipedia.org/wiki/Process_group