### PR TITLE
Horovod auto-selection of g++ version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,10 @@ ENV PYTHON_VERSION=${python}
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
-RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
-
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
         cmake \
-        g++-4.9 \
+        g++-4.8.5 \
         git \
         curl \
         vim \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,13 @@ ENV PYTHON_VERSION=${python}
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need gcc-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
+# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
 RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
         cmake \
-        gcc-4.9 \
         g++-4.9 \
-        gcc-4.9-base \
-        software-properties-common \
         git \
         curl \
         vim \
@@ -72,27 +69,11 @@ RUN mkdir /tmp/openmpi && \
     ldconfig && \
     rm -rf /tmp/openmpi
 
-# Pin GCC to 4.9 (priority 200) to compile correctly against TensorFlow, PyTorch, and MXNet.
-# Backup existing GCC installation as priority 100, so that it can be recovered later.
-RUN update-alternatives --install /usr/bin/gcc gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/g++ g++ $(readlink -f $(which g++)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ $(readlink -f $(which g++)) 100
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-4.9 200
-
 # Install Horovod, temporarily using CUDA stubs
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
-    HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir horovod && \
+    HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 \
+         pip install --no-cache-dir horovod && \
     ldconfig
-
-# Remove GCC pinning
-RUN update-alternatives --remove gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove g++ /usr/bin/g++-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-g++ /usr/bin/g++-4.9
 
 # Install OpenSSH for MPI to communicate between containers
 RUN apt-get install -y --no-install-recommends openssh-client openssh-server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ SHELL ["/bin/bash", "-cu"]
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
         cmake \
-        g++-4.8.5 \
+        g++-4.8 \
         git \
         curl \
         vim \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -16,9 +16,6 @@ ARG PYSPARK_PACKAGE=pyspark==2.4.0
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
-RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
-
 # Install essential packages.
 RUN apt-get update -qq
 RUN apt-get install -y --no-install-recommends \
@@ -27,7 +24,7 @@ RUN apt-get install -y --no-install-recommends \
         openssh-client \
         git \
         build-essential \
-        g++-4.9
+        g++-4.8.5
 
 # Install Python.
 RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -24,7 +24,7 @@ RUN apt-get install -y --no-install-recommends \
         openssh-client \
         git \
         build-essential \
-        g++-4.8.5
+        g++-4.8
 
 # Install Python.
 RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -16,7 +16,7 @@ ARG PYSPARK_PACKAGE=pyspark==2.4.0
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need gcc-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
+# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
 RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
 
 # Install essential packages.
@@ -27,10 +27,7 @@ RUN apt-get install -y --no-install-recommends \
         openssh-client \
         git \
         build-essential \
-        gcc-4.9 \
-        g++-4.9 \
-        gcc-4.9-base \
-        software-properties-common
+        g++-4.9
 
 # Install Python.
 RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev
@@ -112,17 +109,6 @@ RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}
 
-# Pin GCC to 4.9 (priority 200) to compile correctly against TensorFlow, PyTorch, and MXNet.
-# Backup existing GCC installation as priority 100, so that it can be recovered later.
-RUN update-alternatives --install /usr/bin/gcc gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/g++ g++ $(readlink -f $(which g++)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ $(readlink -f $(which g++)) 100
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-4.9 200
-
 # Install Horovod.
 RUN if [[ ${MPI_KIND} == "MLSL" ]]; then \
       if [ -z "${LD_LIBRARY_PATH:-}" ]; then \
@@ -153,13 +139,6 @@ RUN if [[ ${MPI_KIND} == "MLSL" ]]; then \
     else \
       pip install -v /horovod/dist/horovod-*.tar.gz; \
     fi
-
-
-# Remove GCC pinning
-RUN update-alternatives --remove gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove g++ /usr/bin/g++-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-g++ /usr/bin/g++-4.9
 
 # Hack for compatibility of MNIST example with TensorFlow 1.1.0.
 RUN if [[ ${TENSORFLOW_PACKAGE} == "tensorflow==1.1.0" ]]; then \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -28,7 +28,7 @@ RUN apt-get install -y --allow-downgrades --allow-change-held-packages --no-inst
         openssh-client \
         git \
         build-essential \
-        g++-4.8.5 \
+        g++-4.8 \
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION_OVERRIDE} \
         libnccl-dev=${NCCL_VERSION_OVERRIDE}

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -20,9 +20,6 @@ ARG HOROVOD_MIXED_INSTALL=0
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
-RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
-
 # Install essential packages.
 RUN apt-get update -qq
 RUN apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
