### PR TITLE
Fix segment fault in MXNet integration

### DIFF
--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -15,6 +15,7 @@
 // =============================================================================
 
 #include "collective_operations.h"
+#include "../logging.h"
 
 namespace horovod {
 namespace common {

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -39,17 +39,19 @@ struct MpiOpsParam {
   NDArray* input;
   NDArray* output;
   MXTensorSharedPtr cpu_tensor;
+  MXTensorSharedPtr output_tensor;
   OperationType op_type;
   std::string op_name;
   int root_rank;
 
   MpiOpsParam(NDArray* input, NDArray* output,
-              MXTensorSharedPtr cpu_tensor,
+              MXTensorSharedPtr cpu_tensor, MXTensorSharedPtr output_tensor, 
               const OperationType& op_type, const std::string& op_name,
               int root_rank)
       : input(input),
         output(output),
         cpu_tensor(cpu_tensor),
+        output_tensor(output_tensor),
         op_type(op_type),
         op_name(op_name),
         root_rank(root_rank) {
@@ -58,10 +60,11 @@ struct MpiOpsParam {
 
 inline MpiOpsParam* CreateMpiOpsParam(NDArray* input, NDArray* output,
                                       MXTensorSharedPtr cpu_tensor,
+                                      MXTensorSharedPtr output_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
                                       int root_rank) {
-  return new MpiOpsParam(input, output, cpu_tensor, op_type, op_name, root_rank);
+  return new MpiOpsParam(input, output, cpu_tensor, output_tensor, op_type, op_name, root_rank);
 }
 
 void DeleteMpiOpsParam(void* param) {

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -16,6 +16,7 @@
 #include <mxnet/c_api.h>
 
 #include "tensor_util.h"
+#include "../common/logging.h"
 
 namespace horovod {
 namespace mxnet {
@@ -137,13 +138,14 @@ void TensorUtil::Free(NDArray* tensor) { delete tensor; }
 
 // Resize tensor to nDimension with length size[i] in dimension i
 void TensorUtil::ResizeNd(NDArray* tensor, int nDimension, int64_t* size) {
-  void* temp_out;
-  MXNDArrayReshape64(tensor, nDimension, size, false, &temp_out);
-  tensor = static_cast<NDArray*>(temp_out);
+  mxnet::Tuple<dim_t> shape(size, size+nDimension);
+  tensor->ReshapeAndAlloc(shape);
 }
 
 // Copy from tensor to output
 void TensorUtil::Copy(NDArray* output, NDArray* tensor) {
+  LOG(TRACE)<<"Copy Dst Shape"<<output->shape();
+  LOG(TRACE)<<"Copy Src Shape"<<tensor->shape();
   if (tensor->shape() != output->shape())
     output->ReshapeAndAlloc(tensor->shape());
   CopyFromTo(*tensor, output, 0);


### PR DESCRIPTION
This PR solves the segment fault in: https://github.com/horovod/horovod/issues/1409

Basically, AllGather is a function that will allocate more space in the output than the size of input. The previous implementation falsely used the same address space for input and output and did not allocate enough space for output. If we want to use IN_PLACE operation, the MPI standard requires that the send data block to be sitting in the same location as if it is in the AllGather result. 

Currenlty there is a blocking call at the end of the MXNet API calls. Otherwise there will be data corruption. The previous implementation of Allreduce also has this risk when HOROVOD_GPU_REDUCE=MPI.