### PR TITLE
Pin tf-nightly-gpu to 1.14.1.dev20190517

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -189,7 +189,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.3.7-1+cuda10.0
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190517
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         MXNET_PACKAGE: mxnet-cu100 --pre
@@ -203,7 +203,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.3.7-1+cuda10.0
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190517
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         MXNET_PACKAGE: mxnet-cu100 --pre


### PR DESCRIPTION
A workaround until https://github.com/tensorflow/tensorflow/issues/28845 is resolved.