### PR TITLE
Make gloo job raise error when any task failed

### DIFF
--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -298,3 +298,4 @@ def gloo_run(settings, remote_host_names, common_intfs, env):
 
     _launch_jobs(settings, env, host_alloc_plan, remote_host_names, run_command)
     return
+

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -298,4 +298,3 @@ def gloo_run(settings, remote_host_names, common_intfs, env):
 
     _launch_jobs(settings, env, host_alloc_plan, remote_host_names, run_command)
     return
-

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -250,9 +250,12 @@ def _launch_jobs(settings, env, host_alloc_plan, remote_host_names, _run_command
     res = threads.execute_function_multithreaded(_exec_command,
                                                  args_list,
                                                  block_until_all_done=True)
-    for k in res:
-        if res[k] != 0:
-            raise RuntimeError("Run gloo job failed.")
+    for name in res:
+        if res[name] != 0:
+            raise RuntimeError("Gloo job detected that one or more processes exited with non-zero "
+                               "status, thus causing the job to be terminated. The first process "
+                               "to do so was:\nProcess name: {name}\nExit code: {code}\n"
+                               .format(name=name, code=res[name]))
 
 
 def gloo_run(settings, remote_host_names, common_intfs, env):

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -247,9 +247,12 @@ def _launch_jobs(settings, env, host_alloc_plan, remote_host_names, _run_command
     # a SIGINT, the event will be set and the spawned threads will kill their
     # corresponding middleman processes and thus the jobs will be killed as
     # well.
-    threads.execute_function_multithreaded(_exec_command,
-                                           args_list,
-                                           block_until_all_done=True)
+    res = threads.execute_function_multithreaded(_exec_command,
+                                                 args_list,
+                                                 block_until_all_done=True)
+    for k in res:
+        if res[k] != 0:
+            raise RuntimeError("Run gloo job failed.")
 
 
 def gloo_run(settings, remote_host_names, common_intfs, env):

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -20,6 +20,7 @@ import os
 import signal
 import sys
 import threading
+import time
 
 from psutil import net_if_addrs
 from socket import AF_INET
@@ -187,12 +188,13 @@ def _launch_jobs(settings, env, host_alloc_plan, remote_host_names, _run_command
         except Exception as e:
             print('Exception happened during safe_shell_exec, exception '
                   'message: {message}'.format(message=e))
+            exit_code = 1
         finally:
             if stdout_file:
                 stdout_file.close()
             if stderr_file:
                 stderr_file.close()
-        return 0
+        return exit_code, time.time()
 
     ssh_port_arg = '-p {ssh_port}'.format(ssh_port=settings.ssh_port) if settings.ssh_port else ''
 
@@ -250,12 +252,14 @@ def _launch_jobs(settings, env, host_alloc_plan, remote_host_names, _run_command
     res = threads.execute_function_multithreaded(_exec_command,
                                                  args_list,
                                                  block_until_all_done=True)
-    for name in res:
-        if res[name] != 0:
-            raise RuntimeError("Gloo job detected that one or more processes exited with non-zero "
-                               "status, thus causing the job to be terminated. The first process "
-                               "to do so was:\nProcess name: {name}\nExit code: {code}\n"
-                               .format(name=name, code=res[name]))
+
+    for name, value in sorted(res.items(), key=lambda item: item[1][1]):
+        exit_code, timestamp = value
+        if exit_code != 0:
+            raise RuntimeError('Gloo job detected that one or more processes exited with non-zero '
+                               'status, thus causing the job to be terminated. The first process '
+                               'to do so was:\nProcess name: {name}\nExit code: {code}\n'
+                               .format(name=name, code=exit_code))
 
 
 def gloo_run(settings, remote_host_names, common_intfs, env):

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -102,7 +102,4 @@ def mpi_run(settings, common_intfs, env):
     if settings.verbose >= 2:
         print(mpirun_command)
     # Execute the mpirun command.
-    exit_code = safe_shell_exec.execute(mpirun_command, env)
-    if exit_code != 0:
-        raise RuntimeError("Run mpi job failed with exit code {e}".format(e=exit_code))
-
+    os.execve('/bin/sh', ['/bin/sh', '-c', mpirun_command], env)

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -102,4 +102,7 @@ def mpi_run(settings, common_intfs, env):
     if settings.verbose >= 2:
         print(mpirun_command)
     # Execute the mpirun command.
-    os.execve('/bin/sh', ['/bin/sh', '-c', mpirun_command], env)
+    exit_code = safe_shell_exec.execute(mpirun_command, env)
+    if exit_code != 0:
+        raise RuntimeError("Run mpi job failed with exit code {e}".format(e=exit_code))
+

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -43,7 +43,7 @@ class CommonTests(unittest.TestCase):
         """Test that Gloo has been built if env is set."""
         gloo_rank = int(os.getenv('HOROVOD_RANK', -1))
         if gloo_rank >= 0:
-            self.assertEqual(gloo_built())
+            self.assertTrue(gloo_built())
 
     def test_tensorflow_available(self):
         """Test that TensorFLow support has been built."""


### PR DESCRIPTION
Gloo job should raise error if any task failed. But current master code if some task failed, gloo job will still exit normally.

I add checking code and raise error if needed.

(This keep similar behavior with `mpirun`, which will exit with non-zero value if any task failed)

### Test
We could manually test this by:
```
horovodrun -np 1 --gloo python -c "raise RuntimeError('error1')"
echo $?
```

**Before**
`horovodrun` exit with 0

**After**
`horovodrun` exit with 1, and raise Runtime error "Run gloo job failed." 