@@ -31,7 +28,7 @@ RUN apt-get install -y --allow-downgrades --allow-change-held-packages --no-inst
         openssh-client \
         git \
         build-essential \
-        g++-4.9 \
+        g++-4.8.5 \
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION_OVERRIDE} \
         libnccl-dev=${NCCL_VERSION_OVERRIDE}

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -20,7 +20,7 @@ ARG HOROVOD_MIXED_INSTALL=0
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-# We need gcc-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
+# We need g++-4.9 to build plugins for TensorFlow & PyTorch, which is only available in Ubuntu Xenial
 RUN echo deb http://archive.ubuntu.com/ubuntu xenial main universe | tee -a /etc/apt/sources.list
 
 # Install essential packages.
@@ -31,10 +31,7 @@ RUN apt-get install -y --allow-downgrades --allow-change-held-packages --no-inst
         openssh-client \
         git \
         build-essential \
-        gcc-4.9 \
         g++-4.9 \
-        gcc-4.9-base \
-        software-properties-common \
         libcudnn7=${CUDNN_VERSION} \
         libnccl2=${NCCL_VERSION_OVERRIDE} \
         libnccl-dev=${NCCL_VERSION_OVERRIDE}
@@ -94,28 +91,11 @@ RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}
 
-# Pin GCC to 4.9 (priority 200) to compile correctly against TensorFlow, PyTorch, and MXNet.
-# Backup existing GCC installation as priority 100, so that it can be recovered later.
-RUN update-alternatives --install /usr/bin/gcc gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc $(readlink -f $(which gcc)) 100 && \
-    update-alternatives --install /usr/bin/g++ g++ $(readlink -f $(which g++)) 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ $(readlink -f $(which g++)) 100
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 200 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 200 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-4.9 200
-
 # Install Horovod.
 RUN cd /horovod && python setup.py sdist
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     bash -c "${HOROVOD_BUILD_FLAGS} pip install -v /horovod/dist/horovod-*.tar.gz" && \
     ldconfig
-
-# Remove GCC pinning
-RUN update-alternatives --remove gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-gcc /usr/bin/gcc-4.9 && \
-    update-alternatives --remove g++ /usr/bin/g++-4.9 && \
-    update-alternatives --remove x86_64-linux-gnu-g++ /usr/bin/g++-4.9
 
 # Hack for compatibility of MNIST example with TensorFlow 1.1.0.
 RUN if [[ ${TENSORFLOW_PACKAGE} == "tensorflow-gpu==1.1.0" ]]; then \

--- a/README.rst
+++ b/README.rst
@@ -83,14 +83,22 @@ To install Horovod:
 
 1. Install `Open MPI <https://www.open-mpi.org/>`_ or another MPI implementation. Learn how to install Open MPI `on this page <https://www.open-mpi.org/faq/?category=building#easy-build>`_.
 
-**Note**: Open MPI 3.1.3 has an issue that may cause hangs.  The recommended fix is to
-downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
+   **Note**: Open MPI 3.1.3 has an issue that may cause hangs.  The recommended fix is to
+   downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
+
+.. raw:: html
+
+    <p/>
 
 2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
 
-If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+
+.. raw:: html
+
+    <p/>
 
 3. Install the ``horovod`` pip package.
 

--- a/README.rst
+++ b/README.rst
@@ -90,11 +90,11 @@ To install Horovod:
 
     <p/>
 
-2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that the ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that the ``g++-4.9`` or above is installed.
 
-   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that the ``gxx_linux-64`` Conda package is installed.
 
 .. raw:: html
 

--- a/README.rst
+++ b/README.rst
@@ -86,14 +86,22 @@ To install Horovod:
 **Note**: Open MPI 3.1.3 has an issue that may cause hangs.  The recommended fix is to
 downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
 
-2. Install the ``horovod`` pip package.
+2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+
+If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+
+If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+
+3. Install the ``horovod`` pip package.
 
 .. code-block:: bash
 
     $ pip install horovod
 
 This basic installation is good for laptops and for getting to know Horovod.
+
 If you're installing Horovod on a server with GPUs, read the `Horovod on GPU <docs/gpus.rst>`_ page.
+
 If you want to use Docker, read the `Horovod in Docker <docs/docker.rst>`_ page.
 
 

