### PR TITLE
from elementSizeInBytes to element_size, following upstream commit ht…

### DIFF
--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -70,7 +70,11 @@ const TensorShape TorchTensor::shape() const {
 const void* TorchTensor::data() const { return tensor_.data_ptr(); }
 
 int64_t TorchTensor::size() const {
+# if TORCH_VERSION >= 1001000000
   return tensor_.element_size() * tensor_.numel();
+#else
+  return tensor_.type().elementSizeInBytes() * tensor_.numel();
+#endif
 }
 
 TorchOpContext::TorchOpContext(int device, ::torch::Tensor output)

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -70,7 +70,7 @@ const TensorShape TorchTensor::shape() const {
 const void* TorchTensor::data() const { return tensor_.data_ptr(); }
 
 int64_t TorchTensor::size() const {
-  return tensor_.type().elementSizeInBytes() * tensor_.numel();
+  return tensor_.element_size() * tensor_.numel();
 }
 
 TorchOpContext::TorchOpContext(int device, ::torch::Tensor output)

--- a/setup.py
+++ b/setup.py
@@ -623,6 +623,8 @@ def build_tf_extension(build_ext, options):
 
 
 def parse_version(version_str):
+    if "dev" in version_str:
+        return 9999999999
     m = re.match('^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?', version_str)
     if m is None:
         return None


### PR DESCRIPTION
The function elementSizeInBytes was removed from the Aten library following issue pytorch/pytorch#17785. The commit changes the use of `type().elementSizeInBytes()` to `element_size()`.
