### PR TITLE
Do not return random ints from init and shutdown

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -48,15 +48,15 @@ class HorovodBasics(object):
                 self.MPI_LIB_CTYPES.horovod_init_comm.argtypes = [MPI_Comm]
 
             comm_obj = MPI_Comm.from_address(MPI._addressof(comm))
-            return self.MPI_LIB_CTYPES.horovod_init_comm(comm_obj)
+            self.MPI_LIB_CTYPES.horovod_init_comm(comm_obj)
         else:
             comm_size = len(comm)
-            return self.MPI_LIB_CTYPES.horovod_init(
+            self.MPI_LIB_CTYPES.horovod_init(
                 (ctypes.c_int * comm_size)(*comm), ctypes.c_int(comm_size))
 
     def shutdown(self):
         """A function that shuts Horovod down."""
-        return self.MPI_LIB_CTYPES.horovod_shutdown()
+        self.MPI_LIB_CTYPES.horovod_shutdown()
 
     def size(self):
         """A function that returns the number of Horovod processes.


### PR DESCRIPTION
C API defines horovod_init, horovod_init_comm, and horovod_shutdown as returning
void.  When ctypes interprets their return values as ints, it returns garbage.