--- a/docs/gpus.rst
+++ b/docs/gpus.rst
@@ -32,11 +32,11 @@ by installing an `nv_peer_memory <https://github.com/Mellanox/nv_peer_memory>`__
 
    **Note**: Open MPI 3.1.3 has an issue that may cause hangs.  The recommended fix is to downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
 
-4. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+4. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that the ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that the ``g++-4.9`` or above is installed.
 
-   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that the ``gxx_linux-64`` Conda package is installed.
 
 5. Install the ``horovod`` pip package.
 

--- a/docs/gpus.rst
+++ b/docs/gpus.rst
@@ -34,9 +34,9 @@ by installing an `nv_peer_memory <https://github.com/Mellanox/nv_peer_memory>`__
 
 4. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
 
-If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
 
 5. Install the ``horovod`` pip package.
 

--- a/docs/gpus.rst
+++ b/docs/gpus.rst
@@ -32,7 +32,13 @@ by installing an `nv_peer_memory <https://github.com/Mellanox/nv_peer_memory>`__
 
    **Note**: Open MPI 3.1.3 has an issue that may cause hangs.  The recommended fix is to downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
 
-4. Install the ``horovod`` pip package.
+4. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+
+If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+
+If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+
+5. Install the ``horovod`` pip package.
 
    If you have installed NCCL 2 using the ``nccl-<version>.txz`` package, you should specify the path to NCCL 2 using the ``HOROVOD_NCCL_HOME``
    environment variable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@ Choose your deep learning framework to learn how to get started with Horovod.
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
             <li>
-               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
-               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that the <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
+               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that the <code>gxx_linux-64</code> Conda package is installed.
             </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/tensorflow.html">Horovod with TensorFlow</a> for best practices and examples. </li>
@@ -30,8 +30,8 @@ Choose your deep learning framework to learn how to get started with Horovod.
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
             <li>
-               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
-               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that the <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
+               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that the <code>gxx_linux-64</code> Conda package is installed.
             </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/keras.html">Horovod with Keras</a> for best practices and examples. </li>
@@ -46,8 +46,8 @@ Choose your deep learning framework to learn how to get started with Horovod.
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
             <li>
-               If you've installed PyTorch from <a href="https://pypi.org/project/torch">PyPI</a>, make sure that <code>g++-4.9</code> or above is installed.<br/>
-               If you've installed PyTorch from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+               If you've installed PyTorch from <a href="https://pypi.org/project/torch">PyPI</a>, make sure that the <code>g++-4.9</code> or above is installed.<br/>
+               If you've installed PyTorch from <a href="https://conda.io">Conda</a>, make sure that the <code>gxx_linux-64</code> Conda package is installed.
             </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/pytorch.html">Horovod with PyTorch</a> for best practices and examples. </li>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,10 @@ Choose your deep learning framework to learn how to get started with Horovod.
       <p>To use Horovod with TensorFlow on your laptop:
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
+            <li>
+               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
+               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+            </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/tensorflow.html">Horovod with TensorFlow</a> for best practices and examples. </li>
          </ol>
@@ -25,6 +29,10 @@ Choose your deep learning framework to learn how to get started with Horovod.
       <p>To use Horovod with Keras on your laptop:
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
+            <li>
+               If you've installed TensorFlow from <a href="https://pypi.org/project/tensorflow">PyPI</a>, make sure that <code>g++-4.8.5</code> or <code>g++-4.9</code> is installed.<br/>
+               If you've installed TensorFlow from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+            </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/keras.html">Horovod with Keras</a> for best practices and examples. </li>
          </ol>
@@ -37,6 +45,10 @@ Choose your deep learning framework to learn how to get started with Horovod.
       <p>To use Horovod with PyTorch on your laptop:
          <ol>
             <li><a href="https://www.open-mpi.org/faq/?category=building#easy-build">Install Open MPI 3.1.2 or 4.0.0</a>, or another MPI implementation. </li>
+            <li>
+               If you've installed PyTorch from <a href="https://pypi.org/project/torch">PyPI</a>, make sure that <code>g++-4.9</code> or above is installed.<br/>
+               If you've installed PyTorch from <a href="https://conda.io">Conda</a>, make sure that <code>gxx_linux-64</code> Conda package is installed.
+            </li>
             <li>Install the Horovod pip package: <code>pip install horovod</code></li>
             <li>Read <a href="https://horovod.readthedocs.io/en/latest/pytorch.html">Horovod with PyTorch</a> for best practices and examples. </li>
          </ol>

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -85,11 +85,19 @@ To install Horovod:
 
    **Note**: Open MPI 3.1.3 has an issue that may cause hangs. The recommended fix is to downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
 
