### PR TITLE
Pin stricter versions for PyTorch 1.2.0 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ RUN pip install numpy \
         tensorflow-gpu==${TENSORFLOW_VERSION} \
         keras \
         h5py
-RUN pip install -f https://download.pytorch.org/whl/torch_stable.html torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION}
+RUN pip install https://download.pytorch.org/whl/cu100/torch-${PYTORCH_VERSION}-$(python -c "import wheel.pep425tags as w; print('-'.join(w.get_supported()[0][:-1]))")-manylinux1_x86_64.whl \
+        https://download.pytorch.org/whl/cu100/torchvision-${TORCHVISION_VERSION}-$(python -c "import wheel.pep425tags as w; print('-'.join(w.get_supported()[0][:-1]))")-manylinux1_x86_64.whl
 RUN pip install mxnet-cu100==${MXNET_VERSION}
 
 # Install Open MPI

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -108,9 +108,9 @@ RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         pip install torch_nightly -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
     else \
-        pip install ${PYTORCH_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
+        pip install ${PYTORCH_PACKAGE}; \
     fi
-RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
 
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -90,9 +90,9 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
         pip install torch_nightly -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
-        pip install ${PYTORCH_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
+        pip install ${PYTORCH_PACKAGE}; \
     fi
-RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
 
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -198,8 +198,8 @@ services:
         PYTHON_VERSION: 2.7
         TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.4.0+cpu
+        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
+        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_5-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
@@ -210,8 +210,8 @@ services:
         PYTHON_VERSION: 3.5
         TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.4.0+cpu
+        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
+        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
@@ -223,8 +223,8 @@ services:
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.4.0+cpu
+        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
+        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -402,8 +402,8 @@ services:
         PYTHON_VERSION: 2.7
         TENSORFLOW_PACKAGE: tf-nightly-gpu-2.0-preview
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: torch==1.2.0
-        TORCHVISION_PACKAGE: torchvision==0.4.0
+        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.2.0-cp27-cp27mu-manylinux1_x86_64.whl
+        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.4.0-cp27-cp27mu-manylinux1_x86_64.whl
         MXNET_PACKAGE: mxnet-cu100==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
@@ -415,8 +415,8 @@ services:
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu-2.0-preview
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: torch==1.2.0
-        TORCHVISION_PACKAGE: torchvision==0.4.0
+        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.2.0-cp36-cp36m-manylinux1_x86_64.whl
+        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.4.0-cp36-cp36m-manylinux1_x86_64.whl
         MXNET_PACKAGE: mxnet-cu100==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:


### PR DESCRIPTION
Previous upgrade #1320 did not take into account that PyTorch https://download.pytorch.org/whl/torch_stable.html is not usable for latest cuda10 releases, and that PyTorch silently ignores CUDA mismatch errors instead of loudly failing.