### PR TITLE
Fix MXNet Gluon DistributedTrainer for Python < 3.6

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -96,7 +96,8 @@ class DistributedTrainer(mx.gluon.Trainer):
         self._scale /= size()
 
     def _allreduce_grads(self):
-        for i, param in enumerate(self._params):
+        # sort needed for Python < 3.6 is not guaranteed
+        for i, param in enumerate(sorted(self._params, key=lambda p: p.name)):
             if param.grad_req != 'null':
                 allreduce_(param.list_grad()[0], average=False,
                            name=str(i), priority=-i)


### PR DESCRIPTION
**Problem**
Due to a security feature of Python added in 3.2 https://mail.python.org/pipermail/python-announce-list/2012-March/009394.html and then dropped in 3.6 https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-compactdict , the order of elements w.r.t. order of insertion in `dict()` is not guaranteed.

As a consequence, the order of params in Gluon can vary between Python interpreters instances/processes.

**Solution**
Add a sort by name in `_allreduce_grads`.

Signed-off-by: Serge Panev <spanev@nvidia.com>