### PR TITLE
Add ENV of Keras version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV TORCHVISION_VERSION=0.2.2.post3
 ENV CUDNN_VERSION=7.4.1.5-1+cuda9.0
 ENV NCCL_VERSION=2.3.7-1+cuda9.0
 ENV MXNET_VERSION=1.4.1
+ENV KERAS_VERSION=2.2.4
 
 # Python 2.7 or 3.5 is supported by Ubuntu Xenial out of the box
 ARG python=2.7
@@ -35,7 +36,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 # Install TensorFlow, Keras, PyTorch and MXNet
-RUN pip install 'numpy<1.15.0' tensorflow-gpu==${TENSORFLOW_VERSION} keras h5py torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} mxnet-cu90==${MXNET_VERSION}
+RUN pip install 'numpy<1.15.0' tensorflow-gpu==${TENSORFLOW_VERSION} keras==${KERAS_VERSION} h5py torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} mxnet-cu90==${MXNET_VERSION}
 
 # Install Open MPI
 RUN mkdir /tmp/openmpi && \


### PR DESCRIPTION
The requirements of machine spec for the latest version of Horovod is so high such as CUDA10 and the latest type of graphic card etc. Hence our project team uses Horovod V0.16.4. Howerver, this version of Dockerfile doesn't contain ENV of Keras version. If we build this image without changes, the latest version of Keras is installed and Horovod doesn't run correctly. Hence, I added these modifications.