### PR TITLE
Fixes build error in MXNet on certain platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -744,6 +744,7 @@ def build_mx_extension(build_ext, options):
     else:
         mxnet_mpi_lib.define_macros += [('MXNET_USE_MKLDNN', '0')]
     mxnet_mpi_lib.define_macros += [('MSHADOW_USE_MKL', '0')]
+    mxnet_mpi_lib.define_macros += [('MSHADOW_USE_F16C', '0')]
     mxnet_mpi_lib.include_dirs = options['INCLUDES']
     mxnet_mpi_lib.sources = options['SOURCES'] + \
         ['horovod/mxnet/mpi_ops.cc',


### PR DESCRIPTION
Remove the unnecessary `MSHADOW_USE_F16C` compiler flag when building Horovod with MXNet

Fix https://github.com/horovod/horovod/issues/1138