### PR TITLE
Pin GCC to 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export CONTAINER=$(docker ps -q | head -n 1)
   - docker exec ${CONTAINER} /bin/sh -c "apt-get update -qq"
   # install necessary network tools
-  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y wget openssh-client git build-essential"
+  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y --no-install-recommends wget openssh-client git build-essential gcc-4.8 g++-4.8 gcc-4.8-base"
   # install OpenJDK 8 for PySpark
   - docker exec ${CONTAINER} /bin/sh -c "apt install -y openjdk-8-jdk-headless"
   # install Python and add a proper symlink
@@ -96,8 +96,12 @@ install:
   - docker exec ${CONTAINER} /bin/sh -c "pip install ${MXNET_PACKAGE}"
 
   # Horovod
+  # Pin GCC to 4.8 to compile correctly against TensorFlow
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100"
   - docker exec ${CONTAINER} /bin/sh -c "cd /horovod && python setup.py sdist"
   - docker exec ${CONTAINER} /bin/sh -c "pip install -v /horovod/dist/horovod-*.tar.gz"
+  # Remove GCC pinning
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove gcc /usr/bin/gcc-4.8 && update-alternatives --remove g++ /usr/bin/g++-4.8"
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,13 +95,19 @@ install:
   # MXNet
   - docker exec ${CONTAINER} /bin/sh -c "pip install ${MXNET_PACKAGE}"
 
-  # Horovod
   # Pin GCC to 4.8 to compile correctly against TensorFlow
-  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-4.8 100"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-4.8 100"
+  # Horovod
   - docker exec ${CONTAINER} /bin/sh -c "cd /horovod && python setup.py sdist"
   - docker exec ${CONTAINER} /bin/sh -c "pip install -v /horovod/dist/horovod-*.tar.gz"
   # Remove GCC pinning
-  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove gcc /usr/bin/gcc-4.8 && update-alternatives --remove g++ /usr/bin/g++-4.8"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove gcc /usr/bin/gcc-4.8"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove x86_64-linux-gnu-gcc /usr/bin/gcc-4.8"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove g++ /usr/bin/g++-4.8"
+  - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --remove x86_64-linux-gnu-g++ /usr/bin/g++-4.8"
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,25 +41,25 @@ before_install:
 
 env:
   matrix:
-    - TF_PACKAGE=tensorflow==1.1.0 KERAS_PACKAGE=keras==2.0.0 PYTORCH_PACKAGE=torch==0.4.0 MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.1.2
-    - TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.1 MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.3.2
-    - TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.4.0
-    - TF_PACKAGE=tf-nightly KERAS_PACKAGE=git+https://github.com/keras-team/keras.git PYTORCH_PACKAGE=torch-nightly MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.4.0
-    - TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet-gcc5 MPI=MPICH PYSPARK=2.4.0
+    - TF_PACKAGE=tensorflow==1.1.0 KERAS_PACKAGE=keras==2.0.0 PYTORCH_PACKAGE=torch==0.4.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.1.2
+    - TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.1 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.3.2
+    - TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.4.0
+    - TF_PACKAGE=tf-nightly KERAS_PACKAGE=git+https://github.com/keras-team/keras.git PYTORCH_PACKAGE=torch-nightly MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.4.0
+    - TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=MPICH PYSPARK=2.4.0
 
 matrix:
   fast_finish: true
   exclude:
     - python: "3.5"
-      env: TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.0 MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.3.2
+      env: TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.3.2
     - python: "3.6"
-      env: TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.1 MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.3.2
+      env: TF_PACKAGE=tensorflow==1.6.0 KERAS_PACKAGE=keras==2.1.2 PYTORCH_PACKAGE=torch==0.4.1 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.3.2
     - python: "3.5"
-      env: TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet-gcc5 MPI=MPICH PYSPARK=2.4.0
+      env: TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=MPICH PYSPARK=2.4.0
     - python: "3.6"
-      env: TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet-gcc5 MPI=MPICH PYSPARK=2.4.0
+      env: TF_PACKAGE=tensorflow==1.12.0 KERAS_PACKAGE=keras==2.2.2 PYTORCH_PACKAGE=torch==1.0.0 MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=MPICH PYSPARK=2.4.0
     - python: "3.5"
-      env: TF_PACKAGE=tf-nightly KERAS_PACKAGE=git+https://github.com/keras-team/keras.git PYTORCH_PACKAGE=torch-nightly MXNET_PACKAGE=mxnet-gcc5 MPI=OpenMPI PYSPARK=2.4.0
+      env: TF_PACKAGE=tf-nightly KERAS_PACKAGE=git+https://github.com/keras-team/keras.git PYTORCH_PACKAGE=torch-nightly MXNET_PACKAGE=mxnet==1.4.0.post0 MPI=OpenMPI PYSPARK=2.4.0
 
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export CONTAINER=$(docker ps -q | head -n 1)
   - docker exec ${CONTAINER} /bin/sh -c "apt-get update -qq"
   # install necessary network tools
-  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y --no-install-recommends wget openssh-client git build-essential gcc-4.8 g++-4.8 gcc-4.8-base"
+  - docker exec ${CONTAINER} /bin/sh -c "apt-get install -y --no-install-recommends wget ca-certificates openssh-client git build-essential gcc-4.8 g++-4.8 gcc-4.8-base"
   # install OpenJDK 8 for PySpark
   - docker exec ${CONTAINER} /bin/sh -c "apt install -y openjdk-8-jdk-headless"
   # install Python and add a proper symlink
@@ -100,6 +100,9 @@ install:
   - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-4.8 100"
   - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100"
   - docker exec ${CONTAINER} /bin/sh -c "update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-4.8 100"
+  # Remove incompatible flags from Python setup
+  - docker exec ${CONTAINER} /bin/sh -c "sed -i s/-fstack-protector-strong/-fstack-protector/g \$(find /usr/lib/python${TRAVIS_PYTHON_VERSION} -iname '*sysconfigdata*.py')"
+  - docker exec ${CONTAINER} /bin/sh -c "sed -i s/-Wdate-time//g \$(find /usr/lib/python${TRAVIS_PYTHON_VERSION} -iname '*sysconfigdata*.py')"
   # Horovod
   - docker exec ${CONTAINER} /bin/sh -c "cd /horovod && python setup.py sdist"
   - docker exec ${CONTAINER} /bin/sh -c "pip install -v /horovod/dist/horovod-*.tar.gz"


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/27067

Updates symlinks to gcc-4.8/g++-4.8 before Horovod installation, and restores them afterward.

NOTE: if Python was built with a more recent version of GCC, it may have incompatible flags in `/usr/lib/python${version}/.../_sysconfigdata*.py`.  We patch the Python installation to remove those flags.