### PR TITLE
Limit # of CPU threads for PyTorch

### DIFF
--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -86,6 +86,9 @@ verbose = 1 if hvd.rank() == 0 else 0
 log_writer = tensorboardX.SummaryWriter(args.log_dir) if hvd.rank() == 0 else None
 
 
+# Horovod: limit # of CPU threads to be used per worker.
+torch.set_num_threads(4)
+
 kwargs = {'num_workers': 4, 'pin_memory': True} if args.cuda else {}
 train_dataset = \
     datasets.ImageFolder(args.train_dir,

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -40,6 +40,9 @@ if args.cuda:
     torch.cuda.manual_seed(args.seed)
 
 
+# Horovod: limit # of CPU threads to be used per worker.
+torch.set_num_threads(1)
+
 kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
 train_dataset = \
     datasets.MNIST('data-%d' % hvd.rank(), train=True, download=True,


### PR DESCRIPTION
Default thread settings sometimes cause PyTorch to overuse CPU resources available on the server.