+.. raw:: html
+
+    <p/>
+
 2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
 
-If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+
+.. raw:: html
+
+    <p/>
 
 3. Install the ``horovod`` pip package.
 

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -85,14 +85,22 @@ To install Horovod:
 
    **Note**: Open MPI 3.1.3 has an issue that may cause hangs. The recommended fix is to downgrade to Open MPI 3.1.2 or upgrade to Open MPI 4.0.0.
 
-2. Install the ``horovod`` pip package.
+2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+
+If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+
+If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+
+3. Install the ``horovod`` pip package.
 
 .. code-block:: bash
 
     $ pip install horovod
 
 This basic installation is good for laptops and for getting to know Horovod.
+
 If you're installing Horovod on a server with GPUs, read `Horovod on GPU <gpus.rst>`_.
+
 If you want to use Docker, read `Horovod in Docker <docker.rst>`_.
 
 

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -89,11 +89,11 @@ To install Horovod:
 
     <p/>
 
-2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-4.8.5`` or ``g++-4.9`` is installed.
+2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that the ``g++-4.8.5`` or ``g++-4.9`` is installed.
 
-   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-4.9`` or above is installed.
+   If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that the ``g++-4.9`` or above is installed.
 
-   If you've installed either package from `Conda <https://conda.io>`_, make sure that ``gxx_linux-64`` Conda package is installed.
+   If you've installed either package from `Conda <https://conda.io>`_, make sure that the ``gxx_linux-64`` Conda package is installed.
 
 .. raw:: html
 

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -49,6 +49,11 @@ def check_extension(ext_name, ext_env_var, pkg_path, *args):
 
 @contextmanager
 def env(**kwargs):
+    # ignore args with None values
+    for k in list(kwargs.keys()):
+        if kwargs[k] is None:
+            del kwargs[k]
+
     # backup environment
     backup = {}
     for k in kwargs.keys():
@@ -57,11 +62,13 @@ def env(**kwargs):
     # set new values & yield
     for k, v in kwargs.items():
         os.environ[k] = v
-    yield
 
-    # restore environment
-    for k in kwargs.keys():
-        if backup[k] is not None:
-            os.environ[k] = backup[k]
-        else:
-            del os.environ[k]
+    try:
+        yield
+    finally:
+        # restore environment
+        for k in kwargs.keys():
+            if backup[k] is not None:
+                os.environ[k] = backup[k]
+            else:
+                del os.environ[k]

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # =============================================================================
 
+from contextlib import contextmanager
 import os
 import sysconfig
 
@@ -44,3 +45,23 @@ def check_extension(ext_name, ext_env_var, pkg_path, *args):
         raise ImportError(
             'Extension %s has not been built.  If this is not expected, reinstall '
             'Horovod with %s=1 to debug the build error.' % (ext_name, ext_env_var))
+
+
+@contextmanager
+def env(**kwargs):
+    # backup environment
+    backup = {}
+    for k in kwargs.keys():
+        backup[k] = os.environ.get(k)
+
+    # set new values & yield
+    for k, v in kwargs.items():
+        os.environ[k] = v
+    yield
+
+    # restore environment
+    for k in kwargs.keys():
+        if backup[k] is not None:
+            os.environ[k] = backup[k]
+        else:
+            del os.environ[k]

--- a/setup.py
+++ b/setup.py
@@ -737,6 +737,7 @@ def remove_offensive_gxx_compiler_options(compiler_version):
 
         return cflags, cppflags, ldshared
 
+    # Use defaults
     return None, None, None
 
 
@@ -766,7 +767,8 @@ def build_tf_extension(build_ext, options):
             tf_compiler_version = LooseVersion(tf.COMPILER_VERSION)
 
         if tf_compiler_version.version[0] == 4:
-            # g++ 4.x is ABI-incompatible with g++ 5.x+
+            # g++ 4.x is ABI-incompatible with g++ 5.x+ due to std::function change
+            # See: https://github.com/tensorflow/tensorflow/issues/27067
             maximum_compiler_version = LooseVersion('5')
         else:
             maximum_compiler_version = LooseVersion('999')

