### PR TITLE
(MXNet) Fixed: unknown device mask issue

### DIFF
--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -78,6 +78,10 @@ template <class T> int64_t MXTensor<T>::size() const {
   return TensorUtil::GetSize(tensor_);
 }
 
+template <class T> T* MXTensor<T>::tensor() const {
+  return this->tensor_;
+}
+
 template <class T>
 MXTemporaryBuffer<T>::MXTemporaryBuffer(int device, int dtype)
     : MXTensor<T>(nullptr) {
@@ -92,10 +96,6 @@ MXTemporaryBuffer<T>::MXTemporaryBuffer(T* tensor)
 
 template <class T> MXTemporaryBuffer<T>::~MXTemporaryBuffer() {
   TensorUtil::Free(this->tensor_);
-}
-
-template <class T> T* MXTemporaryBuffer<T>::tensor() const {
-  return this->tensor_;
 }
 
 template <class T>

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -71,6 +71,7 @@ template <class T> const TensorShape MXTensor<T>::shape() const {
 }
 
 template <class T> const void* MXTensor<T>::data() const {
+  // returns the raw data instead of NDArray Tensor
   return TensorUtil::GetData(tensor_);
 }
 

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -43,6 +43,7 @@ public:
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
+  virtual T* tensor() const;
 
 protected:
   T* tensor_;
@@ -53,7 +54,6 @@ public:
   MXTemporaryBuffer(int device, int dtype);
   MXTemporaryBuffer(T* tensor);
   ~MXTemporaryBuffer();
-  virtual T* tensor() const;
 };
 
 template <class T> class MXOpContext : public OpContext {

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -33,18 +33,18 @@ using namespace horovod::common;
 typedef ::mxnet::NDArray NDArray;
 typedef ::mxnet::Engine::CallbackOnComplete CallbackOnComplete;
 typedef Request::RequestType OperationType;
-typedef std::shared_ptr<MXTensor<NDArray>> MXTensor_sh_ptr;
+typedef std::shared_ptr<MXTensor<NDArray>> MXTensorSharedPtr;
 
 struct MpiOpsParam {
   NDArray* input;
   NDArray* output;
-  MXTensor_sh_ptr cpu_tensor;
+  MXTensorSharedPtr cpu_tensor;
   OperationType op_type;
   std::string op_name;
   int root_rank;
 
   MpiOpsParam(NDArray* input, NDArray* output,
-              MXTensor_sh_ptr cpu_tensor,
+              MXTensorSharedPtr cpu_tensor,
               const OperationType& op_type, const std::string& op_name,
               int root_rank)
       : input(input),
@@ -57,7 +57,7 @@ struct MpiOpsParam {
 };
 
 inline MpiOpsParam* CreateMpiOpsParam(NDArray* input, NDArray* output,
-                                      MXTensor_sh_ptr cpu_tensor,
+                                      MXTensorSharedPtr cpu_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
                                       int root_rank) {

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -33,16 +33,18 @@ using namespace horovod::common;
 typedef ::mxnet::NDArray NDArray;
 typedef ::mxnet::Engine::CallbackOnComplete CallbackOnComplete;
 typedef Request::RequestType OperationType;
+typedef std::shared_ptr<MXTensor<NDArray>> MXTensor_sh_ptr;
 
 struct MpiOpsParam {
   NDArray* input;
   NDArray* output;
-  NDArray* cpu_tensor;
+  MXTensor_sh_ptr cpu_tensor;
   OperationType op_type;
   std::string op_name;
   int root_rank;
 
-  MpiOpsParam(NDArray* input, NDArray* output, NDArray* cpu_tensor,
+  MpiOpsParam(NDArray* input, NDArray* output,
+              MXTensor_sh_ptr cpu_tensor,
               const OperationType& op_type, const std::string& op_name,
               int root_rank)
       : input(input),
@@ -55,15 +57,11 @@ struct MpiOpsParam {
 };
 
 inline MpiOpsParam* CreateMpiOpsParam(NDArray* input, NDArray* output,
+                                      MXTensor_sh_ptr cpu_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
-                                      int root_rank, bool cuda_on_cpu) {
-  if (cuda_on_cpu) {
-    auto cpu_tensor = TensorUtil::New(CPU_DEVICE_ID, input->dtype());
-    return new MpiOpsParam(nullptr, nullptr, cpu_tensor, op_type, op_name, root_rank);
-  }
-
-  return new MpiOpsParam(input, output, nullptr, op_type, op_name, root_rank);
+                                      int root_rank) {
+  return new MpiOpsParam(input, output, cpu_tensor, op_type, op_name, root_rank);
 }
 
 void DeleteMpiOpsParam(void* param) {


### PR DESCRIPTION
This issue arises `[1,0]<stderr>:mxnet.base.MXNetError: [05:07:07] src/ndarray/ndarray.cc:1282: unknown device mask` when running some specific MXNet model script when horovod installed without NCCL.

The issue is because we had two Async nested calls, for example, `A` and `B` and it is called as `B(A)`. The temporary CPU tensor is created in Async call method `A` and it's deleted when it's goes out of scope, so the Async method `B`doesn't aware of it and tries to copy the data from CPU tensor(Which was created in `A`) to GPU which results in above failure. This block of code is only executed when horovod compiled without NCCL. The fix is to create a shared pointer outside of the `B` scope and pass it in `B(A)` and once the tensor usage has finished, it will be deleted from the memory automatically.

@apeforest @yuxihu @eric-haibin-lin 