### PR TITLE
Add grouped allreduce feature

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -148,6 +148,19 @@ class HorovodBasics(object):
                 'Horovod has not been initialized; use hvd.init().')
         return bool(mpi_threads_supported)
 
+    def register_group(self, group_size, group_name):
+        """A function that registers a group and returns associated group id.
+
+        Returns:
+          An integer scalar with the group id to be used for this group.
+        """
+        group_id = self.MPI_LIB_CTYPES.horovod_register_group(ctypes.c_int(group_size),
+            ctypes.c_char_p(group_name.encode()))
+        if group_id == -1:
+            raise ValueError(
+                'Horovod has not been initialized; use hvd.init().')
+        return group_id
+
     def mpi_enabled(self):
         """Returns True if MPI is mode is currently enabled at runtime.
 

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -76,6 +76,7 @@ namespace common {
 #define HOROVOD_HIERARCHICAL_ALLREDUCE "HOROVOD_HIERARCHICAL_ALLREDUCE"
 #define HOROVOD_HIERARCHICAL_ALLGATHER "HOROVOD_HIERARCHICAL_ALLGATHER"
 #define HOROVOD_CACHE_CAPACITY "HOROVOD_CACHE_CAPACITY"
+#define HOROVOD_GROUPED_ALLREDUCES "HOROVOD_GROUPED_ALLREDUCES"
 #define HOROVOD_MLSL_BGT_AFFINITY "HOROVOD_MLSL_BGT_AFFINITY"
 #define HOROVOD_NUM_NCCL_STREAMS "HOROVOD_NUM_NCCL_STREAMS"
 #define HOROVOD_CPU_OPERATIONS "HOROVOD_CPU_OPERATIONS"
@@ -161,6 +162,11 @@ const Status DUPLICATE_NAME_ERROR = Status::InvalidArgument(
     "Requested to allreduce, allgather, or broadcast a tensor with the same "
     "name as another tensor that is currently being processed.  If you want "
     "to request another tensor, use a different tensor name.");
+
+const Status UNREGISTERED_GROUP_ERROR = Status::InvalidArgument(
+    "Requested to assign an allreduce to a group that has not been "
+    "registered. A valid group id can be obtained via the register_group "
+    "function called prior to submitting the allreduce operation.");
 
 class TensorShape {
 public:

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "global_state.h"
+#include "group_table.h"
 #include "parameter_manager.h"
 #include "response_cache.h"
 #include "stall_inspector.h"
@@ -35,7 +36,8 @@ using MessageTable = std::unordered_map<std::string, std::vector<Request>>;
 class Controller : public std::enable_shared_from_this<Controller> {
 public:
   Controller(ResponseCache& response_cache, TensorQueue& tensor_queue,
-             Timeline& timeline, ParameterManager& parameter_manager);
+             Timeline& timeline, ParameterManager& parameter_manager,
+             GroupTable& group_table);
 
   Controller(const Controller&) = delete;
   // Functions must be overridden by concrete controller
@@ -199,6 +201,8 @@ protected:
   ResponseCache& response_cache_;
 
   ParameterManager& parameter_manager_;
+
+  GroupTable& group_table_;
 };
 
 } // namespace common

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include "fusion_buffer_manager.h"
+#include "group_table.h"
 #include "parameter_manager.h"
 #include "response_cache.h"
 #include "tensor_queue.h"
@@ -92,6 +93,12 @@ struct HorovodGlobalState {
 
   // Index of current CUDA stream to use
   int current_nccl_stream = 0;
+
+  // Perform allreduces in fixed groups (set by framework).
+  bool grouped_allreduces = false;
+
+  // Information on registered groups.
+  GroupTable group_table;
 
   // A LibType indicating what framework we are using to perform CPU operations.
   LibType cpu_operation;

--- a/horovod/common/gloo/gloo_controller.h
+++ b/horovod/common/gloo/gloo_controller.h
@@ -27,9 +27,11 @@ class GlooController : public Controller {
 public:
   GlooController(ResponseCache& response_cache, TensorQueue& tensor_queue,
                  Timeline& timeline, ParameterManager& parameter_manager,
-                 GlooContext& gloo_context)
-      : Controller(response_cache, tensor_queue, timeline, parameter_manager),
-        gloo_context_(gloo_context) {};
+                 GroupTable& group_table, GlooContext& gloo_context)
+      : Controller(response_cache, tensor_queue, timeline, parameter_manager,
+                   group_table),
+        gloo_context_(gloo_context) {
+  };
 
   void Initialize() override;
 

--- a/horovod/common/group_table.cc
+++ b/horovod/common/group_table.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "group_table.h"
+
+#include <assert.h>
+
+namespace horovod {
+namespace common {
+
+int32_t GroupTable::GetGroupSize(int32_t group_id) const {
+  assert(registered_groups_.size() > group_id);
+  std::lock_guard<std::mutex> guard(mutex_);
+  return registered_groups_[group_id].size;
+}
+
+int32_t GroupTable::GetGroupIDFromName(std::string group_name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return group_name_to_id_.at(group_name);
+}
+
+bool GroupTable::IsNameRegistered(std::string group_name) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return group_name_to_id_.find(group_name) != group_name_to_id_.end();
+}
+
+bool GroupTable::IsIDRegistered(int32_t group_id) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return (uint32_t) registered_groups_.size() > group_id;
+}
+
+bool GroupTable::empty(void) const {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return registered_groups_.empty();
+}
+
+int32_t GroupTable::AddEntry(std::string name, int32_t size) {
+  std::lock_guard<std::mutex> guard(mutex_);
+
+  GroupTableEntry e;
+  int32_t group_id = next_group_id_;
+  e.id = group_id;
+  e.size= size;
+  registered_groups_.push_back(std::move(e));
+  group_name_to_id_[name] = group_id;
+
+  next_group_id_++;
+
+  return group_id;
+}
+
+} // namespace common
+} // namespace horovod

--- a/horovod/common/group_table.h
+++ b/horovod/common/group_table.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#ifndef HOROVOD_GROUP_TABLE_H
+#define HOROVOD_GROUP_TABLE_H
+namespace horovod {
+namespace common {
+
+// Table storing information on groups for allreduce grouping.
+struct GroupTableEntry {
+  int32_t id;
+  int32_t size;
+  // Note: We can add other data to this struct to enable more error checking
+  // if desired.
+};
+
+class GroupTable {
+public:
+  GroupTable() = default;
+  GroupTable(const GroupTable&) = delete;
+
+  int32_t GetGroupSize(int32_t group_id) const;
+  int32_t GetGroupIDFromName(std::string group_name) const;
+  bool IsNameRegistered(std::string group_name) const;
+  bool IsIDRegistered(int32_t group_id) const;
+  bool empty(void) const;
+
+  int32_t AddEntry(std::string name, int32_t size);
+
+private:
+  std::vector<GroupTableEntry> registered_groups_;
+
+  // Map to obtain assigned group id value from names
+  std::unordered_map<std::string, int32_t> group_name_to_id_;
+
+  // Next available group id (increases each time a group is added)
+  int32_t next_group_id_ = 0;
+
+  mutable std::mutex mutex_;
+
+};
+
+} // namespace common
+} // namespace horovod
+
+#endif // HOROVOD_GROUP_TABLE_H

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -113,6 +113,10 @@ int32_t Request::device() const { return device_; }
 
 void Request::set_device(int32_t value) { device_ = value; }
 
+int32_t Request::group_id() const { return group_id_; }
+
+void Request::set_group_id(int32_t value) { group_id_ = value; }
+
 const std::vector<int64_t>& Request::tensor_shape() const {
   return tensor_shape_;
 }

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -21,6 +21,9 @@
 #include <string>
 #include <vector>
 
+// Null group ID used when no group is provided.
+#define NULL_GROUP_ID -1
+
 namespace horovod {
 namespace common {
 
@@ -78,6 +81,8 @@ public:
 
   void set_device(int32_t value);
 
+  int32_t group_id() const;
+  void set_group_id(int32_t value);
   const std::vector<int64_t>& tensor_shape() const;
 
   void set_tensor_shape(const std::vector<int64_t>& value);
@@ -94,6 +99,9 @@ private:
   DataType tensor_type_ = DataType::HOROVOD_UINT8;
   int32_t root_rank_ = 0;
   int32_t device_ = 0;
+  // group_id is not included in flatbuffer as it does not
+  // need to be shared between workers
+  int32_t group_id_ = NULL_GROUP_ID;
   std::string tensor_name_;
   std::vector<int64_t> tensor_shape_;
 };

--- a/horovod/common/mpi/mpi_controller.h
+++ b/horovod/common/mpi/mpi_controller.h
@@ -26,8 +26,9 @@ class MPIController : public Controller {
 public:
   MPIController(ResponseCache& response_cache, TensorQueue& tensor_queue,
                 Timeline& timeline, ParameterManager& parameter_manager,
-                MPIContext& mpi_ctx)
-      : Controller(response_cache, tensor_queue, timeline, parameter_manager),
+                GroupTable& group_table, MPIContext& mpi_ctx)
+      : Controller(response_cache, tensor_queue, timeline, parameter_manager,
+                   group_table),
         mpi_ctx_(mpi_ctx) {
     LOG(DEBUG) << "MPI Controller Initialized.";
   }

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -72,6 +72,10 @@ int horovod_local_size();
 // supported. Returns -1 if Horovod is not initialized.
 int horovod_mpi_threads_supported();
 
+// C interface to register group for allreduce grouping. Returns next
+// available group id or -1 if Horovod is not initialized.
+int horovod_register_group(int group_size, const char* group_name);
+
 // C interface to return flag indicating whether MPI is enabled.
 bool horovod_mpi_enabled();
 
@@ -110,7 +114,8 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string name, const int device,
                               StatusCallback callback,
-                              ReduceOp reduce_op = ReduceOp::SUM);
+                              ReduceOp reduce_op = ReduceOp::SUM,
+                              const int group_id = NULL_GROUP_ID);
 
 Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,

--- a/horovod/common/response_cache.cc
+++ b/horovod/common/response_cache.cc
@@ -270,6 +270,11 @@ void CacheCoordinator::record_invalid_bit(uint32_t bit) {
   invalid_in_queue_ = true;
 }
 
+void CacheCoordinator::erase_hit(uint32_t bit) {
+  assert(!synced_);
+  cache_hits_.erase(bit);
+}
+
 void CacheCoordinator::set_should_shut_down(bool should_shut_down) {
   assert(!synced_);
   should_shut_down_ = should_shut_down;

--- a/horovod/common/response_cache.h
+++ b/horovod/common/response_cache.h
@@ -107,6 +107,8 @@ public:
 
   void record_invalid_bit(uint32_t bit);
 
+  void erase_hit(uint32_t bit);
+
   void set_should_shut_down(bool should_shut_down);
 
   void set_uncached_in_queue(bool uncached_in_queue);

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -231,7 +231,7 @@ if _SessionRunHook is not None and _get_default_graph is not None:
 
 @_cache
 def _make_allreduce_grads_fn(name, device_dense, device_sparse,
-                             compression, sparse_as_dense, op, num_groups):
+                             compression, sparse_as_dense, op, num_groups=0):
     def allreduce_grads(grads):
         with tf.name_scope(name + "_Allreduce"):
             if sparse_as_dense:

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -94,8 +94,7 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
         with tf.device(device_dense):
             horovod_size = tf.cast(size(), dtype=tensor.dtype)
             tensor_compressed, ctx = compression.compress(tensor)
-            summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op)
-            summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op, group_id)
+            summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op, group_id=group_id)
             summed_tensor = compression.decompress(summed_tensor_compressed, ctx)
             if op == Adasum:
                 if ('CPU' not in tensor.device and has_gpu):
@@ -432,7 +431,6 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
                          device_sparse='', compression=Compression.none,
                          sparse_as_dense=False, backward_passes_per_step=1,
                          op=Average, num_groups=0):
-                         sparse_as_dense=False, num_groups=0):
     """Construct a new DistributedOptimizer, which uses another optimizer
     under the hood for computing single-process gradient values and
     applying gradient updates after the gradient values have been combined

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -107,7 +107,7 @@ def _allreduce(tensor, name=None, op=Sum, group_id=-1):
         return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op,
                                          group_id=group_id)
     else:
