### PR TITLE
Backup global compiling options when building Tensorflow and PyTorch plugins.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -764,7 +764,11 @@ def remove_offensive_gcc_compiler_options(compiler_version):
     return None, None, None
 
 
-def build_tf_extension(build_ext, options):
+def build_tf_extension(build_ext, global_options):
+    # Backup the options, preventing other plugins access libs that
+    # compiled with compiler of this plugin
+    options = deepcopy(global_options)
+
     check_tf_version()
     tf_compile_flags, tf_link_flags = get_tf_flags(
         build_ext, options['COMPILE_FLAGS'])
@@ -1118,7 +1122,11 @@ def build_torch_extension(build_ext, global_options, torch_version):
         build_ext.build_extension(setuptools_ext)
 
 
-def build_torch_extension_v2(build_ext, options, torch_version):
+def build_torch_extension_v2(build_ext, global_options, torch_version):
+    # Backup the options, preventing other plugins access libs that
+    # compiled with compiler of this plugin
+    options = deepcopy(global_options)
+    
     have_cuda = is_torch_cuda_v2(build_ext, include_dirs=options['INCLUDES'],
                                  extra_compile_args=options['COMPILE_FLAGS'])
     if not have_cuda and check_macro(options['MACROS'], 'HAVE_CUDA'):


### PR DESCRIPTION
After submodule gloo is separately built for each plugin in  #1209,  there can be a situation that one plugin can access to libraries that weren't compiled by its selected compiler. To prevent this corruption, each plugin should be built based on the copy of the global compiling options.