### PR TITLE
MXNet: push Horovod operations to engine using CPU context

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -51,7 +51,8 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
     def _do_allreduce(self, index, grad):
         if isinstance(index, (tuple, list)):
             for i in range(len(index)):
-                allreduce_(grad[i], average=False, name=str(index[i]))
+                allreduce_(grad[i], average=False,
+                           name=str(index[i]), priority=-i)
         else:
             allreduce_(grad, average=False, name=str(index))
 
@@ -97,7 +98,8 @@ class DistributedTrainer(mx.gluon.Trainer):
     def _allreduce_grads(self):
         for i, param in enumerate(self._params):
             if param.grad_req != 'null':
-                allreduce_(param.list_grad()[0], average=False, name=str(i))
+                allreduce_(param.list_grad()[0], average=False,
+                           name=str(i), priority=-i)
 
 
 # Wrapper to inject Horovod broadcast after parameter initialization

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -28,7 +28,7 @@ namespace {
 
 std::atomic_int op_count;
 
-std::string GetOpName(std::string prefix, char* name) {
+std::string GetOpName(const std::string& prefix, const char* name) {
   if (name != nullptr) {
     return prefix + "." + std::string(name);
   }
@@ -37,6 +37,8 @@ std::string GetOpName(std::string prefix, char* name) {
   return prefix + ".noname." + std::to_string(op_count);
 }
 } // namespace
+
+const auto EXEC_CTX = Context::CPU();
 
 inline void InvokeCompleteCallback(CallbackOnComplete on_complete, const Status& status) {
   if (status.ok()) {
@@ -162,7 +164,8 @@ void DoBroadcastCudaOnCPU(MXTempBufferShared& hvd_cpu_buffer, int root_rank,
 #endif
 
 extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
-                                             char* name, bool average) {
+                                             const char* name, bool average,
+                                             int priority) {
   MX_API_BEGIN();
 
   std::string op_name = GetOpName("allreduce", name);
@@ -181,9 +184,10 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
     DoAllreduceCudaOnCPU(hvd_cpu_buffer, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(allreduce_async_cpu_fn, Context::CPU(),
+  Engine::Get()->PushAsync(allreduce_async_cpu_fn, EXEC_CTX,
                            {}, {cpu_tensor->var()},
-                           FnProperty::kNormal, 0, "HorovodAllreduce");
+                           FnProperty::kCPUPrioritized, priority,
+                           "HorovodAllreduce");
 
   // Make async copy of CPU tensor to output tensor.
   TensorUtil::AsyncCopyCPUToCuda(cpu_tensor, output);
@@ -196,14 +200,16 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(allreduce_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(allreduce_async_fn, EXEC_CTX,
                              {input->var()}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodAllreduce");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodAllreduce");
   // In-place
   } else {
-    Engine::Get()->PushAsync(allreduce_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(allreduce_async_fn, EXEC_CTX,
                              {}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodAllreduce");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodAllreduce");
   }
 #endif
 
@@ -215,7 +221,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 }
 
 extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
-                                             char* name) {
+                                             const char* name, int priority) {
   MX_API_BEGIN();
 
   std::string op_name = GetOpName("allgather", name);
@@ -234,9 +240,10 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
     DoAllgatherCudaOnCPU(hvd_cpu_buffer, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(allgather_async_cpu_fn, Context::CPU(),
+  Engine::Get()->PushAsync(allgather_async_cpu_fn, EXEC_CTX,
                            {}, {cpu_tensor->var()},
-                           FnProperty::kNormal, 0, "HorovodAllgather");
+                           FnProperty::kCPUPrioritized, priority,
+                           "HorovodAllgather");
 
   // Make async copy of CPU tensor to output tensor.
   TensorUtil::AsyncCopyCPUToCuda(cpu_tensor, output);
@@ -249,14 +256,16 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(allgather_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(allgather_async_fn, EXEC_CTX,
                              {input->var()}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodAllgather");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodAllgather");
   // In-place
   } else {
-    Engine::Get()->PushAsync(allgather_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(allgather_async_fn, EXEC_CTX,
                              {}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodAllgather");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodAllgather");
   }
 #endif
 
@@ -264,7 +273,8 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
 }
 
 extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
-                                             char* name, int root_rank) {
+                                             const char* name, int root_rank,
+                                             int priority) {
   MX_API_BEGIN();
 
   std::string op_name = GetOpName("broadcast", name);
@@ -283,9 +293,10 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
     DoBroadcastCudaOnCPU(hvd_cpu_buffer, root_rank, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(broadcast_async_cpu_fn, Context::CPU(),
+  Engine::Get()->PushAsync(broadcast_async_cpu_fn, EXEC_CTX,
                            {}, {cpu_tensor->var()},
-                           FnProperty::kNormal, 0, "HorovodBroadcast");
+                           FnProperty::kCPUPrioritized, priority,
+                           "HorovodBroadcast");
 
   // Make async copy of CPU tensor to output tensor.
   TensorUtil::AsyncCopyCPUToCuda(cpu_tensor, output);
@@ -298,14 +309,16 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(broadcast_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(broadcast_async_fn, EXEC_CTX,
                              {input->var()}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodBroadcast");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodBroadcast");
   // In-place
   } else {
-    Engine::Get()->PushAsync(broadcast_async_fn, Context::CPU(),
+    Engine::Get()->PushAsync(broadcast_async_fn, EXEC_CTX,
                              {}, {output->var()},
-                             FnProperty::kNormal, 0, "HorovodBroadcast");
+                             FnProperty::kCPUPrioritized, priority,
+                             "HorovodBroadcast");
   }
 #endif
 

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -181,7 +181,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
     DoAllreduceCudaOnCPU(hvd_cpu_buffer, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(allreduce_async_cpu_fn, cpu_tensor->ctx(),
+  Engine::Get()->PushAsync(allreduce_async_cpu_fn, Context::CPU(),
                            {}, {cpu_tensor->var()},
                            FnProperty::kNormal, 0, "HorovodAllreduce");
 
@@ -196,12 +196,12 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(allreduce_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(allreduce_async_fn, Context::CPU(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllreduce");
   // In-place
   } else {
-    Engine::Get()->PushAsync(allreduce_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(allreduce_async_fn, Context::CPU(),
                              {}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllreduce");
   }
@@ -234,7 +234,7 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
     DoAllgatherCudaOnCPU(hvd_cpu_buffer, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(allgather_async_cpu_fn, cpu_tensor->ctx(),
+  Engine::Get()->PushAsync(allgather_async_cpu_fn, Context::CPU(),
                            {}, {cpu_tensor->var()},
                            FnProperty::kNormal, 0, "HorovodAllgather");
 
@@ -249,12 +249,12 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(allgather_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(allgather_async_fn, Context::CPU(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllgather");
   // In-place
   } else {
-    Engine::Get()->PushAsync(allgather_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(allgather_async_fn, Context::CPU(),
                              {}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodAllgather");
   }
@@ -283,7 +283,7 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
     DoBroadcastCudaOnCPU(hvd_cpu_buffer, root_rank, op_name, on_complete);
   };
 
-  Engine::Get()->PushAsync(broadcast_async_cpu_fn, cpu_tensor->ctx(),
+  Engine::Get()->PushAsync(broadcast_async_cpu_fn, Context::CPU(),
                            {}, {cpu_tensor->var()},
                            FnProperty::kNormal, 0, "HorovodBroadcast");
 
@@ -298,12 +298,12 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
 
   // Not in-place
   if (input->var() != output->var()) {
-    Engine::Get()->PushAsync(broadcast_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(broadcast_async_fn, Context::CPU(),
                              {input->var()}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodBroadcast");
   // In-place
   } else {
-    Engine::Get()->PushAsync(broadcast_async_fn, input->ctx(),
+    Engine::Get()->PushAsync(broadcast_async_fn, Context::CPU(),
                              {}, {output->var()},
                              FnProperty::kNormal, 0, "HorovodBroadcast");
   }

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -33,11 +33,13 @@ typedef ::mxnet::engine::CallbackOnComplete CallbackOnComplete;
 typedef std::shared_ptr<MXTemporaryBuffer<NDArray>> MXTempBufferShared;
 
 extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
-                                             char* name, bool average);
+                                             const char* name, bool average,
+                                             int priority);
 extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
-                                             char* name);
+                                             const char* name, int priority);
 extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
-                                             char* name, int root_rank);
+                                             const char* name, int root_rank,
+                                             int priority);
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -61,8 +61,8 @@ def allreduce(tensor, average=True, name=None, priority=0):
         average: A flag indicating whether to compute average or summation,
                  defaults to average.
         name: A name of the reduction operation.
-        priority: The priority of this operation. Higher priority operations are
-                  likely to be executed before other actions.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -99,8 +99,8 @@ def allreduce_(tensor, average=True, name=None, priority=0):
         average: A flag indicating whether to compute average or summation,
                  defaults to average.
         name: A name of the reduction operation.
-        priority: The priority of this operation. Higher priority operations are
-                  likely to be executed before other actions.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -135,8 +135,8 @@ def allgather(tensor, name=None, priority=0):
     Arguments:
         tensor: A tensor to allgather.
         name: A name of the allgather operation.
-        priority: The priority of this operation. Higher priority operations are
-                  likely to be executed before other actions.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
 
     Returns:
         A tensor of the same type as `tensor`, concatenated on dimension zero
@@ -176,8 +176,8 @@ def broadcast(tensor, root_rank, name=None, priority=0):
         tensor: A tensor to broadcast.
         root_rank: The rank to broadcast the value from.
         name: A name of the broadcast operation.
-        priority: The priority of this operation. Higher priority operations are
-                  likely to be executed before other actions.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
 
     Returns:
         A tensor of the same shape and type as `tensor`, with the value
@@ -212,8 +212,8 @@ def broadcast_(tensor, root_rank, name=None, priority=0):
         tensor: A tensor to broadcast.
         root_rank: The rank to broadcast the value from.
         name: A name of the broadcast operation.
-        priority: The priority of this operation. Higher priority operations are
-                  likely to be executed before other actions.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
 
     Returns:
         A tensor of the same shape and type as `tensor`, with the value

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -42,7 +42,7 @@ dll_path = os.path.join(os.path.dirname(__file__),
 MPI_MXNET_LIB_CTYPES = ctypes.CDLL(dll_path, ctypes.RTLD_GLOBAL)
 
 
-def allreduce(tensor, average=True, name=None):
+def allreduce(tensor, average=True, name=None, priority=0):
     """
     A function that performs averaging or summation of the input tensor over
     all the Horovod processes. The input tensor is not modified.
@@ -61,6 +61,8 @@ def allreduce(tensor, average=True, name=None):
         average: A flag indicating whether to compute average or summation,
                  defaults to average.
         name: A name of the reduction operation.
+        priority: The priority of this operation. Higher priority operations are
+                  likely to be executed before other actions.
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -71,16 +73,18 @@ def allreduce(tensor, average=True, name=None):
     c_in = tensor.handle
     c_out = output.handle
     if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(c_in,
-                   c_out, c_str(name), ctypes.c_bool(average)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
+            c_in, c_out, c_str(name), ctypes.c_bool(average),
+            ctypes.c_int(priority)))
     else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(c_in,
-                   c_out, name, ctypes.c_bool(average)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
+            c_in, c_out, name, ctypes.c_bool(average),
+            ctypes.c_int(priority)))
 
     return output
 
 
-def allreduce_(tensor, average=True, name=None):
+def allreduce_(tensor, average=True, name=None, priority=0):
     """
     A function that performs in-place averaging or summation of the input
     tensor over all the Horovod processes.
@@ -95,6 +99,8 @@ def allreduce_(tensor, average=True, name=None):
         average: A flag indicating whether to compute average or summation,
                  defaults to average.
         name: A name of the reduction operation.
+        priority: The priority of this operation. Higher priority operations are
+                  likely to be executed before other actions.
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -103,15 +109,17 @@ def allreduce_(tensor, average=True, name=None):
     c_in = tensor.handle
     c_out = tensor.handle
     if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(c_in,
-                   c_out, c_str(name), ctypes.c_bool(average)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
+            c_in, c_out, c_str(name), ctypes.c_bool(average),
+            ctypes.c_int(priority)))
     else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(c_in,
-                   c_out, name, ctypes.c_bool(average)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
+            c_in, c_out, name, ctypes.c_bool(average),
+            ctypes.c_int(priority)))
     return tensor
 
 
-def allgather(tensor, name=None):
+def allgather(tensor, name=None, priority=0):
     """
     A function that concatenates the input tensor with the same input tensor on
     all other Horovod processes. The input tensor is not modified.
@@ -127,6 +135,8 @@ def allgather(tensor, name=None):
     Arguments:
         tensor: A tensor to allgather.
         name: A name of the allgather operation.
+        priority: The priority of this operation. Higher priority operations are
+                  likely to be executed before other actions.
 
     Returns:
         A tensor of the same type as `tensor`, concatenated on dimension zero
@@ -140,15 +150,15 @@ def allgather(tensor, name=None):
     c_in = tensor.handle
     c_out = output.handle
     if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allgather_async(c_in,
-                   c_out, c_str(name)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allgather_async(
+            c_in, c_out, c_str(name), ctypes.c_int(priority)))
     else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allgather_async(c_in,
-                   c_out, name))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allgather_async(
+            c_in, c_out, name, ctypes.c_int(priority)))
     return output
 
 
-def broadcast(tensor, root_rank, name=None):
+def broadcast(tensor, root_rank, name=None, priority=0):
     """
     A function that broadcasts the input tensor on root rank to the same input
     tensor on all other Horovod processes. The input tensor is not modified.
@@ -166,6 +176,8 @@ def broadcast(tensor, root_rank, name=None):
         tensor: A tensor to broadcast.
         root_rank: The rank to broadcast the value from.
         name: A name of the broadcast operation.
+        priority: The priority of this operation. Higher priority operations are
+                  likely to be executed before other actions.
 
     Returns:
         A tensor of the same shape and type as `tensor`, with the value
@@ -176,15 +188,17 @@ def broadcast(tensor, root_rank, name=None):
     c_in = tensor.handle
     c_out = output.handle
     if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(c_in,
-                   c_out, c_str(name), ctypes.c_int(root_rank)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(
+            c_in, c_out, c_str(name), ctypes.c_int(root_rank),
+            ctypes.c_int(priority)))
     else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(c_in,
-                   c_out, name, ctypes.c_int(root_rank)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(
+            c_in, c_out, name, ctypes.c_int(root_rank),
+            ctypes.c_int(priority)))
     return output
 
 
-def broadcast_(tensor, root_rank, name=None):
+def broadcast_(tensor, root_rank, name=None, priority=0):
     """
     A function that broadcasts the input tensor on root rank to the same input
     tensor on all other Horovod processes. The operation is performed in-place.
@@ -198,6 +212,8 @@ def broadcast_(tensor, root_rank, name=None):
         tensor: A tensor to broadcast.
         root_rank: The rank to broadcast the value from.
         name: A name of the broadcast operation.
+        priority: The priority of this operation. Higher priority operations are
+                  likely to be executed before other actions.
 
     Returns:
         A tensor of the same shape and type as `tensor`, with the value
@@ -206,9 +222,11 @@ def broadcast_(tensor, root_rank, name=None):
     c_in = tensor.handle
     c_out = tensor.handle
     if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(c_in,
-                   c_out, c_str(name), ctypes.c_int(root_rank)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(
+            c_in, c_out, c_str(name), ctypes.c_int(root_rank),
+            ctypes.c_int(priority)))
     else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(c_in,
-                   c_out, name, ctypes.c_int(root_rank)))
+        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_broadcast_async(
+            c_in, c_out, name, ctypes.c_int(root_rank),
+            ctypes.c_int(priority)))
     return tensor


### PR DESCRIPTION
@romerojosh noticed that small but noticeable time is spent pushing the Horovod ops to the engine, which has the effect of holding back GPU kernel launches if these ops are scheduled on the GPU context.

These small stalls are removed if these operations are put into the CPU context explicitly.
Placing these operations into the CPU context also makes some sense, since the underlying Horovod operation that is pushed to the MXNet engine itself doesn't mutate the GPU data, but just enqueues work to Horovod.

Since now all operations are pushed to CPU context, we also use kCPUPrioritized when pushing such that we can leverage the default multiple [MXNET_CPU_PRIORITY_NTHREADS](http://mxnet.incubator.apache.org/versions/master/faq/env_var.html) to schedule CPU jobs. This also aligns with the way of [pushing operations](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/gluon/trainer.py#L354) into kvstore.