### PR TITLE
Add -hostfile option to horovodrun

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -135,13 +135,6 @@ run_all() {
     ":muscle: Test MXNet MNIST (${test})" \
     "bash -c \"OMP_NUM_THREADS=1 \\\$(cat /mpirun_command) python /horovod/examples/mxnet_mnist.py\""
 
-  if [[ ${test} == *"openmpi"* ]]; then
-    run_test "${test}" "${queue}" \
-      ":muscle: Test Horovodrun (${test})" \
-      "echo 'localhost slots=2' > hostfile" \
-      "horovodrun -np 2 -hostfile hostfile python /horovod/examples/mxnet_mnist.py"
-  fi
-
   # tests that should be executed only with the latest release since they don't test
   # a framework-specific functionality
   if [[ ${test} == *"tf1_14_0"* ]]; then
@@ -153,6 +146,10 @@ run_all() {
       run_test "${test}" "${queue}" \
         ":muscle: Test Horovodrun (${test})" \
         "horovodrun -np 2 -H localhost:2 python /horovod/examples/tensorflow_mnist.py"
+      run_test "${test}" "${queue}" \
+        ":muscle: Test Horovodrun (${test})" \
+        "echo 'localhost slots=2' > hostfile" \
+        "horovodrun -np 2 -hostfile hostfile python /horovod/examples/mxnet_mnist.py"
     fi
   fi
 

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -135,6 +135,13 @@ run_all() {
     ":muscle: Test MXNet MNIST (${test})" \
     "bash -c \"OMP_NUM_THREADS=1 \\\$(cat /mpirun_command) python /horovod/examples/mxnet_mnist.py\""
 
+  if [[ ${test} == *"openmpi"* ]]; then
+    run_test "${test}" "${queue}" \
+      ":muscle: Test Horovodrun (${test})" \
+      "echo 'localhost slots=2' > hostfile" \
+      "horovodrun -np 2 -hostfile hostfile python /horovod/examples/mxnet_mnist.py"
+  fi
+
   # tests that should be executed only with the latest release since they don't test
   # a framework-specific functionality
   if [[ ${test} == *"tf1_14_0"* ]]; then

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -4,10 +4,12 @@
 Run Horovod
 ===========
 
-This page includes examples for Open MPI that use ``horovodrun``. Check your MPI documentation for arguments to the ``mpirun``
+This page includes examples for Open MPI that use ``horovodrun``. Check your
+MPI documentation for arguments to the ``mpirun``
 command on your system.
 
-Typically one GPU will be allocated per process, so if a server has 4 GPUs, you would run 4 processes. In ``horovodrun``,
+Typically one GPU will be allocated per process, so if a server has 4 GPUs,
+you would run 4 processes. In ``horovodrun``,
 the number of processes is specified with the ``-np`` flag.
 
 To run on a machine with 4 GPUs:
@@ -23,29 +25,35 @@ To run on 4 machines with 4 GPUs each:
     $ horovodrun -np 16 -H server1:4,server2:4,server3:4,server4:4 python train.py
 
 You can also specify host nodes in a host file:
-For example, 
+For example,
 
 .. code-block:: bash
+
     $ cat myhostfile
 
 aa slots=2
 bb slots=2
 cc slots=2
 
-This example lists the host names (aa, bb, and cc) and how many "slots" there are for each.
+This example lists the host names (aa, bb, and cc) and how many "slots" there
+are for each.
 Slots indicate how many processes can potentially execute on a node.
-This format is the same as in `mpirun command <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php#toc6>`__.
+This format is the same as in
+`mpirun command <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php#toc6>`__.
 
 To run on hosts specified in a hostfile:
 
 .. code-block:: bash
+
     $ horovodrun -np 6 -hostfile myhostfile python train.py
 
 Failures due to SSH issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-The host where ``horovodrun`` is executed must be able to SSH to all other hosts without any prompts.
+The host where ``horovodrun`` is executed must be able to SSH to all other
+hosts without any prompts.
 
-If ``horovodrun`` fails with permission error, verify that you can ssh to every other server without entering a password or
+If ``horovodrun`` fails with permission error, verify that you can ssh to
+every other server without entering a password or
 answering questions like this:
 
 
@@ -56,7 +64,8 @@ Are you sure you want to continue connecting (yes/no)?``
 
 To learn more about setting up passwordless authentication, see `this page <http://www.linuxproblem.org/art_9.html>`__.
 
-To avoid ``The authenticity of host '<hostname> (<ip address>)' can't be established`` prompts, add all the hosts to
+To avoid ``The authenticity of host '<hostname> (<ip address>)' can't be
+established`` prompts, add all the hosts to
 the ``~/.ssh/known_hosts`` file using ``ssh-keyscan``:
 
 .. code-block:: bash
@@ -67,6 +76,7 @@ the ``~/.ssh/known_hosts`` file using ``ssh-keyscan``:
 Advanced: Run Horovod with Open MPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In some advanced cases you might want fine-grained control over options passed to Open MPI.
-To learn how run Horovod training directly using Open MPI, read `Run Horovod with Open MPI <mpirun.rst>`_.
+To learn how run Horovod training directly using Open MPI,
+read `Run Horovod with Open MPI <mpirun.rst>`_.
 
 .. inclusion-marker-end-do-not-remove

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -9,7 +9,7 @@ MPI documentation for arguments to the ``mpirun``
 command on your system.
 
 Typically one GPU will be allocated per process, so if a server has 4 GPUs,
-you would run 4 processes. In ``horovodrun``,
+you will run 4 processes. In ``horovodrun``,
 the number of processes is specified with the ``-np`` flag.
 
 To run on a machine with 4 GPUs:
@@ -31,9 +31,9 @@ For example,
 
     $ cat myhostfile
 
-aa slots=2
-bb slots=2
-cc slots=2
+   aa slots=2
+   bb slots=2
+   cc slots=2
 
 This example lists the host names (aa, bb, and cc) and how many "slots" there
 are for each.
@@ -52,7 +52,7 @@ Failures due to SSH issues
 The host where ``horovodrun`` is executed must be able to SSH to all other
 hosts without any prompts.
 
-If ``horovodrun`` fails with permission error, verify that you can ssh to
+If ``horovodrun`` fails with a permission error, verify that you can ssh to
 every other server without entering a password or
 answering questions like this:
 
@@ -76,7 +76,7 @@ the ``~/.ssh/known_hosts`` file using ``ssh-keyscan``:
 Advanced: Run Horovod with Open MPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In some advanced cases you might want fine-grained control over options passed to Open MPI.
-To learn how run Horovod training directly using Open MPI,
+To learn how to run Horovod training directly using Open MPI,
 read `Run Horovod with Open MPI <mpirun.rst>`_.
 
 .. inclusion-marker-end-do-not-remove

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -22,20 +22,22 @@ To run on 4 machines with 4 GPUs each:
 
     $ horovodrun -np 16 -H server1:4,server2:4,server3:4,server4:4 python train.py
 
-Host nodes can also be specified in a host file:
+You can also specify host nodes in a host file:
 For example, 
 
-$ cat myhostfile
+.. code-block:: bash
+    $ cat myhostfile
+
 aa slots=2
 bb slots=2
 cc slots=2
 
-Here, we list both the host names (aa, bb, and cc) but also how many "slots" there are for each.
+This example lists the host names (aa, bb, and cc) and how many "slots" there are for each.
 Slots indicate how many processes can potentially execute on a node.
-This format is the same as in mpirun command,
-see `this page <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php#toc6>`_.
+This format is the same as in `mpirun command <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php#toc6>`__.
 
 To run on hosts specified in a hostfile:
+
 .. code-block:: bash
     $ horovodrun -np 6 -hostfile myhostfile python train.py
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -31,9 +31,9 @@ For example,
 
     $ cat myhostfile
 
-   aa slots=2
-   bb slots=2
-   cc slots=2
+    aa slots=2
+    bb slots=2
+    cc slots=2
 
 This example lists the host names (aa, bb, and cc) and how many "slots" there
 are for each.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -24,8 +24,7 @@ To run on 4 machines with 4 GPUs each:
 
     $ horovodrun -np 16 -H server1:4,server2:4,server3:4,server4:4 python train.py
 
-You can also specify host nodes in a host file:
-For example,
+You can also specify host nodes in a host file. For example:
 
 .. code-block:: bash
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -22,6 +22,22 @@ To run on 4 machines with 4 GPUs each:
 
     $ horovodrun -np 16 -H server1:4,server2:4,server3:4,server4:4 python train.py
 
+Host nodes can also be specified in a host file:
+For example, 
+
+$ cat myhostfile
+aa slots=2
+bb slots=2
+cc slots=2
+
+Here, we list both the host names (aa, bb, and cc) but also how many "slots" there are for each.
+Slots indicate how many processes can potentially execute on a node.
+This format is the same as in mpirun command,
+see `this page <https://www.open-mpi.org/doc/v4.0/man1/mpirun.1.php#toc6>`_.
+
+To run on hosts specified in a hostfile:
+.. code-block:: bash
+    $ horovodrun -np 6 -hostfile myhostfile python train.py
 
 Failures due to SSH issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -400,7 +400,7 @@ def run():
                                parameters_hash)
 
     remote_host_names = []
-    if args.host:
+    if args.host or args.hostfile:
         if settings.verbose >= 2:
             print("Filtering local host names.")
         remote_host_names = network.filter_local_addresses(all_host_names)
@@ -414,15 +414,16 @@ def run():
             if settings.verbose >= 2:
                 print("SSH was successful into all the remote hosts.")
 
-        hosts_arg = "-H {hosts}".format(hosts=args.host)
-    elif args.hostfile:
-        hosts_arg = "-hostfile {hostfile}".format(hostfile=args.hostfile)
+        if args.host:
+            hosts_arg = "-H {hosts}".format(hosts=args.host)
+        else:
+            hosts_arg = "-hostfile {hostfile}".format(hostfile=args.hostfile)
     else:
         # if user does not specify any hosts, mpirun by default uses local host.
         # There is no need to specify localhost.
         hosts_arg = ""
 
-    if args.host and len(remote_host_names) > 0:
+    if len(remote_host_names) > 0:
         if settings.verbose >= 2:
             print("Testing interfaces on all the hosts.")
 

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -308,7 +308,11 @@ def parse_args():
                                  "on host3.")
     host_group.add_argument('-hostfile', '--hostfile', action="store",
                             dest="hostfile",
-                            help="Provide a hostfile to use")
+                            help="To specify a host file with the list of "
+                                  "host names as well as the number of "
+                                  "available slots on each host. "
+                                  "Each line of the host file is formatted "
+                                  "as <hostname> slots=<number of slots")
     parser.add_argument('--disable-cache', action="store_true",
                         dest="disable_cache",
                         help="If the flag is not set, horovodrun will perform "
@@ -419,7 +423,8 @@ def run():
         else:
             hosts_arg = "-hostfile {hostfile}".format(hostfile=args.hostfile)
     else:
-        # if user does not specify any hosts, mpirun by default uses local host.
+        # if none of --host  of --hostfile is specified, localhost will be
+        # used by default
         # There is no need to specify localhost.
         hosts_arg = ""
 


### PR DESCRIPTION
Enable the same --hostfile option in horovodrun as in mpirun.
Users can specify a list of hosts in the hostfile as:

<host1> slots=<num_procs>
<host2> slots=<num_procs>
...

Tested on a GPU cluster with 8 nodes.

This PR fix https://github.com/horovod/horovod/issues/1231