### PR TITLE
Fix compiler version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -798,7 +798,7 @@ def find_matching_gcc_compiler_path(gxx_compiler_version):
             # gcc, or gcc-7, gcc-4.9, or gcc-4.8.5
             compiler = os.path.join(path_dir, bin_file)
             compiler_version = determine_gcc_version(compiler)
-            if compiler_version == gxx_compiler_version:
+            if compiler_version and compiler_version == gxx_compiler_version:
                 return compiler
 
     print('INFO: Unable to find gcc compiler (version %s).' % gxx_compiler_version)


### PR DESCRIPTION
Resolves the following scenario:
```
>>> from distutils.version import LooseVersion
>>> LooseVersion('1.0.0') == None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 46, in __eq__
    c = self._cmp(other)
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 335, in _cmp
    if self.version == other.version:
AttributeError: 'NoneType' object has no attribute 'version'
```

Fixes #1334 