### PR TITLE
support fp16 with ibm ddl

### DIFF
--- a/horovod/common/ops/ddl_operations.cc
+++ b/horovod/common/ops/ddl_operations.cc
@@ -23,6 +23,8 @@ DDL_Type GetDDLDataType(const std::shared_ptr<Tensor> tensor) {
   switch (tensor->dtype()) {
     case HOROVOD_FLOAT32:
       return DDL_TYPE_FLOAT;
+    case HOROVOD_FLOAT16:
+      return DDL_TYPE_HALF;
     default:
       throw std::logic_error("Type " + DataType_Name(tensor->dtype()) +
                              " is not supported in DDL mode.");


### PR DESCRIPTION
Hello,

IBM DDL support half precision training. I have add two lines to make it work with Horovod.