### PR TITLE
Fix bug introduced by _allreduce_delay

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -70,6 +70,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
             self._parameter_names = {v: 'allreduce.noname.%s' % i
                                      for param_group in self.param_groups
                                      for i, v in enumerate(param_group['params'])}
+            # named_parameters = [(k, v) for v, k in self._parameter_names.items()]
         self.backward_passes_per_step = backward_passes_per_step
         self._allreduce_delay = {v: self.backward_passes_per_step
                                  for _, v in sorted(named_parameters)}

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -50,7 +50,9 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         if named_parameters is not None:
             named_parameters = list(named_parameters)
         else:
-            named_parameters = []
+            named_parameters = [('allreduce.noname.%s' % i, v)
+                                for param_group in self.param_groups
+                                for i, v in enumerate(param_group['params'])]
 
         # make sure that named_parameters are tuples
         if any([not isinstance(p, tuple) for p in named_parameters]):
@@ -63,14 +65,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
             raise ValueError('Parameter names in named_parameters must be unique. '
                              'Found duplicates: %s' % ', '.join(dups))
 
-        if len(named_parameters) > 0:
-            self._parameter_names = {v: k for k, v
-                                     in sorted(named_parameters)}
-        else:
-            self._parameter_names = {v: 'allreduce.noname.%s' % i
-                                     for param_group in self.param_groups
-                                     for i, v in enumerate(param_group['params'])}
-            named_parameters = [(k, v) for v, k in self._parameter_names.items()]
+        self._parameter_names = {v: k for k, v in sorted(named_parameters)}
         self.backward_passes_per_step = backward_passes_per_step
         self._allreduce_delay = {v: self.backward_passes_per_step
                                  for _, v in sorted(named_parameters)}

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -70,7 +70,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
             self._parameter_names = {v: 'allreduce.noname.%s' % i
                                      for param_group in self.param_groups
                                      for i, v in enumerate(param_group['params'])}
-            # named_parameters = [(k, v) for v, k in self._parameter_names.items()]
+            named_parameters = [(k, v) for v, k in self._parameter_names.items()]
         self.backward_passes_per_step = backward_passes_per_step
         self._allreduce_delay = {v: self.backward_passes_per_step
                                  for _, v in sorted(named_parameters)}

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1293,5 +1293,34 @@ class TorchTests(unittest.TestCase):
             assert 'optimizer.step(synchronize=True) called after optimizer.synchronize()' \
                 in str(ws[0].message)
 
+    def test_no_named_parameters(self):
+        """Test that leaving the default named_parameters=None will not throw an error."""
+        hvd.init()
+
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                # Place parts of model on different GPUs.
+                self.conv1 = torch.nn.Conv2d(1, 100, 1).cuda(first_device)
+                self.conv2 = torch.nn.Conv2d(100, 1, 1).cuda(second_device)
+
+            def forward(self, x):
+                x = x.cuda(first_device)
+                x = self.conv1(x)
+                x = x.cuda(second_device)
+                x = self.conv2(x)
+                return x
+
+        model = Net()
+        inp = torch.rand([1, 1, 1000, 1000])
+
+        opt = torch.optim.SGD(model.parameters(), lr=0.1)
+        opt = hvd.DistributedOptimizer(opt)
+
+        loss = model(inp).sum()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
 if __name__ == "__main__":
    unittest.main()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1301,13 +1301,11 @@ class TorchTests(unittest.TestCase):
             def __init__(self):
                 super(Net, self).__init__()
                 # Place parts of model on different GPUs.
-                self.conv1 = torch.nn.Conv2d(1, 100, 1).cuda(first_device)
-                self.conv2 = torch.nn.Conv2d(100, 1, 1).cuda(second_device)
+                self.conv1 = torch.nn.Conv2d(1, 100, 1)
+                self.conv2 = torch.nn.Conv2d(100, 1, 1)
 
             def forward(self, x):
-                x = x.cuda(first_device)
                 x = self.conv1(x)
-                x = x.cuda(second_device)
                 x = self.conv2(x)
                 return x
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1300,7 +1300,6 @@ class TorchTests(unittest.TestCase):
         class Net(torch.nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
-                # Place parts of model on different GPUs.
                 self.conv1 = torch.nn.Conv2d(1, 100, 1)
                 self.conv2 = torch.nn.Conv2d(100, 1, 1)
 


### PR DESCRIPTION
When adding the ability to perform local gradient accumulation, a bug was introduced which caused an error if `named_parameters=None`, i.e. was left at its default, when passed to `hvd.DistributedOptimizer`. 