### PR TITLE
Skip test_horovod_allreduce_multi_gpu and test_model_parallelism if not enough GPUs.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1173,6 +1173,10 @@ class TorchTests(unittest.TestCase):
         if size == 1:
             return
 
+        # Skip the test if there are not enough GPUs.
+        if torch.cuda.device_count() < hvd.local_size() * 2:
+            return
+
         first_device = local_rank * 2
         second_device = local_rank * 2 + 1
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -267,6 +267,10 @@ class TorchTests(unittest.TestCase):
         local_rank = hvd.local_rank()
         size = hvd.size()
 
+        # Skip the test if there are not enough GPUs.
+        if torch.cuda.device_count() < hvd.local_size() * 2:
+            return
+
         iter = 0
         dtypes = [torch.cuda.IntTensor, torch.cuda.LongTensor,
                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor]


### PR DESCRIPTION
Right now these tests will fail with "CUDA error: invalid device ordinal" if number of available GPUs is less than number of local processes.