### PR TITLE
Use try-finally in contextmanager

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -174,8 +174,10 @@ class _DistributedOptimizer(torch.optim.Optimizer):
                 optimizer.step()
         """
         self._should_synchronize = False
-        yield
-        self._should_synchronize = True
+        try:
+            yield
+        finally:
+            self._should_synchronize = True
 
     def step(self, closure=None):
         if self._should_synchronize:


### PR DESCRIPTION
According to https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager, we should use try-finally around `@contextmanager`.