### PR TITLE
Allow . characters in remote hostnames

### DIFF
--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -390,7 +390,7 @@ def run():
 
     host_list = args.hosts.split(',')
     all_host_names = []
-    pattern = re.compile(r'^[\w-.]+:\d+$')
+    pattern = re.compile(r'^[\w.-]+:\d+$')
     for host in host_list:
         if not pattern.match(host.strip()):
             raise ValueError('Invalid host input, please make sure it has '

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -390,7 +390,7 @@ def run():
 
     host_list = args.hosts.split(',')
     all_host_names = []
-    pattern = re.compile(r'^[\w-]+:\d+$')
+    pattern = re.compile(r'^[\w-.]+:\d+$')
     for host in host_list:
         if not pattern.match(host.strip()):
             raise ValueError('Invalid host input, please make sure it has '


### PR DESCRIPTION
Addresses #1325 to support IPs as well as `.` subdomain separators in domain names.