### PR TITLE
Ignore OLDPWD environment variable in Horovodrun

### DIFF
--- a/horovod/run/common/util/env.py
+++ b/horovod/run/common/util/env.py
@@ -17,7 +17,7 @@ import re
 
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'BASH_FUNC_.*\(\)'}
+IGNORE_REGEXES = {'BASH_FUNC_.*\(\)', 'OLDPWD'}
 
 
 def is_exportable(v):


### PR DESCRIPTION
Resolves the following warning:
```
Warning: could not find environment variable "OLDPWD"
```