### PR TITLE
Fix BASH_FUNC_* environment exclude

### DIFF
--- a/horovod/run/common/util/env.py
+++ b/horovod/run/common/util/env.py
@@ -18,7 +18,7 @@ import re
 LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'BASH_FUNC_.*\(\)', 'OLDPWD'}
+IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD'}
 
 
 def is_exportable(v):


### PR DESCRIPTION
`is_exportable` is queried with the environment variable name. `()` is not part of the name, but value.