### PR TITLE
Add `horovod.run.run_func` to make horovod notebook friendly

### DIFF
--- a/horovod/run/__init__.py
+++ b/horovod/run/__init__.py
@@ -1,0 +1,1 @@
+from .run_func import run_func

--- a/horovod/run/run_func.py
+++ b/horovod/run/run_func.py
@@ -115,7 +115,7 @@ def run_func(
         rank=${{OMPI_COMM_WORLD_RANK:-0}}
         {exec} -c "import cloudpickle; cloudpickle.load(open('{fn_file}', 'rb'))(rank=$rank)"
         if [[ "$rank" -eq 0 ]]; then
-        scp -q {scp_port_opt} -o StrictHostKeyChecking=no \
+        scp -v -q {scp_port_opt} -o StrictHostKeyChecking=no \
         {wdir}/{local_result} {local_ip}:{wdir}/{result}
         fi
         """.format(wdir=wdir,

--- a/horovod/run/run_func.py
+++ b/horovod/run/run_func.py
@@ -1,0 +1,151 @@
+import cloudpickle
+import tempfile
+import os
+import sys
+import six
+import subprocess
+import collections
+import textwrap
+import time
+
+from horovod.run.util import network
+from horovod.run.common.util import safe_shell_exec
+
+_TAIL_LINES_TO_KEEP = 100
+
+_LOCAL_PICKLED_RESULT_FILENAME = "local_result.pkl"
+_PICKLED_RESULT_FILENAME = "result.pkl"
+_PICKLED_PROC_FN_FILENAME = "proc_fn.pkl"
+_PROC_LAUNCHER_FILENAME = "launch.sh"
+
+
+def run_func(
+        proc_fn,
+        num_proc,
+        host,
+        ssh_port=None,
+        disable_cache=False,
+        start_timeout=None,
+        verbose=False):
+    wdir = tempfile.mkdtemp()
+    wdir_par = os.path.dirname(wdir)
+    if verbose:
+        print("mpirun working dir is " + wdir)
+
+    if ssh_port:
+        ssh_port_opt = "-p " + str(ssh_port)
+    else:
+        ssh_port_opt = ""
+
+    # Invokes proc_fn with args. So we don't need to pickle them separately.
+    def wrapped_proc_fn(rank=0):
+        return_value = proc_fn()
+        if rank == 0:
+            with open(_LOCAL_PICKLED_RESULT_FILENAME, 'wb') as f:
+                try:
+                    cloudpickle.dump(return_value, f)
+                except Exception as e:
+                    raise RuntimeError("Caught an excpetion while pickling "
+                                       "return value: {}".format(repr(e)))
+
+    pickled_proc_fn_str = cloudpickle.dumps(wrapped_proc_fn)
+    pickled_proc_fn_path = os.path.join(wdir, _PICKLED_PROC_FN_FILENAME)
+    with open(pickled_proc_fn_path, 'wb') as f:
+        f.write(pickled_proc_fn_str)
+
+    local_ip = network.get_local_ip_addr()
+    launcher_path = os.path.join(wdir, _PROC_LAUNCHER_FILENAME)
+    with open(launcher_path, 'w') as f:
+        f.write(textwrap.dedent("""
+        set -e
+        cd {wdir}
+        rank=${{OMPI_COMM_WORLD_RANK:-0}}
+        {exec} -c "import cloudpickle; cloudpickle.load(open('{fn_file}', 'rb'))(rank=$rank)"
+        if [[ "$rank" -eq 0 ]]; then
+        scp -q {ssh_port_opt} -o StrictHostKeyChecking=no \
+        {wdir}/{local_result} {local_ip}:{wdir}/{result}
+        fi
+        """.format(wdir=wdir,
+                   exec=sys.executable,
+                   ssh_port_opt=ssh_port_opt,
+                   fn_file=_PICKLED_PROC_FN_FILENAME,
+                   local_ip=local_ip,
+                   local_result=_LOCAL_PICKLED_RESULT_FILENAME,
+                   result=_PICKLED_RESULT_FILENAME)))
+
+    os.chmod(launcher_path, 0o777)
+
+    all_host_names = list(set(x.split(':')[0] for x in host.split(',')))
+    remote_host_names = network.filter_local_addresses(all_host_names)
+
+    for remote_host in remote_host_names:
+        scp_cmd = textwrap.dedent(
+            """
+            ssh {ssh_port_opt} -o StrictHostKeyChecking=no {remote_host} mkdir -p {wdir_par} && \
+            scp -r -q {ssh_port_opt} -o StrictHostKeyChecking=no \
+            {wdir} {remote_host}:{wdir_par}
+            """).format(ssh_port_opt=ssh_port_opt, wdir=wdir,
+                        remote_host=remote_host, wdir_par=wdir_par)
+        output = six.StringIO()
+        exit_code = safe_shell_exec.execute(scp_cmd, stdout=output, stderr=output)
+        if exit_code != 0:
+            output_msg = output.getvalue()
+            raise RuntimeError("Copy working dir to remote host {remote_host} failed."
+                               "Error message is {msg}"
+                               .format(remote_host=remote_host, msg=output_msg))
+
+    cmd = ["horovodrun", "-np", str(num_proc)]
+    if ssh_port:
+        cmd += ["-p", str(ssh_port)]
+    if host:
+        cmd += ["-H", str(host)]
+    if disable_cache:
+        cmd += ["--disable-cache"]
+    if start_timeout:
+        cmd += ["--start-timeout", str(start_timeout)]
+    if verbose:
+        cmd += ["--verbose"]
+
+    cmd += ["bash", launcher_path]
+
+    # Use `os.environ` to preserve the environ to support nested MPI jobs
+    task = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            stdin=subprocess.PIPE,
+                            env=os.environ)
+    task.stdin.close()
+
+    tail = collections.deque(maxlen=_TAIL_LINES_TO_KEEP)
+    try:
+        for line in task.stdout:
+            decoded = line.decode()
+            tail.append(decoded)
+            sys.stdout.write(decoded)
+        task.wait()
+    finally:
+        if task.poll() is None:
+            try:
+                task.terminate()  # SIGTERM
+                time.sleep(0.5)
+                if task.poll() is None:
+                    task.kill()  # SIGKILL
+            except OSError:
+                pass
+
+    if task.returncode != os.EX_OK:
+        if len(tail) == _TAIL_LINES_TO_KEEP:
+            last_n_msg = "last %d lines of the task output are" % _TAIL_LINES_TO_KEEP
+        else:
+            last_n_msg = "task output is"
+        raise RuntimeError(
+            "Command %s failed with return code %d.\n" % (cmd, task.returncode) +
+            """
+            The %s included below.
+            """ % last_n_msg + "\n%s\n" % "".join(tail))
+
+    result_path = os.path.join(wdir, _PICKLED_RESULT_FILENAME)
+    with open(result_path, 'rb') as f:
+        result_bytes = f.read()
+
+    return cloudpickle.loads(result_bytes)

--- a/horovod/run/run_func.py
+++ b/horovod/run/run_func.py
@@ -86,7 +86,7 @@ def run_func(
         scp_port_opt = ""
 
     # Invokes proc_fn with args. So we don't need to pickle them separately.
-    if args is None
+    if args is None:
         args = ()
     if kwargs is None:
         kwargs = {}

--- a/horovod/run/run_func.py
+++ b/horovod/run/run_func.py
@@ -1,3 +1,19 @@
+# Copyright 2018 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import print_function
 import cloudpickle
 import tempfile
 import os

--- a/horovod/run/util/network.py
+++ b/horovod/run/util/network.py
@@ -40,12 +40,3 @@ def filter_local_addresses(all_host_names):
             remote_host_names.append(host_name)
 
     return remote_host_names
-
-
-def get_local_ip_addr():
-    """ Returns the IP address of the current machine. """
-    import socket
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    host_ip = s.getsockname()[0]
-    return host_ip

--- a/horovod/run/util/network.py
+++ b/horovod/run/util/network.py
@@ -40,3 +40,12 @@ def filter_local_addresses(all_host_names):
             remote_host_names.append(host_name)
 
     return remote_host_names
+
+
+def get_local_ip_addr():
+    """ Returns the IP address of the current machine. """
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    host_ip = s.getsockname()[0]
+    return host_ip

--- a/test/test_run_func.py
+++ b/test/test_run_func.py
@@ -45,5 +45,6 @@ class RunFuncTests(unittest.TestCase):
             if hvd.rank() == 0:
                 return res, hvd.rank()
 
-        res = run_func(fn, num_proc=3, host='localhost:3')
+        res = run_func(fn, num_proc=3, host='localhost:3',
+                       env={'PATH': os.environ.get('PATH')})
         self.assertEqual(([0, 1, 2], 0), res)

--- a/test/test_run_func.py
+++ b/test/test_run_func.py
@@ -41,11 +41,9 @@ class RunFuncTests(unittest.TestCase):
 
         def fn():
             hvd.init()
-            res = hvd.allgather(torch.tensor([hvd.rank()])).tolist()
-            if hvd.rank() == 0:
-                return res, hvd.rank()
+            res = hvd.allgather(torch.tensor([hvd.rank()])) + hvd.rank() * 10
+            return res.tolist(), hvd.rank()
 
-        res = run_func(fn, num_proc=3, host='localhost:3',
-                       env={'PATH': os.environ.get('PATH')},
-                       driver_host='localhost')
-        self.assertEqual(([0, 1, 2], 0), res)
+        results = run_func(fn, num_proc=3, host='127.0.0.1:3',
+                           env={'PATH': os.environ.get('PATH')})
+        self.assertListEqual([([0, 1, 2], 0), ([10, 11, 12], 1), ([20, 21, 22], 2)], results)

--- a/test/test_run_func.py
+++ b/test/test_run_func.py
@@ -1,0 +1,49 @@
+# Copyright 2018 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import subprocess
+import time
+import torch
+import traceback
+import unittest
+import warnings
+
+import horovod.torch as hvd
+from horovod.run import run_func
+
+
+class RunFuncTests(unittest.TestCase):
+    """
+    Tests for horovod.run.run_func().
+    """
+    def __init__(self, *args, **kwargs):
+        super(RunFuncTests, self).__init__(*args, **kwargs)
+        warnings.simplefilter('module')
+
+    def test_happy_run(self):
+
+        def fn():
+            hvd.init()
+            res = hvd.allgather(torch.tensor([hvd.rank()])).tolist()
+            if hvd.rank() == 0:
+                return res, hvd.rank()
+
+        res = run_func(fn, num_proc=3, host='localhost:3')
+        self.assertListEqual(([0, 1, 2], 0), res)

--- a/test/test_run_func.py
+++ b/test/test_run_func.py
@@ -46,4 +46,4 @@ class RunFuncTests(unittest.TestCase):
                 return res, hvd.rank()
 
         res = run_func(fn, num_proc=3, host='localhost:3')
-        self.assertListEqual(([0, 1, 2], 0), res)
+        self.assertEqual(([0, 1, 2], 0), res)

--- a/test/test_run_func.py
+++ b/test/test_run_func.py
@@ -46,5 +46,6 @@ class RunFuncTests(unittest.TestCase):
                 return res, hvd.rank()
 
         res = run_func(fn, num_proc=3, host='localhost:3',
-                       env={'PATH': os.environ.get('PATH')})
+                       env={'PATH': os.environ.get('PATH')},
+                       driver_host='localhost')
         self.assertEqual(([0, 1, 2], 0), res)


### PR DESCRIPTION
## Proposed API:

Exported `run_fun` method in package `horovod.run`

```
def run_func(
        fn,
        num_proc,
        host=None,
        ssh_port=None,
        disable_cache=False,
        start_timeout=None,
        env=None,
        verbose=False):
    """
    Run horovod inside python program.
    Run `num_proc` processes executing `fn` on specified hosts.

    :param fn: Function to run.
    :param num_proc: Number of Horovod processes.
    :param host: To specify the list of host names as well as the
                 number of available slots on each host for
                 training processes using the following format:
                 <hostname>:<number of slots>,... .
                 E.g., host1:2,host2:4,host3:1 indicates that 2 processes can run on
                 host1, 4 processes on host2, and 1 process on host3.
                 If None, launch all mpi processes on local node.
    :param ssh_port: SSH port on all the hosts.
                     If None, use default SSH port.
    :param disable_cache: If the flag is not set, horovodrun will perform
                          the initialization checks only once every 60
                          minutes -- if the checks successfully pass.
                          Otherwise, all the checks will run every time
                          horovodrun is called."
    :param start_timeout: Horovodrun has to perform all the checks and
                          start the processes before the specified
                          timeout. The default value is 30 seconds.
                          Alternatively, The environment variable
                          HOROVOD_START_TIMEOUT can also be used to
                          specify the initialization timeout.
    :param env: Environment dictionary to use in Horovod run.
                If None, use `os.environ`.
    :param verbose: If this flag is set, extra messages will be printed.

    :return: A list contains returned result from each MPI process. The ith value of the list
             corresponds to the returned result of rank i process.
    """
```

## Example:

```
import horovod

def hvd_train1():
    # define your training function, with no args.
    # train code
    ...
    if hvd.rank == 0:
        return result

# result_list will be [result_from_rank_0_process, None]
result_list = horovod.run.run_func(hvd_train1, num_proc=2, host="10.95.255.92:1,10.95.232.120:1")

```

## Test

To be added. This is a version for first review.
