### PR TITLE
Add Join op (with only support for AllReduce and PyTorch for now)

### DIFF
--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -214,6 +214,8 @@ public:
                      std::shared_ptr<PersistentBuffer>* tensor) = 0;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) = 0;
+  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
+                                std::shared_ptr<Tensor>* tensor) = 0;
   virtual Framework framework() const = 0;
   virtual ~OpContext() = default;
 };

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -95,6 +95,9 @@ namespace common {
 // Device ID used for CPU.
 #define CPU_DEVICE_ID (-1)
 
+// Temporary tensor name for ranks that did Join().
+#define JOIN_TENSOR_NAME "join.noname"
+
 // List of supported frameworks.
 enum Framework { TENSORFLOW, PYTORCH, MXNET };
 

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -51,7 +51,8 @@ Controller::Controller(ResponseCache& response_cache, TensorQueue& tensor_queue,
       timeline_(timeline), response_cache_(response_cache),
       parameter_manager_(parameter_manager) {}
 
-ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
+ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
+                                             HorovodGlobalState& state) {
   // Update cache capacity if autotuning is active.
   if (parameter_manager_.IsAutoTuning()) {
     response_cache_.set_capacity((int)parameter_manager_.CacheEnabled() *
@@ -68,6 +69,11 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
   std::deque<Request> message_queue_tmp;
   tensor_queue_.PopMessagesFromQueue(message_queue_tmp);
   for (auto& message : message_queue_tmp) {
+    if (message.request_type() == Request::JOIN) {
+      state.joined = true;
+      state.join_device = message.device();
+    }
+
     // Keep track of cache hits
     if (response_cache_.capacity() > 0) {
       auto cache_ = response_cache_.cached(message);
@@ -193,7 +199,12 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
         Request message = message_queue_tmp.front();
         message_queue_tmp.pop_front();
 
-        bool reduce = IncrementTensorCount(message);
+        if (message.request_type() == Request::JOIN) {
+          state.joined_size++;
+          continue;
+        }
+
+        bool reduce = IncrementTensorCount(message, state.joined_size);
         stall_inspector_.RecordUncachedTensorStart(
             message.tensor_name(), message.request_rank(), size_);
         if (reduce) {
@@ -211,7 +222,13 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
         auto received_message_list = ready_list[i];
         for (auto& received_message : received_message_list.requests()) {
           auto& received_name = received_message.tensor_name();
-          bool reduce = IncrementTensorCount(received_message);
+
+          if (received_message.request_type() == Request::JOIN) {
+            state.joined_size++;
+            continue;
+          }
+
+          bool reduce = IncrementTensorCount(received_message, state.joined_size);
           stall_inspector_.RecordUncachedTensorStart(
               received_message.tensor_name(), received_message.request_rank(),
               size_);
@@ -222,6 +239,19 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
         if (received_message_list.shutdown()) {
           // Received SHUTDOWN request from one of the workers.
           should_shut_down = true;
+        }
+      }
+
+      // Check if tensors from previous ticks are ready to reduce after Joins.
+      if (state.joined_size > 0) {
+        for (auto& table_iter : message_table_) {
+          int count = (int)table_iter.second.size();
+          if (count == (size_ - state.joined_size) &&
+              std::find(ready_to_reduce.begin(), ready_to_reduce.end(),
+                        table_iter.first) == ready_to_reduce.end()) {
+            state.timeline.NegotiateEnd(table_iter.first);
+            ready_to_reduce.push_back(table_iter.first);
+          }
         }
       }
 
@@ -244,10 +274,16 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down) {
       }
 
       for (auto& tensor_name : ready_to_reduce) {
-        Response response = ConstructResponse(tensor_name);
+        Response response = ConstructResponse(tensor_name, state.joined_size);
         responses.push_back(std::move(response));
       }
-
+      if (state.joined_size == size_) {
+        Response join_response;
+        join_response.set_response_type(Response::JOIN);
+        join_response.add_tensor_name(JOIN_TENSOR_NAME);
+        responses.push_back(std::move(join_response));
+        state.joined_size = 0;
+      }
       response_list = FuseResponses(responses);
       response_list.set_shutdown(should_shut_down);
 
@@ -317,7 +353,7 @@ int64_t Controller::TensorFusionThresholdBytes() {
   return proposed_fusion_threshold;
 }
 
-Response Controller::ConstructResponse(std::string& name) {
+Response Controller::ConstructResponse(std::string& name, int joined_size) {
   bool error = false;
   auto it = message_table_.find(name);
   assert(it != message_table_.end());
@@ -390,11 +426,12 @@ Response Controller::ConstructResponse(std::string& name) {
     }
   }
 
+  std::vector<int64_t> tensor_sizes;
   // If we are doing an allgather, make sure all but the first dimension are
   // the same. The first dimension may be different and the output tensor is
   // the sum of the first dimension. Collect the sizes by rank.
-  std::vector<int64_t> tensor_sizes(requests.size());
   if (message_type == Request::ALLGATHER) {
+    tensor_sizes.resize(requests.size());
     TensorShape tensor_shape;
     for (auto dim : requests[0].tensor_shape()) {
       tensor_shape.AddDim(dim);
@@ -449,6 +486,16 @@ Response Controller::ConstructResponse(std::string& name) {
 
       tensor_sizes[requests[i].request_rank()] = request_shape.dim_size(0);
     }
+  }
+
+  // If there is at least one rank that requested Join, communicate tensor sizes
+  // in the response, because joined ranks don't have this info.
+  if (joined_size > 0 && message_type == Request::ALLREDUCE) {
+    TensorShape tensor_shape;
+    for (auto dim : requests[0].tensor_shape()) {
+      tensor_shape.AddDim(dim);
+    }
+    tensor_sizes.push_back(tensor_shape.num_elements());
   }
 
   // If we are doing a broadcast, check that all root ranks are identical.
@@ -508,6 +555,12 @@ Response Controller::ConstructResponse(std::string& name) {
     }
   } else if (message_type == Request::ALLREDUCE) {
     response.set_response_type(Response::ALLREDUCE);
+    if (joined_size > 0) {
+      for (auto dim : tensor_sizes) {
+        response.add_tensor_size(dim);
+      }
+      response.set_tensor_type(data_type);
+    }
   } else if (message_type == Request::BROADCAST) {
     response.set_response_type(Response::BROADCAST);
   }
@@ -556,11 +609,18 @@ ResponseList Controller::FuseResponses(std::deque<Response>& responses) {
     assert(response.tensor_names().size() == 1);
     responses.pop_front();
     int64_t tensor_size = 0;
+    DataType dtype;
+
     if (response.response_type() == Response::ResponseType::ALLREDUCE) {
       // Attempt to add more responses to this fused response.
-      const auto& entry =
-          tensor_queue_.GetTensorEntry(response.tensor_names()[0]);
-      tensor_size = entry.tensor->size();
+      try {
+        const auto& entry =
+            tensor_queue_.GetTensorEntry(response.tensor_names()[0]);
+        tensor_size = entry.tensor->size();
+        dtype = entry.tensor->dtype();
+      } catch (std::out_of_range& e) {
+        // Ranks that did Join don't have the tensor entry.
+      }
 
       std::deque<Response> skipped_responses;
       int64_t skipped_size = 0;
@@ -571,9 +631,10 @@ ResponseList Controller::FuseResponses(std::deque<Response>& responses) {
             tensor_queue_.GetTensorEntry(new_response.tensor_names()[0]);
         int64_t new_tensor_size = new_entry.tensor->size();
 
-        if (response.response_type() == new_response.response_type() &&
+        if (tensor_size > 0 &&
+            response.response_type() == new_response.response_type() &&
             response.devices() == new_response.devices() &&
-            entry.tensor->dtype() == new_entry.tensor->dtype() &&
+            dtype == new_entry.tensor->dtype() &&
             tensor_size + new_tensor_size <= TensorFusionThresholdBytes()) {
           // These tensors will fuse together well.
           tensor_size += new_tensor_size;
@@ -697,7 +758,7 @@ int Controller::GetLocalSizeAtCrossRank(int i) {
   return local_sizes_for_cross_rank_[i];
 }
 
-bool Controller::IncrementTensorCount(const Request& msg) {
+bool Controller::IncrementTensorCount(const Request& msg, int joined_size) {
   auto& name = msg.tensor_name();
   auto table_iter = message_table_.find(name);
   if (table_iter == message_table_.end()) {
@@ -715,7 +776,7 @@ bool Controller::IncrementTensorCount(const Request& msg) {
 
   std::vector<Request>& messages = table_iter->second;
   int count = (int)messages.size();
-  bool ready_to_reduce = count == size_;
+  bool ready_to_reduce = count == (size_ - joined_size);
   if (ready_to_reduce) {
     timeline_.NegotiateEnd(name);
   }

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -20,6 +20,7 @@
 #include <queue>
 #include <vector>
 
+#include "global_state.h"
 #include "parameter_manager.h"
 #include "response_cache.h"
 #include "stall_inspector.h"
@@ -94,7 +95,8 @@ public:
   //      response from the coordinator. At that point, the tick ends.
   //      If instead of "DONE" they receive "SHUTDOWN", they mark it in the
   //      response list.
-  ResponseList ComputeResponseList(std::atomic_bool& shut_down);
+  ResponseList ComputeResponseList(std::atomic_bool& shut_down,
+                                   HorovodGlobalState& state);
 
   // Get current tensors fusion threshold.
   int64_t TensorFusionThresholdBytes();
@@ -142,7 +144,7 @@ protected:
   // also contains error messages in case the submitted Requests were not
   // valid (for example, contained mismatched shapes or types).
   // Constructing the Response, thus, requires a whole lot of error checking.
-  Response ConstructResponse(std::string& name);
+  Response ConstructResponse(std::string& name, int joined_size = 0);
 
   // Routine to sync cache hit and invalid bit sets across workers.
   // Also determines global shutdown state and whether uncached requests
@@ -159,7 +161,7 @@ protected:
   // Store the Request for a name, and return whether the total count of
   // Requests for that tensor is now equal to the HOROVOD size (and thus we are
   // ready to reduce the tensor).
-  bool IncrementTensorCount(const Request& msg);
+  bool IncrementTensorCount(const Request& msg, int joined_size = 0);
 
   int rank_ = 0;
   int local_rank_ = 0;

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -102,9 +102,10 @@ struct HorovodGlobalState {
 
   // Number of ranks that did Join()
   int joined_size = 0;
+  // If a rank is Joined, AllReduce uses temporary 0 tensors for it.
   bool joined = false;
   // ID of the device to create temporary tensors while Joined
-  int join_device = -1;
+  int join_device = CPU_DEVICE_ID;
 
   ~HorovodGlobalState() {
     // Make sure that the destructor of the background thread is safe to

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -100,6 +100,12 @@ struct HorovodGlobalState {
   // operations.
   LibType control_operation;
 
+  // Number of ranks that did Join()
+  int joined_size = 0;
+  bool joined = false;
+  // ID of the device to create temporary tensors while Joined
+  int join_device = -1;
+
   ~HorovodGlobalState() {
     // Make sure that the destructor of the background thread is safe to
     // call. If a thread is still joinable (not detached or complete) its

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -72,6 +72,9 @@ const std::string& Request::RequestType_Name(RequestType value) {
     case RequestType::BROADCAST:
       static const std::string broadcast("BROADCAST");
       return broadcast;
+    case RequestType::JOIN:
+      static const std::string join("JOIN");
+      return join;
     default:
       static const std::string unknown("<unknown>");
       return unknown;
@@ -236,6 +239,9 @@ const std::string& Response::ResponseType_Name(ResponseType value) {
     case ResponseType::BROADCAST:
       static const std::string broadcast("BROADCAST");
       return broadcast;
+    case ResponseType::JOIN:
+      static const std::string join("JOIN");
+      return join;
     case ResponseType::ERROR:
       static const std::string error("ERROR");
       return error;
@@ -256,6 +262,10 @@ void Response::set_response_type(ResponseType value) {
 const std::vector<std::string>& Response::tensor_names() const {
   return tensor_names_;
 }
+
+DataType Response::tensor_type() const { return tensor_type_; }
+
+void Response::set_tensor_type(DataType value) { tensor_type_ = value; }
 
 const std::string Response::tensor_names_string() const {
   std::string result;
@@ -321,6 +331,7 @@ void Response_ParseFromWire(Response& response,
   for (const auto& tensor_name_obj : *obj->tensor_names()) {
     response.add_tensor_name(tensor_name_obj->str());
   }
+  response.set_tensor_type((DataType) obj->tensor_type());
   response.set_error_message(obj->error_message()->str());
   response.set_devices(
       std::vector<int32_t>(obj->devices()->begin(), obj->devices()->end()));
@@ -347,6 +358,8 @@ void Response_SerializeToWire(const Response& response,
   response_builder.add_response_type(
       (wire::ResponseType) response.response_type());
   response_builder.add_tensor_names(tensor_names_wire);
+  response_builder.add_tensor_type(
+      (wire::DataType) response.tensor_type());
   response_builder.add_error_message(error_message_wire);
   response_builder.add_devices(devices_wire);
   response_builder.add_tensor_sizes(tensor_sizes_wire);

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -45,7 +45,7 @@ const std::string& DataType_Name(DataType value);
 class Request {
 public:
   enum RequestType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3
   };
 
   static const std::string& RequestType_Name(RequestType value);
@@ -130,7 +130,7 @@ private:
 class Response {
 public:
   enum ResponseType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, ERROR = 3
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ERROR = 4
   };
 
   static const std::string& ResponseType_Name(ResponseType value);
@@ -141,6 +141,10 @@ public:
 
   // Empty if the type is DONE or SHUTDOWN.
   const std::vector<std::string>& tensor_names() const;
+
+  DataType tensor_type() const;
+
+  void set_tensor_type(DataType value);
 
   const std::string tensor_names_string() const;
 
@@ -179,6 +183,7 @@ public:
 private:
   ResponseType response_type_ = ResponseType::ALLREDUCE;
   std::vector<std::string> tensor_names_;
+  DataType tensor_type_ = DataType::HOROVOD_UINT8;
   std::string error_message_;
   std::vector<int32_t> devices_;
   std::vector<int64_t> tensor_sizes_;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -852,8 +852,8 @@ Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
   return status;
 }
 
-// MPI must be initialized and the background thread must be running before
-// this function is called.
+// Contexts and controller must be initialized and the background thread
+// must be running before this function is called.
 Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    std::shared_ptr<ReadyEvent> ready_event,
                    const std::string name, const int device,

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -107,6 +107,11 @@ Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
                               const std::string name, const int device,
                               StatusCallback callback);
 
+Status EnqueueJoin(std::shared_ptr<OpContext> context,
+                              std::shared_ptr<ReadyEvent> ready_event,
+                              const std::string name, const int device,
+                              StatusCallback callback);
+
 } // namespace common
 } // namespace horovod
 

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -197,10 +197,18 @@ void AllgatherOp::MemcpyOutFusionBuffer(
 BroadcastOp::BroadcastOp(HorovodGlobalState* global_state)
     : HorovodOp(global_state) {}
 
+// Join
+JoinOp::JoinOp(HorovodGlobalState* global_state) : HorovodOp(global_state) {}
+
+Status JoinOp::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
+  // This never should be actually called.
+  return Status::PreconditionError(response.error_message());
+}
+
+// Error
 ErrorOp::ErrorOp(HorovodGlobalState* global_state) : HorovodOp(global_state) {}
 
-Status ErrorOp::Execute(std::vector<TensorTableEntry>& entries,
-                        const Response& response) {
+Status ErrorOp::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
   return Status::PreconditionError(response.error_message());
 }
 

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -200,9 +200,14 @@ BroadcastOp::BroadcastOp(HorovodGlobalState* global_state)
 // Join
 JoinOp::JoinOp(HorovodGlobalState* global_state) : HorovodOp(global_state) {}
 
-Status JoinOp::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
-  // This never should be actually called.
-  return Status::PreconditionError(response.error_message());
+Status JoinOp::Execute(std::vector<TensorTableEntry>& entries,
+                       const Response& response) {
+  assert(entries.size() == 0);
+  if (global_state_->joined) {
+    global_state_->tensor_queue.RemoveJoinTensor();
+    global_state_->joined = false;
+  }
+  return Status::OK();
 }
 
 // Error

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -127,14 +127,23 @@ public:
                        const Response& response) const = 0;
 };
 
+class JoinOp : public HorovodOp {
+public:
+  JoinOp(HorovodGlobalState* global_state);
+
+  virtual ~JoinOp() = default;
+
+  virtual Status Execute(std::vector<TensorTableEntry>& entries,
+                         const Response& response);
+};
+
 class ErrorOp : public HorovodOp {
 public:
   ErrorOp(HorovodGlobalState* global_state);
 
   virtual ~ErrorOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries,
-                         const Response& response);
+  virtual Status Execute(std::vector<TensorTableEntry>& entries, const Response& response);
 };
 
 } // namespace common

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -159,7 +159,10 @@ Status CUDAAllreduce::FinalizeCUDAQueue(const std::vector<TensorTableEntry>& ent
   // Claim a std::shared_ptr to the fusion buffer to prevent its memory from being reclaimed
   // during finalization.
   auto fusion_buffer = global_state_->fusion_buffer.GetBuffer(
-      first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
+      first_entry.device,
+      // JoinTensor doesn't have context or framework
+      first_entry.context ? first_entry.context->framework() : PYTORCH,
+      global_state_->current_nccl_stream);
 
   // TODO: use thread pool or single thread for callbacks
   std::thread finalizer_thread([entries, first_entry, host_buffer, fusion_buffer,
@@ -174,7 +177,9 @@ Status CUDAAllreduce::FinalizeCUDAQueue(const std::vector<TensorTableEntry>& ent
 
     for (auto& e : entries) {
       timeline.End(e.tensor_name, e.output);
-      e.callback(Status::OK());
+      if (e.callback != nullptr) {
+        e.callback(Status::OK());
+      }
     }
   });
 

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -159,10 +159,7 @@ Status CUDAAllreduce::FinalizeCUDAQueue(const std::vector<TensorTableEntry>& ent
   // Claim a std::shared_ptr to the fusion buffer to prevent its memory from being reclaimed
   // during finalization.
   auto fusion_buffer = global_state_->fusion_buffer.GetBuffer(
-      first_entry.device,
-      // JoinTensor doesn't have context or framework
-      first_entry.context ? first_entry.context->framework() : PYTORCH,
-      global_state_->current_nccl_stream);
+      first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
 
   // TODO: use thread pool or single thread for callbacks
   std::thread finalizer_thread([entries, first_entry, host_buffer, fusion_buffer,

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -177,6 +177,7 @@ Status CUDAAllreduce::FinalizeCUDAQueue(const std::vector<TensorTableEntry>& ent
 
     for (auto& e : entries) {
       timeline.End(e.tensor_name, e.output);
+      // Callback can be null if the rank sent Join request.
       if (e.callback != nullptr) {
         e.callback(Status::OK());
       }

--- a/horovod/common/ops/operation_manager.cc
+++ b/horovod/common/ops/operation_manager.cc
@@ -22,11 +22,13 @@ OperationManager::OperationManager(ParameterManager* param_manager,
                                    std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops,
                                    std::vector<std::shared_ptr<AllgatherOp>> allgather_ops,
                                    std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops,
+                                   std::shared_ptr<JoinOp> join_op,
                                    std::shared_ptr<ErrorOp> error_op)
     : param_manager_(param_manager),
       allreduce_ops_(std::move(allreduce_ops)),
       allgather_ops_(std::move(allgather_ops)),
       broadcast_ops_(std::move(broadcast_ops)),
+      join_op_(std::move(join_op)),
       error_op_(std::move(error_op)) {}
 
 Status OperationManager::ExecuteAllreduce(std::vector<TensorTableEntry>& entries,
@@ -59,6 +61,11 @@ Status OperationManager::ExecuteBroadcast(std::vector<TensorTableEntry>& entries
   throw std::logic_error("No Broadcast operation enabled");
 }
 
+Status OperationManager::ExecuteJoin(std::vector<TensorTableEntry>& entries,
+                                          const Response& response) const {
+  return join_op_->Execute(entries, response);
+}
+
 Status OperationManager::ExecuteError(std::vector<TensorTableEntry>& entries,
                                       const Response& response) const {
   return error_op_->Execute(entries, response);
@@ -72,6 +79,8 @@ Status OperationManager::ExecuteOperation(std::vector<TensorTableEntry>& entries
     return ExecuteAllgather(entries, response);
   } else if (response.response_type() == Response::BROADCAST) {
     return ExecuteBroadcast(entries, response);
+  } else if (response.response_type() == Response::JOIN) {
+    return ExecuteJoin(entries, response);
   } else if (response.response_type() == Response::ERROR) {
     return ExecuteError(entries, response);
   } else {

--- a/horovod/common/ops/operation_manager.h
+++ b/horovod/common/ops/operation_manager.h
@@ -28,6 +28,7 @@ public:
                    std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops,
                    std::vector<std::shared_ptr<AllgatherOp>> allgather_ops,
                    std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops,
+                   std::shared_ptr<JoinOp> join_op,
                    std::shared_ptr<ErrorOp> error_op);
 
   virtual ~OperationManager() = default;
@@ -40,6 +41,8 @@ public:
 
   Status ExecuteError(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
+  Status ExecuteJoin(std::vector<TensorTableEntry>& entries, const Response& response) const;
+
   Status ExecuteOperation(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
 private:
@@ -48,6 +51,7 @@ private:
   std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops_;
   std::vector<std::shared_ptr<AllgatherOp>> allgather_ops_;
   std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops_;
+  std::shared_ptr<JoinOp> join_op_;
   std::shared_ptr<ErrorOp> error_op_;
 };
 

--- a/horovod/common/tensor_queue.cc
+++ b/horovod/common/tensor_queue.cc
@@ -92,54 +92,18 @@ void TensorQueue::GetTensorEntriesFromResponse(
         // Clear the tensor table of this tensor.
         tensor_table_.erase(iter);
       } else if (response.response_type() != Response::ERROR) {
+        // Find Join tensor to use its context.
+        auto join_iter = tensor_table_.find(JOIN_TENSOR_NAME);
+        assert(join_iter != tensor_table_.end());
+
         TensorTableEntry entry;
-        switch (response.tensor_type()) {
-        case HOROVOD_UINT8:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_UINT8, uint8_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_INT8:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_INT8, int8_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_UINT16:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_UINT16, uint16_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_INT16:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_INT16, int16_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_INT32:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_INT32, int32_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_INT64:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_INT64, int64_t>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_FLOAT16:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_FLOAT16, float>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_FLOAT32:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_FLOAT32, float>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_FLOAT64:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_FLOAT64, double>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        case HOROVOD_BOOL:
-          entry.tensor = std::make_shared<JoinTensor<HOROVOD_BOOL, bool>>(
-              join_device, response.tensor_sizes()[0]);
-          break;
-        default:
-          throw std::logic_error("Unknown tensor data type");
-        }
+        join_iter->second.context->AllocateZeros(response.tensor_sizes()[0],
+                                                 response.tensor_type(),
+                                                 &(entry.tensor));
 
         entry.output = entry.tensor;
         entry.device = join_device;
+        entry.context = join_iter->second.context;
         entry.tensor_name = name;
         entries.push_back(std::move(entry));
       }
@@ -199,65 +163,6 @@ void TensorQueue::RemoveJoinTensor() {
   Status status;
   e.callback(status);
   tensor_table_.erase(iter);
-}
-
-template <DataType DT, class T>
-JoinTensor<DT, T>::JoinTensor(int device, int64_t num_elements) {
-  num_elements_ = num_elements;
-  device_ = device;
-  if (device_ == CPU_DEVICE_ID) {
-    buffer_data_ = new T[num_elements_];
-    for (int i = 0; i < num_elements_; i++) {
-      buffer_data_[i] = 0;
-    }
-  } else {
-#if HAVE_CUDA
-    cudaSetDevice(device_);
-    cudaMalloc(&buffer_data_, size());
-    auto tmp = new T[num_elements_];
-    for (int i = 0; i < num_elements_; i++) {
-      tmp[i] = 0;
-    }
-    cudaMemcpy(buffer_data_, tmp, size(), cudaMemcpyHostToDevice);
-    delete[] tmp;
-#else
-    throw std::logic_error("Internal error. Requested Join "
-                           "with GPU device but not compiled with CUDA.");
-#endif
-  }
-}
-
-template <DataType DT, class T> JoinTensor<DT, T>::~JoinTensor() {
-  if (device_ == CPU_DEVICE_ID) {
-    delete[] buffer_data_;
-  } else {
-#if HAVE_CUDA
-    cudaFree(buffer_data_);
-#else
-    throw std::logic_error("Internal error. Requested Join "
-                           "with GPU device but not compiled with CUDA.");
-#endif
-  }
-}
-
-template <DataType DT, class T>
-const DataType JoinTensor<DT, T>::dtype() const {
-  return DT;
-}
-
-template <DataType DT, class T>
-const TensorShape JoinTensor<DT, T>::shape() const {
-  TensorShape shape;
-  shape.AddDim(num_elements_);
-  return shape;
-}
-
-template <DataType DT, class T> const void* JoinTensor<DT, T>::data() const {
-  return (void*)buffer_data_;
-}
-
-template <DataType DT, class T> int64_t JoinTensor<DT, T>::size() const {
-  return num_elements_ * sizeof(T);
 }
 
 } // namespace common

--- a/horovod/common/tensor_queue.cc
+++ b/horovod/common/tensor_queue.cc
@@ -91,7 +91,7 @@ void TensorQueue::GetTensorEntriesFromResponse(
 
         // Clear the tensor table of this tensor.
         tensor_table_.erase(iter);
-      } else {
+      } else if (response.response_type() != Response::ERROR) {
         TensorTableEntry entry;
         switch (response.tensor_type()) {
         case HOROVOD_UINT8:

--- a/horovod/common/tensor_queue.h
+++ b/horovod/common/tensor_queue.h
@@ -42,7 +42,7 @@ public:
 
   void GetTensorEntriesFromResponse(Response& response,
                                     std::vector<TensorTableEntry>& entries,
-                                    int rank = 0, bool joined = false,
+                                    bool joined = false,
                                     int join_device = CPU_DEVICE_ID);
 
   const TensorTableEntry& GetTensorEntry(const std::string& tensor_name) const;
@@ -50,6 +50,9 @@ public:
   void PopMessagesFromQueue(std::deque<Request>& message_queue_buffer);
 
   void PushMessageToQueue(Request& message);
+
+  bool GetTensorSizeAndType(const std::string& tensor_name, int64_t& size,
+                             DataType& dtype);
 
   void RemoveJoinTensor();
 

--- a/horovod/common/tensor_queue.h
+++ b/horovod/common/tensor_queue.h
@@ -68,22 +68,6 @@ protected:
   mutable std::mutex mutex_;
 };
 
-template <DataType DT, class T>
-class JoinTensor : public Tensor {
-public:
-  JoinTensor(int device, int64_t num_elements);
-  ~JoinTensor();
-  virtual const DataType dtype() const override;
-  virtual const TensorShape shape() const override;
-  virtual const void* data() const override;
-  virtual int64_t size() const override;
-
-private:
-  int64_t num_elements_;
-  int device_;
-  T* buffer_data_;
-};
-
 } // namespace common
 } // namespace horovod
 

--- a/horovod/common/tensor_queue.h
+++ b/horovod/common/tensor_queue.h
@@ -22,10 +22,6 @@
 
 #include "common.h"
 
-#if HAVE_CUDA
-#include <cuda_runtime.h>
-#endif
-
 namespace horovod {
 namespace common {
 

--- a/horovod/common/wire/message.fbs
+++ b/horovod/common/wire/message.fbs
@@ -36,7 +36,8 @@ enum DataType:byte {
 enum RequestType:byte {
     ALLREDUCE = 0,
     ALLGATHER = 1,
-    BROADCAST = 2
+    BROADCAST = 2,
+    JOIN = 3
 }
 table Request {
     // The request rank is necessary to create a consistent ordering of results,
@@ -73,7 +74,8 @@ enum ResponseType:byte {
     ALLREDUCE = 0,
     ALLGATHER = 1,
     BROADCAST = 2,
-    ERROR = 3
+    JOIN = 3,
+    ERROR = 4
 }
 table Response {
     response_type:ResponseType;
@@ -88,10 +90,15 @@ table Response {
     // List of devices participating in this operation.
     devices:[int];
 
-    // Empty unless response_type is ALLGATHER.
-    // These tensor sizes are the dimension zero sizes of all the input matrices,
-    // indexed by the rank.
+    // Empty unless response_type is ALLGATHER or there is at least one rank
+    // that requested Join and response_type is ALLREDUCE.
+    // For ALLGATHER, these tensor sizes are the dimension zero sizes
+    // of all the input matrices, indexed by the rank.
     tensor_sizes:[long];
+
+    // Empty unless response_type is ALLREDUCE and there is at least one rank
+    // that requested Join.
+    tensor_type:DataType;
 }
 table ResponseList {
     responses:[Response];

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -125,6 +125,14 @@ Status MXOpContext<T>::AllocateOutput(TensorShape shape,
   return Status::OK();
 }
 
+template <class T>
+Status
+MXOpContext<T>::AllocateZeros(int64_t num_elements, DataType dtype,
+                                          std::shared_ptr<Tensor>* tensor) {
+  return Status::PreconditionError(
+      "AllocateZeros is not supported for MXNet yet.");
+}
+
 template <class T> Framework MXOpContext<T>::framework() const {
   return Framework::MXNET;
 }

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -64,6 +64,8 @@ public:
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
+  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
+                               std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;
 
 private:

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -115,6 +115,9 @@ public:
   virtual common::Status
   AllocateOutput(common::TensorShape shape,
                  std::shared_ptr<common::Tensor>* tensor) override;
+  virtual common::Status
+  AllocateZeros(int64_t num_elements, common::DataType dtype,
+                std::shared_ptr<common::Tensor>* tensor) override;
   virtual common::Framework framework() const override;
   OpKernelContext* GetKernelContext() const;
 
@@ -242,6 +245,13 @@ TFOpContext::AllocateOutput(common::TensorShape shape,
   }
 #endif
   return ConvertStatus(status);
+}
+
+common::Status
+TFOpContext::AllocateZeros(int64_t num_elements, common::DataType dtype,
+                           std::shared_ptr<common::Tensor>* tensor) {
+  return common::Status::PreconditionError(
+      "AllocateZeros is not supported for TensorFlow yet.");
 }
 
 common::Framework TFOpContext::framework() const {

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -33,6 +33,7 @@ from horovod.torch.compression import Compression
 from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allreduce_async_
 from horovod.torch.mpi_ops import allgather, allgather_async
 from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
+from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
 from horovod.torch.mpi_ops import init, shutdown
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank

--- a/horovod/torch/adapter.cc
+++ b/horovod/torch/adapter.cc
@@ -132,6 +132,14 @@ TorchOpContext<DT, Dev, T>::AllocateOutput(TensorShape shape,
 }
 
 template <DataType DT, DeviceType Dev, class T>
+Status
+TorchOpContext<DT, Dev, T>::AllocateZeros(int64_t num_elements, DataType dtype,
+                                          std::shared_ptr<Tensor>* tensor) {
+  return Status::PreconditionError(
+      "AllocateZeros is not supported for PyTorch < 1.0");
+}
+
+template <DataType DT, DeviceType Dev, class T>
 Framework TorchOpContext<DT, Dev, T>::framework() const {
   return Framework::PYTORCH;
 }

--- a/horovod/torch/adapter.h
+++ b/horovod/torch/adapter.h
@@ -65,7 +65,7 @@ public:
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
-                                std::shared_ptr<Tensor>* tensor) override;
+                               std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;
 
 private:

--- a/horovod/torch/adapter.h
+++ b/horovod/torch/adapter.h
@@ -64,6 +64,8 @@ public:
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
+  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
+                                std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;
 
 private:

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -125,15 +125,13 @@ Status TorchOpContext::AllocateOutput(TensorShape shape,
 }
 
 Status TorchOpContext::AllocateZeros(int64_t num_elements, DataType dtype,
-                                      std::shared_ptr<Tensor>* tensor) {
+                                     std::shared_ptr<Tensor>* tensor) {
   with_device device_context(device_);
-  ::torch::Tensor zero_tensor;
   auto torch_data_type = GetTorchDataType(dtype);
-  if (device_ == CPU_DEVICE_ID) {
-    zero_tensor = ::torch::zeros(num_elements, ::torch::device(::torch::kCPU).dtype(torch_data_type));
-  } else {
-    zero_tensor = ::torch::zeros(num_elements, ::torch::device(::torch::kCUDA).dtype(torch_data_type));
-  }
+  ::torch::DeviceType device_type =
+      device_ != CPU_DEVICE_ID ? ::torch::kCUDA : ::torch::kCPU;
+  ::torch::Tensor zero_tensor = ::torch::zeros(
+      num_elements, ::torch::device(device_type).dtype(torch_data_type));
   *tensor = std::make_shared<TorchTensor>(zero_tensor);
   return Status::OK();
 }

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -26,6 +26,8 @@ namespace torch {
 
 using namespace horovod::common;
 
+::torch::ScalarType GetTorchDataType(DataType dtype);
+
 class TorchPersistentBuffer : public PersistentBuffer {
 public:
   TorchPersistentBuffer(int device, int64_t size);
@@ -56,6 +58,8 @@ public:
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
+                                std::shared_ptr<Tensor>* tensor) override;
+  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                 std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;
 

--- a/horovod/torch/interface.h
+++ b/horovod/torch/interface.h
@@ -72,3 +72,5 @@ int horovod_torch_broadcast_async_torch_DoubleTensor(THDoubleTensor* tensor,
 
 int horovod_torch_poll(int handle);
 void horovod_torch_wait_and_clear(int handle);
+
+void horovod_torch_join(int device);

--- a/horovod/torch/mpi_ops.cc
+++ b/horovod/torch/mpi_ops.cc
@@ -216,36 +216,9 @@ int DoBroadcastCudaOnCPU(TC* tensor, TC* output, int root_rank, char* name) {
 }
 #endif
 
-void WaitAndClear(int handle) {
-  while (!handle_manager.PollHandle(handle)) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-  auto status = handle_manager.ReleaseHandle(handle);
-  ThrowIfError(*status);
-}
-
 int DoJoin(int device) {
-  ThrowIfError(common::CheckInitialized());
-
-  auto handle = handle_manager.AllocateHandle();
-  auto ready_event = RecordReadyEvent(device);
-
-  auto hvd_cpu_buffer =
-      std::make_shared<TorchTemporaryBuffer<DataType::HOROVOD_INT64, DeviceType::CPU, THLongTensor>>(
-          CPU_DEVICE_ID);
-  auto hvd_context = std::make_shared<TorchOpContext<DataType::HOROVOD_INT64, DeviceType::CPU, THLongTensor>>(
-      CPU_DEVICE_ID, hvd_cpu_buffer->tensor());
-
-  auto enqueue_result = EnqueueJoin(
-      hvd_context, ready_event,
-      JOIN_TENSOR_NAME, device,
-      [handle](const Status& status) mutable {
-        handle_manager.MarkDone(handle, status);
-      });
-  ThrowIfError(enqueue_result);
-
-  WaitAndClear(handle);
-  return handle;
+  throw std::runtime_error("Join Op is not supported for PyTorch < 1.0");
+  return 0;
 }
 
 #define ALLREDUCE(torch_Tensor, HorovodType, DeviceType, THTensor)             \

--- a/horovod/torch/mpi_ops.cc
+++ b/horovod/torch/mpi_ops.cc
@@ -218,7 +218,6 @@ int DoBroadcastCudaOnCPU(TC* tensor, TC* output, int root_rank, char* name) {
 
 int DoJoin(int device) {
   throw std::runtime_error("Join Op is not supported for PyTorch < 1.0");
-  return 0;
 }
 
 #define ALLREDUCE(torch_Tensor, HorovodType, DeviceType, THTensor)             \

--- a/horovod/torch/mpi_ops.cc
+++ b/horovod/torch/mpi_ops.cc
@@ -238,7 +238,7 @@ int DoJoin(int device) {
 
   auto enqueue_result = EnqueueJoin(
       hvd_context, ready_event,
-      "join.noname", device,
+      JOIN_TENSOR_NAME, device,
       [handle](const Status& status) mutable {
         handle_manager.MarkDone(handle, status);
       });

--- a/horovod/torch/mpi_ops.h
+++ b/horovod/torch/mpi_ops.h
@@ -90,6 +90,8 @@ BROADCAST_H(torch_cuda_DoubleTensor, THCudaDoubleTensor)
 extern "C" int horovod_torch_poll(int handle);
 extern "C" void horovod_torch_wait_and_clear(int handle);
 
+extern "C" int horovod_torch_join(int device);
+
 } // namespace torch
 } // namespace horovod
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -443,3 +443,13 @@ def synchronize(handle):
     mpi_lib.horovod_torch_wait_and_clear(handle)
     _, output = _handle_map.pop(handle)
     return output
+
+
+def join(device=-1):
+    """
+    A function that indicates that the rank finished processing data.
+    All ranks that did not call join() continue to process allreduce operations.
+    This function blocks Python thread until all ranks join.
+
+    """
+    return mpi_lib.horovod_torch_join(device)

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -446,10 +446,15 @@ def synchronize(handle):
 
 
 def join(device=-1):
-    """
-    A function that indicates that the rank finished processing data.
+    """A function that indicates that the rank finished processing data.
+
     All ranks that did not call join() continue to process allreduce operations.
     This function blocks Python thread until all ranks join.
 
+    Arguments:
+        device: An id of the device to create temprorary zero tensors (default -1, CPU)
+
+    Returns:
+        Id of the rank that joined last.
     """
     return mpi_lib.horovod_torch_join(device)

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -457,4 +457,6 @@ def join(device=-1):
     Returns:
         Id of the rank that joined last.
     """
+    if not _v2_api:
+        raise NotImplementedError("Join Op is not supported for PyTorch < 1.0")
     return mpi_lib.horovod_torch_join(device)

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -233,6 +233,31 @@ void WaitAndClear(int handle) {
   ThrowIfError(*status);
 }
 
+int DoJoin(int device) {
+  ThrowIfError(common::CheckInitialized());
+
+#if !HOROVOD_GPU_ALLREDUCE
+  device = CPU_DEVICE_ID;
+#endif
+
+  auto handle = handle_manager.AllocateHandle();
+  auto ready_event = RecordReadyEvent(device);
+  auto cpu_output = ::torch::empty(1);
+  auto hvd_context = std::make_shared<TorchOpContext>(device, cpu_output);
+
+  auto enqueue_result = EnqueueJoin(
+      hvd_context, ready_event,
+      "join.noname", device,
+      [handle](const Status& status) mutable {
+        handle_manager.MarkDone(handle, status);
+      });
+  ThrowIfError(enqueue_result);
+
+  WaitAndClear(handle);
+  return handle;
+}
+
+
 PYBIND11_MODULE(mpi_lib_v2, m) {
   // allreduce
   m.def("horovod_torch_allreduce_async_torch_IntTensor", &DoAllreduce);
@@ -332,6 +357,9 @@ PYBIND11_MODULE(mpi_lib_v2, m) {
   m.def("horovod_torch_broadcast_async_torch_cuda_DoubleTensor",
         &DoBroadcastCudaOnCPU);
 #endif
+
+  // join
+  m.def("horovod_torch_join", &DoJoin);
 
   // basics
   m.def("horovod_torch_poll", &PollHandle);

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -247,7 +247,7 @@ int DoJoin(int device) {
 
   auto enqueue_result = EnqueueJoin(
       hvd_context, ready_event,
-      "join.noname", device,
+      JOIN_TENSOR_NAME, device,
       [handle](const Status& status) mutable {
         handle_manager.MarkDone(handle, status);
       });

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -242,8 +242,8 @@ int DoJoin(int device) {
 
   auto handle = handle_manager.AllocateHandle();
   auto ready_event = RecordReadyEvent(device);
-  auto cpu_output = ::torch::empty(1);
-  auto hvd_context = std::make_shared<TorchOpContext>(device, cpu_output);
+  auto output = ::torch::empty(1);
+  auto hvd_context = std::make_shared<TorchOpContext>(device, output);
 
   auto enqueue_result = EnqueueJoin(
       hvd_context, ready_event,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1417,10 +1417,7 @@ class TorchTests(unittest.TestCase):
                 tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
                 tensor = self.cast_and_place(tensor, dtype)
                 averaged = hvd.allreduce(tensor, average=True)
-                if dtype.is_cuda:
-                    ret = hvd.join(hvd.local_rank())
-                else:
-                    ret = hvd.join()
+                ret = hvd.join(hvd.local_rank())
 
                 max_difference = averaged.data.sub(tensor * (size - 1) / size).max()
                 # Threshold for floating point equality depends on number of
@@ -1465,10 +1462,7 @@ class TorchTests(unittest.TestCase):
             except (torch.FatalError, RuntimeError):
                 pass
 
-            if torch.cuda.is_available():
-                ret = hvd.join(hvd.local_rank())
-            else:
-                ret = hvd.join()
+            ret = hvd.join(hvd.local_rank())
 
     def test_horovod_join_broadcast(self):
         """Test Join op with allgather."""
@@ -1488,10 +1482,7 @@ class TorchTests(unittest.TestCase):
         tensor = torch.FloatTensor(*dims)
 
         if rank == 0:
-            if torch.cuda.is_available():
-                ret = hvd.join(hvd.local_rank())
-            else:
-                ret = hvd.join()
+            ret = hvd.join(hvd.local_rank())
         else:
             try:
                 broadcasted_tensor = hvd.broadcast(tensor, 1)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -34,7 +34,8 @@ import horovod.torch as hvd
 
 from common import mpi_env_rank_and_size
 
-_fp16_supported = LooseVersion(torch.__version__) >= LooseVersion('1.0.0')
+_v2_api = LooseVersion(torch.__version__) >= LooseVersion('1.0.0')
+_fp16_supported = _v2_api
 
 # MLSL supports only byte, float and double data types
 mlsl_supported_types = set([torch.FloatTensor, torch.DoubleTensor])
@@ -1388,6 +1389,10 @@ class TorchTests(unittest.TestCase):
 
     def test_horovod_join_allreduce(self):
         """Test Join op with allreduce."""
+        # "Join Op is not supported for PyTorch < 1.0"
+        if not _v2_api:
+            return
+
         hvd.init()
         rank = hvd.rank()
         size = hvd.size()
@@ -1433,6 +1438,10 @@ class TorchTests(unittest.TestCase):
 
     def test_horovod_join_allgather(self):
         """Test Join op with allgather."""
+        # "Join Op is not supported for PyTorch < 1.0"
+        if not _v2_api:
+            return
+
         hvd.init()
         rank = hvd.rank()
         size = hvd.size()
@@ -1463,6 +1472,10 @@ class TorchTests(unittest.TestCase):
 
     def test_horovod_join_broadcast(self):
         """Test Join op with allgather."""
+        # "Join Op is not supported for PyTorch < 1.0"
+        if not _v2_api:
+            return
+
         hvd.init()
         rank = hvd.rank()
         size = hvd.size()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1431,5 +1431,65 @@ class TorchTests(unittest.TestCase):
                     break
                 assert max_difference <= threshold, 'hovd.join with hvd.allreduce produces incorrect results'
 
+    def test_horovod_join_allgather(self):
+        """Test Join op with allgather."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        dims = [17] * 3
+        tensor = torch.FloatTensor(*dims)
+
+        if rank == 0:
+            if torch.cuda.is_available():
+                ret = hvd.join(hvd.local_rank())
+            else:
+                ret = hvd.join()
+        else:
+            try:
+                hvd.allgather(tensor)
+                assert False, 'hvd.allgather did not throw error'
+            except (torch.FatalError, RuntimeError):
+                pass
+
+            if torch.cuda.is_available():
+                ret = hvd.join(hvd.local_rank())
+            else:
+                ret = hvd.join()
+
+    def test_horovod_join_broadcast(self):
+        """Test Join op with allgather."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            return
+
+        dims = [17] * 3
+        tensor = torch.FloatTensor(*dims)
+
+        if rank == 0:
+            if torch.cuda.is_available():
+                ret = hvd.join(hvd.local_rank())
+            else:
+                ret = hvd.join()
+        else:
+            try:
+                broadcasted_tensor = hvd.broadcast(tensor, 1)
+                assert False, 'hvd.broadcast did not throw error'
+            except (torch.FatalError, RuntimeError):
+                pass
+
+            if torch.cuda.is_available():
+                ret = hvd.join(hvd.local_rank())
+            else:
+                ret = hvd.join()
+
 if __name__ == "__main__":
    unittest.main()


### PR DESCRIPTION
This is very earlier work in progress PR to add hvd.join() as described in https://github.com/horovod/horovod/issues/832

This is mostly boilerplate code, it compiles and I can call hvd.join() from the pytorch test (the Join op goes to the queue but does nothing).

The purpose of this PR for me is to understand if I'm going in the right direction.
Some other questions I have (in no particular order):

1. Should Join op have name?
2. Join op doesn't have an input, and should have single int output (last joined rank), right?
3. Does the Join op need to be implemented separately for cuda, nccl, in cuda_operations.cc,  nccl_operations.cc, etc. ?
4. In operation manager, should it be a vector of available Join ops or just one Join op?
5. The logic for join op should track already joined ranks, this should be similar to the logic in AllReduce and AllGather ops? Any code pointers/suggestions?
6. AllReduce and AllGather ops need to know already joined ranks. Is it going to be stored in global state? Any code pointers/suggestions?
7. Any suggestions how to make adding Join op more granular (several smaller PRs)?