### PR TITLE
Use the first fragment of hostname for host-hash in Spark

### DIFF
--- a/horovod/run/common/util/host_hash.py
+++ b/horovod/run/common/util/host_hash.py
@@ -33,5 +33,6 @@ def _namespaces():
 def host_hash():
     hostname = socket.gethostname()
     ns = _namespaces()
-    hash = hashlib.md5(hostname + '-' + ns.encode('ascii')).hexdigest()
+    host_ns = hostname + '-' + ns
+    hash = hashlib.md5(host_ns.encode('ascii')).hexdigest()
     return '%s-%s' % (hostname.split('.')[0], hash)

--- a/horovod/run/common/util/host_hash.py
+++ b/horovod/run/common/util/host_hash.py
@@ -33,4 +33,5 @@ def _namespaces():
 def host_hash():
     hostname = socket.gethostname()
     ns = _namespaces()
-    return '%s-%s' % (hostname, hashlib.md5(ns.encode('ascii')).hexdigest())
+    hash = hashlib.md5(hostname + '-' + ns.encode('ascii')).hexdigest()
+    return '%s-%s' % (hostname.split('.')[0], hash)


### PR DESCRIPTION
Apparently, if the full hostname is used in mpirun, e.g. `john-cdhx-3.gce.cloudera.com-11aed9aa6c5cdabe73c81686492d16bc:2`, MPI is able to deduce that `john-cdhx-3` is localhost and hence skip running `rsh` script.

This causes `Exception: Timed out waiting for command to run. Please check that you have enough resources to run all Horovod processes. Each Horovod process runs in a Spark task. You may need to increase the start_timeout parameter to a larger value if your Spark resources are allocated on-demand.`

Fixes #1000 
Possibly related #952

cc @mengxr