### PR TITLE
Fix integration with MXNet nightly build

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -305,7 +305,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100==1.5.0b20190709
+        MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-gpu-base
@@ -318,7 +318,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100==1.5.0b20190709
+        MXNET_PACKAGE: mxnet-cu100 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-mpich-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -36,7 +36,7 @@ std::string GetOpName(const char* prefix, const char* name) {
 }
 } // namespace
 
-static const auto MX_EXEC_CTX = Context::CPU();
+static const auto MX_EXEC_CTX = Context();
 static const auto MX_FUNC_PROP = FnProperty::kCPUPrioritized;
 static const char* ALLREDUCE_OP_TYPE_NAME = "horovod_allreduce";
 static const char* ALLGATHER_OP_TYPE_NAME = "horovod_allgather";

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -123,14 +123,14 @@ int TensorUtil::GetDevice(NDArray* tensor) {
 // If dev_id equal to CPU_DEVICE_ID, construct Tensor on CPU
 // Otherwise construct on GPU
 NDArray* TensorUtil::New(int device, int dtype) {
+  int dev_type = gpu::kDevMask;
   if (device == CPU_DEVICE_ID) {
-    NDArray* my_array = new NDArray(TShape(), Context::CPU(0), false, dtype);
-    return my_array;
-  } else {
-    NDArray* my_array =
-        new NDArray(TShape(), Context::GPU(device), false, dtype);
-    return my_array;
+    dev_type = cpu::kDevMask;
+    device = 0;
   }
+  NDArrayHandle array;
+  MXNDArrayCreateEx(nullptr, 0, dev_type, device, false, dtype, &array);
+  return static_cast<NDArray*>(array);
 }
 
 void TensorUtil::Free(NDArray* tensor) { delete tensor; }


### PR DESCRIPTION
Due to a new set of [APIs](https://github.com/apache/incubator-mxnet/pull/15551) introduced in recent MXNet master branch, we hit [undefined symbol error](https://github.com/horovod/horovod/issues/1217) when running Horovod with nightly MXNet build. This PR fixes #1217 and https://github.com/apache/incubator-mxnet/issues/15578 by using C API.