### PR TITLE
Move allreduce to opt.apply_gradients when possible

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -168,6 +168,10 @@ run_all() {
     run_test "${test}" "${queue}" \
       ":muscle: Test TensorFlow 2.0 MNIST (${test})" \
       "bash -c \"\\\$(cat /mpirun_command) python /horovod/examples/tensorflow2_mnist.py\""
+
+    run_test "${test}" "${queue}" \
+      ":muscle: Test TensorFlow 2.0 Keras MNIST (${test})" \
+      "bash -c \"\\\$(cat /mpirun_command) python /horovod/examples/tensorflow2_keras_mnist.py\""
   fi
 }
 

--- a/examples/tensorflow2_mnist.py
+++ b/examples/tensorflow2_mnist.py
@@ -45,10 +45,13 @@ mnist_model = tf.keras.Sequential([
     tf.keras.layers.Dropout(0.5),
     tf.keras.layers.Dense(10, activation='softmax')
 ])
-loss = tf.losses.SparseCategoricalCrossentropy(from_logits=True)
+loss = tf.losses.SparseCategoricalCrossentropy()
 
 # Horovod: adjust learning rate based on number of GPUs.
 opt = tf.optimizers.Adam(0.001 * hvd.size())
+
+# Horovod: add Horovod Distributed Optimizer.
+opt = hvd.DistributedOptimizer(opt)
 
 checkpoint_dir = './checkpoints'
 checkpoint = tf.train.Checkpoint(model=mnist_model, optimizer=opt)
@@ -57,11 +60,8 @@ checkpoint = tf.train.Checkpoint(model=mnist_model, optimizer=opt)
 @tf.function
 def training_step(images, labels, first_batch):
     with tf.GradientTape() as tape:
-        logits = mnist_model(images, training=True)
-        loss_value = loss(labels, logits)
-
-    # Horovod: add Horovod Distributed GradientTape.
-    tape = hvd.DistributedGradientTape(tape)
+        probs = mnist_model(images, training=True)
+        loss_value = loss(labels, probs)
 
     grads = tape.gradient(loss_value, mnist_model.trainable_variables)
     opt.apply_gradients(zip(grads, mnist_model.trainable_variables))

--- a/examples/tensorflow_synthetic_benchmark.py
+++ b/examples/tensorflow_synthetic_benchmark.py
@@ -69,8 +69,8 @@ target = tf.random_uniform([args.batch_size, 1], minval=0, maxval=999, dtype=tf.
 
 
 def loss_function():
-    logits = model(data, training=True)
-    return tf.losses.sparse_softmax_cross_entropy(target, logits)
+    probs = model(data, training=True)
+    return tf.losses.sparse_softmax_cross_entropy(target, probs)
 
 
 def log(s, nl=True):

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -19,16 +19,36 @@ import tensorflow as tf
 
 def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
                                  compression, sparse_as_dense):
-    class _DistributedOptimizer(keras.optimizers.Optimizer):
+    class _DistributedOptimizerWithApplyGradients(keras.optimizers.Optimizer):
         def __init__(self, name, device_dense, device_sparse, compression, sparse_as_dense,
                      config):
             if name is None:
                 name = "Distributed%s" % self.__class__.__base__.__name__
-            self._name = name
-            self._device_dense = device_dense
-            self._device_sparse = device_sparse
-            self._compression = compression
-            self._sparse_as_dense = sparse_as_dense
+            self._allreduce_grads = hvd._make_allreduce_grads_fn(
+                name, device_dense, device_sparse, compression, sparse_as_dense)
+            super(self.__class__, self).__init__(**config)
+
+        def apply_gradients(self, grads_and_vars, **kwargs):
+            """Apply gradients to provided variables.
+
+            See Optimizer.apply_gradients() for more info.
+
+            In DistributedOptimizer, apply_gradients() is overriden to also
+            allreduce the gradients before applying them.
+            """
+            if hvd.size() > 1:
+                grads, vars = zip(*grads_and_vars)
+                avg_grads = self._allreduce_grads(grads)
+                grads_and_vars = list(zip(avg_grads, vars))
+            return super(self.__class__, self).apply_gradients(grads_and_vars, **kwargs)
+
+    class _DistributedOptimizerWithGetGradients(keras.optimizers.Optimizer):
+        def __init__(self, name, device_dense, device_sparse, compression, sparse_as_dense,
+                     config):
+            if name is None:
+                name = "Distributed%s" % self.__class__.__base__.__name__
+            self._allreduce_grads = hvd._make_allreduce_grads_fn(
+                name, device_dense, device_sparse, compression, sparse_as_dense)
             super(self.__class__, self).__init__(**config)
 
         def get_gradients(self, loss, params):
@@ -42,21 +62,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
             """
             gradients = super(self.__class__, self).get_gradients(loss, params)
             if hvd.size() > 1:
-                averaged_gradients = []
-                with tf.name_scope(self._name + "_Allreduce"):
-                    for grad in gradients:
-                        if grad is not None:
-                            if self._sparse_as_dense and \
-                                    isinstance(grad, tf.IndexedSlices):
-                                grad = tf.convert_to_tensor(grad)
-                            avg_grad = hvd.allreduce(grad,
-                                                     device_dense=self._device_dense,
-                                                     device_sparse=self._device_sparse,
-                                                     compression=self._compression)
-                            averaged_gradients.append(avg_grad)
-                        else:
-                            averaged_gradients.append(None)
-                    return averaged_gradients
+                return self._allreduce_grads(gradients)
             else:
                 return gradients
 
@@ -64,8 +70,12 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
     # The goal is to override get_gradients() method with an allreduce implementation.
     # This class will have the same name as the optimizer it's wrapping, so that the saved
     # model could be easily restored without Horovod.
-    cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
-               dict(_DistributedOptimizer.__dict__))
+    if hasattr(optimizer, 'apply_gradients'):
+        cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
+                dict(_DistributedOptimizerWithApplyGradients.__dict__))
+    else:
+        cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
+                dict(_DistributedOptimizerWithGetGradients.__dict__))
     return cls(name, device_dense, device_sparse, compression, sparse_as_dense,
                optimizer.get_config())
 


### PR DESCRIPTION
Motivation: new TensorFlow-Keras 2.0 [doesn't use](https://github.com/tensorflow/tensorflow/blob/498e815097e74aff7fefdbbae69ba9daf6e9c023/tensorflow/python/keras/engine/training_eager.py#L272) `Optimizer.get_gradients()` in eager mode.  However, it started using `Optimizer.apply_gradients()`, which was not the case with legacy Keras.

The proposal is to align gradient aggregation to happen during apply, similar to MXNet.  This way we will be able to deprecate `hvd.DistributedGradientTape()` and align user experience between Graph and Eager mode further.