### PR TITLE
Fixed start time set in Timeline to ensure timestamps are given relative to initialization of the TimelineWriter

### DIFF
--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -29,7 +29,7 @@ void TimelineWriter::Initialize(std::string file_name) {
   file_.open(file_name, std::ios::out | std::ios::trunc);
   if (file_.good()) {
     // Initialize the timeline with '[' character.
-    file_ << "[\n";
+    file_ << "[" << std::endl;
     healthy_ = true;
 
     // Spawn writer thread.
@@ -150,6 +150,8 @@ void Timeline::Initialize(std::string file_name, unsigned int horovod_size) {
   if (initialized_) {
     return;
   }
+
+  start_time_ = std::chrono::steady_clock::now();
 
   // Start the writer.
   writer_.Initialize(std::move(file_name));


### PR DESCRIPTION
Fixes #1472.

Current timeline events have cryptic timestamps, e.g.:

```
{"ph": "B", "name": "NEGOTIATE_ALLREDUCE", "ts": 678417958358, "pid": 1},
```

With this fix, events properly represent the number of microseconds elapsed since initialization:

```
{"ph": "B", "name": "NEGOTIATE_ALLREDUCE", "ts": 4203464, "pid": 1},
```

Signed-off-by: Travis Addair <taddair@uber.com>