### PR TITLE
Update env.py for Ignore BASH_FUNC_module() environment variable (bash bug) #949

### DIFF
--- a/horovod/run/common/util/env.py
+++ b/horovod/run/common/util/env.py
@@ -18,7 +18,7 @@ import re
 LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'OLDPWD'}
+IGNORE_REGEXES = {'BASH_FUNC_.*\(\)','OLDPWD'}
 
 
 def is_exportable(v):


### PR DESCRIPTION
i met Ignore BASH_FUNC_module() environment variable (bash bug) #949 again on the 0.17.1version
i checked change history,i think should add  'BASH_FUNC_.*\(\)', in the ignore list
and i test it on my env