### PR TITLE
Pin tf-nightly to 1.14.1.dev20190606 & remove torchvision-nightly

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -104,7 +104,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision_nightly
+        TORCHVISION_PACKAGE: torchvision
         PYSPARK_PACKAGE: pyspark==2.4.0
         MXNET_PACKAGE: mxnet --pre
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -116,7 +116,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision_nightly
+        TORCHVISION_PACKAGE: torchvision
         PYSPARK_PACKAGE: pyspark==2.4.0
         MXNET_PACKAGE: mxnet --pre
   test-cpu-mpich-py2_7-tf1_12_0-keras2_2_2-torch1_0_0-mxnet1_4_1-pyspark2_4_0:
@@ -204,7 +204,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision_nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -219,7 +219,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision_nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-mpich-py2_7-tf1_12_0-keras2_2_2-torch1_0_0-mxnet1_4_1-pyspark2_4_0:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -101,7 +101,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly
+        TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision_nightly
@@ -113,7 +113,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly
+        TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision_nightly
@@ -201,7 +201,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.3.7-1+cuda10.0
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision_nightly
@@ -216,7 +216,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.3.7-1+cuda10.0
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision_nightly

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -104,7 +104,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
+        TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         PYSPARK_PACKAGE: pyspark==2.4.0
         MXNET_PACKAGE: mxnet --pre
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -116,7 +116,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
+        TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         PYSPARK_PACKAGE: pyspark==2.4.0
         MXNET_PACKAGE: mxnet --pre
   test-cpu-mpich-py2_7-tf1_12_0-keras2_2_2-torch1_0_0-mxnet1_4_1-pyspark2_4_0:
@@ -204,7 +204,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
+        TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -219,7 +219,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu==1.14.1.dev20190606
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
+        TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-mpich-py2_7-tf1_12_0-keras2_2_2-torch1_0_0-mxnet1_4_1-pyspark2_4_0:


### PR DESCRIPTION
1. Pin TF until tensorflow/tensorflow#29559 is resolved.
2. `s/torchvision_nightly/torchvision/` due to pytorch/vision#833.