### PR TITLE
MXNet: explicitly include c_api.h in tensor_utils.cc

### DIFF
--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 // =============================================================================
 
+#include <mxnet/c_api.h>
+
 #include "tensor_util.h"
 
 namespace horovod {


### PR DESCRIPTION
Fix include issue for the upcoming MXNet 1.4.1 release.