### PR TITLE
Fix hostfile argument bug in horovodrun

### DIFF
--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -383,7 +383,7 @@ def run():
     # localhost
     if not args.hosts:
         if args.hostfile:
-            args.hosts = parse_host_files(args.hostfiles)
+            args.hosts = parse_host_files(args.hostfile)
         else:
             # Set hosts to localhost if not specified
             args.hosts = 'localhost:{np}'.format(np=args.np)


### PR DESCRIPTION
Fix hostfile argument bug in horovodrun:
`args.hostfiles` ==> `args.hostfile`