--- a/setup.py
+++ b/setup.py
@@ -689,22 +689,23 @@ def find_gxx_in_path():
     compilers = []
 
     for path_dir in os.getenv('PATH', '').split(':'):
-        for bin_file in os.listdir(path_dir):
-            if re.match('^g\\+\\+(?:-\\d+(?:\\.\\d+)?)?$', bin_file):
-                # g++, or g++-7, or g++-4.9
-                compiler = os.path.join(path_dir, bin_file)
+        if os.path.isdir(path_dir):
+            for bin_file in os.listdir(path_dir):
+                if re.match('^g\\+\\+(?:-\\d+(?:\\.\\d+)?)?$', bin_file):
+                    # g++, or g++-7, or g++-4.9
+                    compiler = os.path.join(path_dir, bin_file)
 
-                try:
-                    version_string = subprocess.check_output(
-                        [compiler, '-dumpfullversion', '-dumpversion'],
-                        universal_newlines=True).strip()
-                    compiler_version = LooseVersion(version_string)
-                except subprocess.CalledProcessError:
-                    print('INFO: Unable to determine version of the compiler %s.\n%s'
-                          '' % (compiler, traceback.format_exc()))
-                    continue
+                    try:
+                        version_string = subprocess.check_output(
+                            [compiler, '-dumpfullversion', '-dumpversion'],
+                            universal_newlines=True).strip()
+                        compiler_version = LooseVersion(version_string)
+                    except subprocess.CalledProcessError:
+                        print('INFO: Unable to determine version of the compiler %s.\n%s'
+                            '' % (compiler, traceback.format_exc()))
+                        continue
 
-                compilers.append((compiler, compiler_version))
+                    compilers.append((compiler, compiler_version))
 
     return compilers
 

--- a/setup.py
+++ b/setup.py
@@ -737,7 +737,7 @@ def remove_offensive_gxx_compiler_options(compiler_version):
 
         return cflags, cppflags, ldshared
 
-    return None, None
+    return None, None, None
 
 
 def build_tf_extension(build_ext, options):

--- a/setup.py
+++ b/setup.py
@@ -728,12 +728,14 @@ def remove_offensive_gxx_compiler_options(compiler_version):
         from sysconfig import get_config_var
         cflags = get_config_var('CONFIGURE_CFLAGS')
         cppflags = get_config_var('CONFIGURE_CPPFLAGS')
+        ldshared = get_config_var('LDSHARED')
 
         for k, v in offensive_replacements.items():
             cflags = cflags.replace(k, v)
             cppflags = cppflags.replace(k, v)
+            ldshared = ldshared.replace(k, v)
 
-        return cflags, cppflags
+        return cflags, cppflags, ldshared
 
     return None, None
 
@@ -791,10 +793,11 @@ def build_tf_extension(build_ext, options):
                 'Please check Horovod website for recommended compiler versions.\n'
                 'To force a specific compiler version, set CC and CXX environment variables.')
 
-        cflags, cppflags = remove_offensive_gxx_compiler_options(compiler_version)
+        cflags, cppflags, ldshared = remove_offensive_gxx_compiler_options(compiler_version)
 
     try:
-        with env(CC=compiler, CXX=compiler, CFLAGS=cflags, CPPFLAGS=cppflags):
+        with env(CC=compiler, CXX=compiler, CFLAGS=cflags, CPPFLAGS=cppflags,
+                 LDSHARED=ldshared):
             customize_compiler(build_ext.compiler)
             build_ext.build_extension(tensorflow_mpi_lib)
     finally:
@@ -1144,10 +1147,11 @@ def build_torch_extension_v2(build_ext, options, torch_version):
                 'Please check Horovod website for recommended compiler versions.\n'
                 'To force a specific compiler version, set CC and CXX environment variables.')
 
-        cflags, cppflags = remove_offensive_gxx_compiler_options(compiler_version)
+        cflags, cppflags, ldshared = remove_offensive_gxx_compiler_options(compiler_version)
 
     try:
-        with env(CC=compiler, CXX=compiler, CFLAGS=cflags, CPPFLAGS=cppflags):
+        with env(CC=compiler, CXX=compiler, CFLAGS=cflags, CPPFLAGS=cppflags,
+                 LDSHARED=ldshared):
             customize_compiler(build_ext.compiler)
             build_ext.build_extension(torch_mpi_lib_v2)
     finally:

