### PR TITLE
MXNet: Normalize rescale_grad in optimizer by Horovod size

### DIFF
--- a/examples/mxnet_imagenet_resnet50.py
+++ b/examples/mxnet_imagenet_resnet50.py
@@ -279,15 +279,6 @@ net.cast(args.dtype)
 initializer = mx.init.Xavier(rnd_type='gaussian', factor_type="in",
                              magnitude=2)
 
-# Create optimizer
-optimizer_params = {'wd': args.wd,
-                    'momentum': args.momentum,
-                    'rescale_grad': 1.0 / batch_size,
-                    'lr_scheduler': lr_sched}
-if args.dtype == 'float16':
-    optimizer_params['multi_precision'] = True
-opt = mx.optimizer.create('sgd', **optimizer_params)
-
 
 def train_gluon():
     def evaluate(epoch):
@@ -316,6 +307,14 @@ def train_gluon():
     params = net.collect_params()
     if params is not None:
         hvd.broadcast_parameters(params, root_rank=0)
+
+    # Create optimizer
+    optimizer_params = {'wd': args.wd,
+                        'momentum': args.momentum,
+                        'lr_scheduler': lr_sched}
+    if args.dtype == 'float16':
+        optimizer_params['multi_precision'] = True
+    opt = mx.optimizer.create('sgd', **optimizer_params)
 
     # Horovod: create DistributedTrainer, a subclass of gluon.Trainer
     trainer = hvd.DistributedTrainer(params, opt)
@@ -408,6 +407,15 @@ def train_module():
     if aux_params is not None:
         hvd.broadcast_parameters(aux_params, root_rank=0)
     mod.set_params(arg_params=arg_params, aux_params=aux_params)
+
+    # Create optimizer
+    optimizer_params = {'wd': args.wd,
+                        'momentum': args.momentum,
+                        'rescale_grad': 1.0 / batch_size,
+                        'lr_scheduler': lr_sched}
+    if args.dtype == 'float16':
+        optimizer_params['multi_precision'] = True
+    opt = mx.optimizer.create('sgd', **optimizer_params)
 
     # Horovod: wrap optimizer with DistributedOptimizer
     dist_opt = hvd.DistributedOptimizer(opt)

--- a/examples/mxnet_imagenet_resnet50.py
+++ b/examples/mxnet_imagenet_resnet50.py
@@ -409,6 +409,10 @@ def train_module():
     mod.set_params(arg_params=arg_params, aux_params=aux_params)
 
     # Create optimizer
+    # Note that when using Module API, we need to specify rescale_grad since
+    # we create optimizer first and wrap it with DistributedOptimizer. For
+    # Gluon API, it is handled in Trainer.step() function so there is no need
+    # to specify rescale_grad (see above train_gluon() function). 
     optimizer_params = {'wd': args.wd,
                         'momentum': args.momentum,
                         'rescale_grad': 1.0 / batch_size,

--- a/examples/mxnet_mnist.py
+++ b/examples/mxnet_mnist.py
@@ -114,8 +114,7 @@ model.hybridize()
 
 # Create optimizer
 optimizer_params = {'momentum': args.momentum,
-                    'learning_rate': args.lr * hvd.size(),
-                    'rescale_grad': 1.0 / args.batch_size}
+                    'learning_rate': args.lr * hvd.size()}
 opt = mx.optimizer.create('sgd', **optimizer_params)
 
 # Initialize parameters


### PR DESCRIPTION
We currently perform average on gradients using allreduce methods in DistributedOptimizer and DistributedTrainer. This is equivalent to normalizing optimizer.rescale_grad by Horovod size(), which has better performance. 

This PR replaces allreduce average with normalized rescale_grad. Our tests show 2~3% performance boost when training ResNet50 with 8 GPUs.