### PR TITLE
Add Spectrum MPI support to horovodrun

### DIFF
--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -16,7 +16,7 @@
 
 class Settings(object):
 
-    def __init__(self, verbose=0, ssh_port=None, key=None, timeout=None,
+    def __init__(self, verbose=0, ssh_port=None, extra_mpi_args=None, key=None, timeout=None,
                  num_hosts=None, num_proc=None, hosts=None, output_filename=None,
                  command=None):
         """
@@ -24,6 +24,8 @@ class Settings(object):
         :type verbose: int
         :param ssh_port: SSH port on all the hosts
         :type ssh_port: int
+        :param extra_mpi_args: Extra MPI arguments to pass to mpirun
+        :type extra_mpi_args: string
         :param key: used for encryption of parameters passed across the hosts
         :type key: str
         :param timeout: has to finish all the checks before this timeout runs
@@ -42,6 +44,7 @@ class Settings(object):
         """
         self.verbose = verbose
         self.ssh_port = ssh_port
+        self.extra_mpi_args = extra_mpi_args
         self.key = key
         self.timeout = timeout
         self.num_hosts = num_hosts

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -389,6 +389,11 @@ def parse_args():
     parser.add_argument('-p', '--ssh-port', action='store', dest='ssh_port',
                         type=int, help='SSH port on all the hosts.')
 
+    parser.add_argument('--mpi-args', action='store', dest='mpi_args',
+                        help='Extra MPI arguments to pass to mpirun. '
+                             'They need to be passed with the equal sign to avoid parsing issues. '
+                             'e.g. --mpi-args="--map-by ppr:6:node"')
+
     parser.add_argument('--disable-cache', action='store_true',
                         dest='disable_cache',
                         help='If the flag is not set, horovodrun will perform '
@@ -635,6 +640,7 @@ def run():
                                     'parameter if you have too many servers.')
     settings = hvd_settings.Settings(verbose=2 if args.verbose else 0,
                                      ssh_port=args.ssh_port,
+                                     extra_mpi_args=args.mpi_args,
                                      key=secret.make_secret_key(),
                                      timeout=tmout,
                                      num_hosts=len(all_host_names),

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -389,11 +389,6 @@ def parse_args():
     parser.add_argument('-p', '--ssh-port', action='store', dest='ssh_port',
                         type=int, help='SSH port on all the hosts.')
 
-    parser.add_argument('--mpi-args', action='store', dest='mpi_args',
-                        help='Extra MPI arguments to pass to mpirun. '
-                             'They need to be passed with the equal sign to avoid parsing issues. '
-                             'e.g. --mpi-args="--map-by ppr:6:node"')
-
     parser.add_argument('--disable-cache', action='store_true',
                         dest='disable_cache',
                         help='If the flag is not set, horovodrun will perform '
@@ -536,6 +531,10 @@ def parse_args():
                                                 'of Horovod.')
     group_mpi_threads_disable.add_argument('--no-mpi-threads-disable', dest='mpi_threads_disable',
                                            action=make_override_false_action(override_args), help=argparse.SUPPRESS)
+    group_library_options.add_argument('--mpi-args', action='store', dest='mpi_args',
+                                       help='Extra MPI arguments to pass to mpirun. '
+                                       'They need to be passed with the equal sign to avoid parsing issues. '
+                                       'e.g. --mpi-args="--map-by ppr:6:node"')
     group_library_options.add_argument('--num-nccl-streams', action=make_override_action(override_args),
                                        type=int, default=1,
                                        help='Number of NCCL streams. Only applies when running with NCCL support. '


### PR DESCRIPTION
* Also, add '--mpi-args' flag to pass extra arguments to MPI.
In the case of LSF clusters, the slot numbers in the '-H' arguments can be
overwritten by the LSF MPI config. So to run on 2 boxes with 6 GPUs each, you
need to use: horovodrun --start-timeout 180 -np 12 --mpi-args="--map-by ppr:6:node" -H host1:6,host2:6 python mnist.py