### PR TITLE
Pin tf-nightly-gpu and mxnet-cu100 --pre

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -305,7 +305,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100 --pre
+        MXNET_PACKAGE: mxnet-cu100==1.5.0b20190709
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-gpu-base
@@ -318,7 +318,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100 --pre
+        MXNET_PACKAGE: mxnet-cu100==1.5.0b20190709
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-mpich-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -301,7 +301,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -314,7 +314,7 @@ services:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -301,7 +301,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709 tf-estimator-nightly==1.14.0.dev2019070901
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -314,7 +314,7 @@ services:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==1.15.0.dev20190709 tf-estimator-nightly==1.14.0.dev2019070901
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git


### PR DESCRIPTION
There are two separate issues.

# TensorFlow

`tf-nightly-gpu` between 20190710 - 20190715 fails with:
```
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/util/module_wrapper.py", line 174, in __setattr__
    if arg not in self.__all__ and arg != '__all__':
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/util/module_wrapper.py", line 161, in __getattr__
    raise e
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/util/module_wrapper.py", line 158, in __getattr__
    attr = getattr(self._tfmw_wrapped_module, name)
AttributeError: module 'tensorflow_estimator.python.estimator.api' has no attribute '__all__'
root@opusgpux1-wbu2:/# pip3 install tf-nightly==1.15.0.dev20190709
```

The issue is resolved in `tf-nightly` 20190717, but the `tf-nightly-gpu` build is temporarily broken.

# MXNet

apache/incubator-mxnet#15449 and apache/incubator-mxnet#15551 introduced an issue:
```
OSError: /usr/local/lib/python2.7/dist-packages/horovod/mxnet/mpi_lib.so: undefined symbol: _ZN5mxnet7Context13CudaLibChecksEv
```

This is being tracked in #1217.