### PR TITLE
Replace .step(synchronize=False) with optimizer.skip_synchronize()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ autodoc_default_options = {
     'special-members': '__init__',
     'imported-members': None,
     'undoc-members': None,
+    'exclude-members': 'contextmanager',
 }
 
 

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -166,11 +166,12 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         not perform synchronization.
 
         It's typically used in a following pattern:
-        ```
-        optimizer.synchronize()
-        with optimizer.already_synchronized():
-            optimizer.step()
-        ```
+
+        .. code-block:: python
+
+            optimizer.synchronize()
+            with optimizer.already_synchronized():
+                optimizer.step()
         """
         self._should_synchronize = False
         yield
@@ -204,31 +205,32 @@ def DistributedOptimizer(optimizer, named_parameters=None,
     An optimizer that wraps another torch.optim.Optimizer, using an allreduce to
     average gradient values before applying gradients to model weights.
 
-    Allreduce operations are executed after each gradient is computed by `loss.backward()`
-    in parallel with each other. The `step()` method ensures that all allreduce operations are
+    Allreduce operations are executed after each gradient is computed by ``loss.backward()``
+    in parallel with each other. The ``step()`` method ensures that all allreduce operations are
     finished before applying gradients to the model.
 
-    DistributedOptimizer exposes the `synchronize()` method, which forces allreduce operations
+    DistributedOptimizer exposes the ``synchronize()`` method, which forces allreduce operations
     to finish before continuing the execution. It's useful in conjunction with gradient
-    clipping, or other operations that modify gradients in place before `step()` is executed.
-    Make sure to use `optimizer.already_synchronized()` if you're calling `synchronize()`
+    clipping, or other operations that modify gradients in place before ``step()`` is executed.
+    Make sure to use ``optimizer.already_synchronized()`` if you're calling ``synchronize()``
     in your code.
 
     Example of gradient clipping:
-    ```
-    output = model(data)
-    loss = F.nll_loss(output, target)
-    loss.backward()
-    optimizer.synchronize()
-    torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
-    with optimizer.already_synchronized():
-        optimizer.step()
-    ```
+
+    .. code-block:: python
+
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.synchronize()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
+        with optimizer.already_synchronized():
+            optimizer.step()
 
     Arguments:
         optimizer: Optimizer to use for computing gradients and applying updates.
         named_parameters: A mapping between parameter names and values. Used for naming of
-                          allreduce operations. Typically just `model.named_parameters()`.
+                          allreduce operations. Typically just ``model.named_parameters()``.
         compression: Compression algorithm used during allreduce to reduce the amount
                      of data sent during the each parameter update step.  Defaults to
                      not using compression.
@@ -249,8 +251,8 @@ def DistributedOptimizer(optimizer, named_parameters=None,
 def broadcast_parameters(params, root_rank):
     """
     Broadcasts the parameters from root rank to all other processes.
-    Typical usage is to broadcast the `model.state_dict()`,
-    `model.named_parameters()`, or `model.parameters()`.
+    Typical usage is to broadcast the ``model.state_dict()``,
+    ``model.named_parameters()``, or ``model.parameters()``.
 
     Arguments:
         params: One of the following:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1261,13 +1261,13 @@ class TorchTests(unittest.TestCase):
         torch.nn.utils.clip_grad_norm_(model.parameters(), 0.1)
         clipped_grad = model.weight.grad.item()
         assert abs(prior_grad) > abs(clipped_grad)
-        with optimizer.already_synchronized():
+        with optimizer.skip_synchronize():
             optimizer.step()
 
     def test_synchronize_step_warning(self):
         """
         Test that .synchronize() followed by .step() without
-        optimizer.already_synchronized() context will produce a warning.
+        optimizer.skip_synchronize() context will produce a warning.
         """
         hvd.init()
         size = hvd.size()
@@ -1292,10 +1292,9 @@ class TorchTests(unittest.TestCase):
         optimizer.synchronize()
         torch.nn.utils.clip_grad_norm_(model.parameters(), 0.1)
         with warnings.catch_warnings(record=True) as ws:
-            with optimizer.already_synchronized():
-                optimizer.step()
+            optimizer.step()
             assert len(ws) == 1
-            assert 'optimizer.step() called without optimizer.already_synchronized()' \
+            assert 'optimizer.step() called without optimizer.skip_synchronize()' \
                 in str(ws[0].message)
 
     def test_no_named_parameters(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1261,10 +1261,14 @@ class TorchTests(unittest.TestCase):
         torch.nn.utils.clip_grad_norm_(model.parameters(), 0.1)
         clipped_grad = model.weight.grad.item()
         assert abs(prior_grad) > abs(clipped_grad)
-        optimizer.step(synchronize=False)
+        with optimizer.already_synchronized():
+            optimizer.step()
 
     def test_synchronize_step_warning(self):
-        """Test that .synchronize() followed by .step(synchronize=True) will produce a warning."""
+        """
+        Test that .synchronize() followed by .step() without
+        optimizer.already_synchronized() context will produce a warning.
+        """
         hvd.init()
         size = hvd.size()
 
@@ -1288,9 +1292,10 @@ class TorchTests(unittest.TestCase):
         optimizer.synchronize()
         torch.nn.utils.clip_grad_norm_(model.parameters(), 0.1)
         with warnings.catch_warnings(record=True) as ws:
-            optimizer.step(synchronize=True)
+            with optimizer.already_synchronized():
+                optimizer.step()
             assert len(ws) == 1
-            assert 'optimizer.step(synchronize=True) called after optimizer.synchronize()' \
+            assert 'optimizer.step() called without optimizer.already_synchronized()' \
                 in str(ws[0].message)
 
     def test_no_named_parameters(self):


### PR DESCRIPTION
NVIDIA AMP does not support passing additional flags to `optimizer.step()`, such as `optimizer.step(synchronize=False)`.

This PR switches API to use context manager:
```python
optimizer.synchronize()
with optimizer.skip_synchronize():
    optimizer.step()
```