### PR TITLE
(minor change) AllreduceOp: use output tensor pointer and size

### DIFF
--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -62,7 +62,7 @@ void AllreduceOp::MemcpyOutFusionBuffer(
   for (auto& e : entries) {
     void* buffer_data_at_offset = (uint8_t*)buffer_data + offset;
     MemcpyEntryOutFusionBuffer(entries, buffer_data_at_offset, e);
-    offset += e.tensor->size();
+    offset += e.output->size();
   }
 }
 
@@ -77,7 +77,7 @@ void AllreduceOp::MemcpyEntryOutFusionBuffer(
     const std::vector<TensorTableEntry>& entries,
     const void* buffer_data_at_offset, TensorTableEntry& e) {
   std::memcpy((void*)e.output->data(), buffer_data_at_offset,
-              (size_t)e.tensor->size());
+              (size_t)e.output->size());
 }
 
 // Allgather


### PR DESCRIPTION
For clarity, use output tensor size (`e.output->size()`) when writing to output tensor pointer (`e.output->data()`).

Note: for AllreduceOp, input tensor and output tensor have same shape/size, so this doesn't actually change any functionality.