### PR TITLE
(minor change) Auto-remove temporary docker containers in build-docker-images.sh

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -15,10 +15,10 @@ function build_one()
 
     tag=horovod-build-py${py}-${device}:$(date +%Y%m%d-%H%M%S)
     docker build -f Dockerfile.${device} -t ${tag} --build-arg python=${py} --no-cache .
-    horovod_version=$(docker run ${tag} pip freeze | grep ^horovod= | awk -F== '{print $2}')
-    tensorflow_version=$(docker run ${tag} pip freeze | grep ^${tensorflow_pkg}= | awk -F== '{print $2}')
-    pytorch_version=$(docker run ${tag} pip freeze | grep ^torch= | awk -F== '{print $2}' | awk -F+ '{print $1}')
-    mxnet_version=$(docker run ${tag} pip freeze | grep ^mxnet | awk -F== '{print $2}')
+    horovod_version=$(docker run --rm ${tag} pip freeze | grep ^horovod= | awk -F== '{print $2}')
+    tensorflow_version=$(docker run --rm ${tag} pip freeze | grep ^${tensorflow_pkg}= | awk -F== '{print $2}')
+    pytorch_version=$(docker run --rm ${tag} pip freeze | grep ^torch= | awk -F== '{print $2}' | awk -F+ '{print $1}')
+    mxnet_version=$(docker run --rm ${tag} pip freeze | grep ^mxnet | awk -F== '{print $2}')
     final_tag=horovod/horovod:${horovod_version}-tf${tensorflow_version}-torch${pytorch_version}-mxnet${mxnet_version}-py${py}-${device}
     docker tag ${tag} ${final_tag}
     docker rmi ${tag}


### PR DESCRIPTION
Auto-remove temporary docker containers used to read horovod/tensorflow/pytorch/mxnet versions.