### PR TITLE
Pin MXNet-GPU-head to 1.6.0b20190817

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -429,7 +429,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100 --pre
+        MXNET_PACKAGE: mxnet-cu100==1.6.0b20190817 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-gpu-base
@@ -442,7 +442,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
-        MXNET_PACKAGE: mxnet-cu100 --pre
+        MXNET_PACKAGE: mxnet-cu100==1.6.0b20190817 --pre
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-mpich-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-gpu-base


### PR DESCRIPTION
mxnet-cu100 --pre is failing with:
```
E   OSError: /usr/local/lib/python2.7/dist-packages/horovod/mxnet/mpi_lib.so: undefined symbol: _ZN5mxnet12on_enter_apiEPKc
```