-        return MPI_LIB.horovod_allreduce(tensor, name=name)
+        return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op)
 
 
 @ops.RegisterGradient('HorovodAllreduce')

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -64,6 +64,7 @@ gloo_built = _basics.gloo_built
 nccl_built = _basics.nccl_built
 ddl_built = _basics.ddl_built
 mlsl_built = _basics.mlsl_built
+register_group = _basics.register_group
 
 # import reduction op values
 Average = _basics.Average
@@ -87,7 +88,7 @@ def _normalize_name(name):
     return re.sub('[^a-zA-Z0-9_]', '_', name)
 
 
-def _allreduce(tensor, name=None, op=Sum):
+def _allreduce(tensor, name=None, op=Sum, group_id=-1):
     """An op which reduces an input tensor over all the Horovod processes. The
     default reduction is a sum.
 
@@ -101,7 +102,12 @@ def _allreduce(tensor, name=None, op=Sum):
     """
     if name is None and not _executing_eagerly():
         name = 'HorovodAllreduce_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op)
+
+    if group_id != -1:
+        return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op,
+                                         group_id=group_id)
+    else:
+        return MPI_LIB.horovod_allreduce(tensor, name=name)
 
 
 @ops.RegisterGradient('HorovodAllreduce')

--- a/setup.py
+++ b/setup.py
@@ -646,6 +646,7 @@ def get_common_options(build_ext):
     SOURCES = ['horovod/common/common.cc',
                'horovod/common/controller.cc',
                'horovod/common/fusion_buffer_manager.cc',
+               'horovod/common/group_table.cc',
                'horovod/common/logging.cc',
                'horovod/common/message.cc',
                'horovod/common/operations.cc',


### PR DESCRIPTION
This is a preliminary PR for a new feature that enables explicit assignment of allreduce operations into manually defined groups. This enables users to exert more direct control over how/when allreduces are scheduled within Horovod.

Current implementation is for TensorFlow only and exposed via additional `num_groups` argument to `DistributedOptimizer` wrapper. Right now, the wrapper will evenly split and assign tensors to requested number of groups. Grouping is enabled via new env var `HOROVOD_GROUPED_ALLREDUCES`. 

A few benefits of this feature:
1. Ability to disable all overlap of allreduces (`num_groups = 1`) and computation which can be useful.
2. Explicit group assignment can be used to impose minimum fused allreduce size. This enables users to reduce `HOROVOD_CYCLE_TIME` for reduced latency *without* the side effect of generating many small allreduces as is the case with the fully dynamic strategy.
3. (not implemented yet) Can be used to enforce deterministic allreduces. Fully dynamic strategy results in non-deterministic allreduce results due to dynamic fusion buffer packing. If multiple groups are prohibited from fusing, and the fusion order is explicitly defined within groups, the allreduces will be deterministic. 