--- a/setup.py
+++ b/setup.py
@@ -760,6 +760,7 @@ def build_tf_extension(build_ext, options):
         # Determine g++ version compatible with this TensorFlow installation
         import tensorflow as tf
         if hasattr(tf, 'version'):
+            # Since TensorFlow 1.13.0
             tf_compiler_version = LooseVersion(tf.version.COMPILER_VERSION)
         else:
             tf_compiler_version = LooseVersion(tf.COMPILER_VERSION)

--- a/setup.py
+++ b/setup.py
@@ -793,7 +793,7 @@ def build_tf_extension(build_ext, options):
         else:
             raise DistutilsPlatformError(
                 'Could not find compiler compatible with this TensorFlow installation.\n'
-                'Please check Horovod website for recommended compiler versions.\n'
+                'Please check the Horovod website for recommended compiler versions.\n'
                 'To force a specific compiler version, set CC and CXX environment variables.')
 
         cflags, cppflags, ldshared = remove_offensive_gxx_compiler_options(compiler_version)
@@ -1147,7 +1147,7 @@ def build_torch_extension_v2(build_ext, options, torch_version):
         else:
             raise DistutilsPlatformError(
                 'Could not find compiler compatible with this PyTorch installation.\n'
-                'Please check Horovod website for recommended compiler versions.\n'
+                'Please check the Horovod website for recommended compiler versions.\n'
                 'To force a specific compiler version, set CC and CXX environment variables.')
 
         cflags, cppflags, ldshared = remove_offensive_gxx_compiler_options(compiler_version)

--- a/test/common.py
+++ b/test/common.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from contextlib import contextmanager
 import os
 
 
@@ -55,23 +54,3 @@ def mpi_env_rank_and_size():
 
     # Default to rank zero and size one if there are no environment variables
     return 0, 1
-
-
-@contextmanager
-def env(**kwargs):
-    # backup environment
-    backup = {}
-    for k in kwargs.keys():
-        backup[k] = os.environ.get(k)
-
-    # set new values & yield
-    for k, v in kwargs.items():
-        os.environ[k] = v
-    yield
-
-    # restore environment
-    for k in kwargs.keys():
-        if backup[k] is not None:
-            os.environ[k] = backup[k]
-        else:
-            del os.environ[k]

--- a/test/test_stall.py
+++ b/test/test_stall.py
@@ -4,26 +4,26 @@ from __future__ import print_function
 
 from mpi4py import MPI
 import horovod.torch as hvd
+from horovod.common.util import env
 import torch
 import time
 import os
 import signal
-from common import env
 
 def test():
-  signal.alarm(45)
-  with env(HOROVOD_STALL_CHECK_TIME_SECONDS="2",
-    HOROVOD_STALL_SHUTDOWN_TIME_SECONDS="5"):
-    hvd.init()
-    tensor = torch.IntTensor([[1, 2], [3, 4]])
-    if hvd.rank() != 0:
-      time.sleep(10 * hvd.rank());
-    try:
-      summed = hvd.allreduce(tensor, average=False)
-    except:
-      pass
-    finally:
-      hvd.shutdown()
+    signal.alarm(45)
+    with env(HOROVOD_STALL_CHECK_TIME_SECONDS="2",
+             HOROVOD_STALL_SHUTDOWN_TIME_SECONDS="5"):
+        hvd.init()
+        tensor = torch.IntTensor([[1, 2], [3, 4]])
+        if hvd.rank() != 0:
+            time.sleep(10 * hvd.rank());
+        try:
+            summed = hvd.allreduce(tensor, average=False)
+        except:
+            pass
+        finally:
+            hvd.shutdown()
 
 if __name__ == "__main__":
-  test()
+    test()

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -25,8 +25,7 @@ import unittest
 import warnings
 
 import horovod.torch as hvd
-
-from common import env
+from horovod.common.util import env
 
 
 class TimelineTests(unittest.TestCase):


### PR DESCRIPTION
g++ version selection has been a long-standing pain point.  TensorFlow from PyPI requires g++ 4.8.5 or 4.9, PyTorch from PyPI requires g++ 4.9+, and Conda versions require g++ 5.4.0+.

This change introduces the ability of Horovod to use different compiler per framework and provide users with meaningful error messages when it's known that given compiler/framework combination will not work.

Additionally, this change allows us to remove cherry-picked g++-4.9 and use g++-7 & g++-4.8.5 combination.

Fixes #1197
Fixes #1131