### PR TITLE
Restore 'BASH_FUNC_.*\(\)' environment exclude

### DIFF
--- a/horovod/run/common/util/env.py
+++ b/horovod/run/common/util/env.py
@@ -18,7 +18,7 @@ import re
 LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'OLDPWD'}
+IGNORE_REGEXES = {'BASH_FUNC_.*\(\)', 'OLDPWD'}
 
 
 def is_exportable(v):


### PR DESCRIPTION
See #1339 
cc @nlslzf