### PR TITLE
Update reference to horovod/common/ddl_mpi_context_manager.cc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -673,7 +673,7 @@ def get_common_options(build_ext):
         MACROS += [('HAVE_DDL', '1')]
         INCLUDES += ddl_include_dirs
         SOURCES += ['horovod/common/ops/ddl_operations.cc',
-                    'horovod/common/ops/ddl_mpi_context_manager.cc']
+                    'horovod/common/ddl_mpi_context_manager.cc']
         LIBRARY_DIRS += ddl_lib_dirs
         LIBRARIES += ['ddl', 'ddl_pack']
 


### PR DESCRIPTION
#1154 Broke the build for PowerAI DDL.

The location of "horovod/common/ddl_mpi_context_manager.cc" is incorrect in setup.py

https://github.com/horovod/horovod/commit/4451dd0df5243fd9941022f72b2ff17cb6833222#diff-2eeaed663bd0d25b7e608891384b7298R676

@nvcastet 