### PR TITLE
horovodrun: use os.execve() for mpirun

### DIFF
--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -475,10 +475,7 @@ def run():
     if args.verbose:
         print(mpirun_command)
     # Execute the mpirun command.
-    exit_code = safe_shell_exec.execute(mpirun_command, env)
-    if exit_code != 0:
-        raise Exception(
-            'mpirun exited with code %d, see the error above.' % exit_code)
+    os.execve('/bin/sh', ['/bin/sh', '-c', mpirun_command], env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
safe_shell_exec uses line buffering which does not play very well with
Keras and tqdm -- libraries that make use of progress bars.