### PR TITLE
Add CUDA Allgather implementation to support tensor fusion

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -157,6 +157,11 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
     allreduce_ops.push_back(std::shared_ptr<AllreduceOp>(
         new DDLAllreduce(&ddl_context, &cuda_context, &state)));
 #endif
+
+#if HOROVOD_GPU_ALLGATHER == 'M'
+    allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
+        new MPI_CUDAAllgather(&mpi_context, &cuda_context, &state)));
+#endif
     allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
         new MPIHierarchicalAllgather(&mpi_context, &state)));
   }

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -111,6 +111,18 @@ protected:
                         const int64_t* const* entry_component_sizes,
                         const void* buffer_data, int element_size,
                         std::vector<TensorTableEntry>& entries);
+
+  virtual void
+  MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                            const TensorTableEntry& e,
+                            void* buffer_data_at_offset);
+
+  virtual void
+  MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                             const void* buffer_data_at_offset,
+                             TensorTableEntry& e,
+                             int64_t entry_offset,
+                             size_t entry_size);
 };
 
 class BroadcastOp : public HorovodOp {

--- a/horovod/common/ops/cuda_operations.h
+++ b/horovod/common/ops/cuda_operations.h
@@ -101,6 +101,46 @@ protected:
   struct CUDAContext* cuda_context_;
 };
 
+class CUDAAllgather : public AllgatherOp {
+public:
+  CUDAAllgather(CUDAContext* context,
+                HorovodGlobalState* global_state);
+
+  bool Enabled(const ParameterManager& param_manager,
+               const std::vector<TensorTableEntry>& entries,
+               const Response& response) const override;
+
+protected:
+  void MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                 const TensorTableEntry& e, void* buffer_data_at_offset) override;
+
+  void MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                  const void* buffer_data_at_offset, TensorTableEntry& e,
+                                  int64_t entry_offset, size_t entry_size) override;
+
+  void InitCUDA(const std::vector<TensorTableEntry>& entries);
+
+  void InitCUDAQueue(const std::vector<TensorTableEntry>& entries, const Response& response);
+
+  Status FinalizeCUDAQueue(const std::vector<TensorTableEntry>& entries);
+
+  // CUDA events are used as an alternative to host-device synchronization (which stalls the GPU pipeline)
+  // for the purpose of recording timing on the Horovod timeline.
+  //
+  // When an event we wish to record occurs (for example, NCCL_ALLREDUCE), the event is enqueued. After the entire
+  // operation completes, a background thread is spawned to synchronize on the events in the queue and record
+  // timing, while allowing Horovod to continue processing additional tensors.
+  //
+  // For more information of CUDA Events, see:
+  // https://devblogs.nvidia.com/how-implement-performance-metrics-cuda-cc/
+  std::queue<std::pair<std::string, cudaEvent_t>> event_queue_;
+
+  cudaStream_t* stream_;
+  void* host_buffer_;
+
+  struct CUDAContext* cuda_context_;
+};
+
 } // namespace common
 } // namespace horovod
 

--- a/horovod/common/ops/mpi_cuda_operations.cc
+++ b/horovod/common/ops/mpi_cuda_operations.cc
@@ -78,5 +78,102 @@ Status MPI_CUDAAllreduce::Execute(std::vector<TensorTableEntry>& entries, const 
   return Status::OK();
 }
 
+MPI_CUDAAllgather::MPI_CUDAAllgather(MPIContext* mpi_context,
+                                     CUDAContext* cuda_context,
+                                     HorovodGlobalState* global_state)
+    : CUDAAllgather(cuda_context, global_state),
+      mpi_context_(mpi_context) {}
+
+Status MPI_CUDAAllgather::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
+  auto& timeline = global_state_->timeline;
+
+  InitCUDA(entries);
+
+  // Sizes of subcomponents of each entry from all ranks
+  auto** entry_component_sizes = new int64_t* [entries.size()];
+
+  // Offset of each subcomponent of every entry in the final buffer after
+  // allgatherv
+  auto** entry_component_offsets = new int64_t* [entries.size()];
+
+  int global_size = global_state_->controller->GetSize();
+  auto* recvcounts = new int[global_size]();
+  auto* displcmnts = new int[global_size]();
+
+  for (size_t ec = 0; ec < entries.size(); ++ec) {
+    entry_component_sizes[ec] = new int64_t[global_size]();
+    entry_component_offsets[ec] = new int64_t[global_size]();
+  }
+
+  auto& first_entry = entries[0];
+
+  timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
+  Status status = AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  if (!status.ok()) {
+    return status;
+  }
+  timeline.ActivityEndAll(entries);
+
+  SetDisplacements(recvcounts, displcmnts);
+  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts, entry_component_offsets);
+
+  int element_size = mpi_context_->GetMPITypeSize(first_entry.tensor->dtype());
+
+  const void* sendbuf = nullptr;
+  void* buffer_data;
+  int64_t total_num_elements = NumElements(entries);
+
+  if (entries.size() > 1) {
+    timeline.ActivityStartAll(entries, MEMCPY_IN_FUSION_BUFFER);
+    MemcpyInFusionBuffer(entries, displcmnts, element_size, buffer_data);
+
+    auto cuda_result = cudaStreamSynchronize(cuda_context_->streams[global_state_->current_nccl_stream][entries[0].device]);
+    cuda_context_->ErrorCheck("cudaStreamSynchronize", cuda_result);
+
+    timeline.ActivityEndAll(entries);
+  } else {
+    sendbuf = first_entry.tensor->data();
+    buffer_data = (void*) first_entry.output->data();
+  }
+
+  global_state_->timeline.ActivityStartAll(entries, MPI_ALLGATHER);
+  auto dtype = mpi_context_->GetMPIDataType(first_entry.tensor->dtype());
+  int op = MPI_Allgatherv(sendbuf != nullptr ? sendbuf : MPI_IN_PLACE,
+                          (int) total_num_elements,
+                          dtype,
+                          buffer_data,
+                          recvcounts,
+                          displcmnts,
+                          dtype,
+                          mpi_context_->GetMPICommunicator(Communicator::GLOBAL));
+  if (op != MPI_SUCCESS) {
+    throw std::runtime_error("MPI_Allgatherv failed, see MPI output for details.");
+  }
+  global_state_->timeline.ActivityEndAll(entries);
+
+  if (entries.size() > 1) {
+    timeline.ActivityStartAll(entries, MEMCPY_OUT_FUSION_BUFFER);
+    MemcpyOutFusionBuffer(entry_component_offsets, entry_component_sizes,
+                          buffer_data, element_size, entries);
+
+    auto cuda_result = cudaStreamSynchronize(cuda_context_->streams[global_state_->current_nccl_stream][entries[0].device]);
+    cuda_context_->ErrorCheck("cudaStreamSynchronize", cuda_result);
+
+    timeline.ActivityEndAll(entries);
+  }
+
+  delete[] recvcounts;
+  delete[] displcmnts;
+
+  for (size_t ec = 0; ec < entries.size(); ++ec) {
+    delete[] entry_component_sizes[ec];
+    delete[] entry_component_offsets[ec];
+  }
+  delete[] entry_component_sizes;
+  delete[] entry_component_offsets;
+
+  return Status::OK();
+}
+
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/mpi_cuda_operations.cc
+++ b/horovod/common/ops/mpi_cuda_operations.cc
@@ -28,7 +28,7 @@ MPI_CUDAAllreduce::MPI_CUDAAllreduce(MPIContext* mpi_context,
 Status MPI_CUDAAllreduce::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
   auto& first_entry = entries[0];
 
-  InitCUDA(entries);
+  cuda_op_context_.InitCUDA(entries);
 
   void* buffer_data;
   size_t buffer_len;
@@ -87,7 +87,7 @@ MPI_CUDAAllgather::MPI_CUDAAllgather(MPIContext* mpi_context,
 Status MPI_CUDAAllgather::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
   auto& timeline = global_state_->timeline;
 
-  InitCUDA(entries);
+  cuda_op_context_.InitCUDA(entries);
 
   // Sizes of subcomponents of each entry from all ranks
   auto** entry_component_sizes = new int64_t* [entries.size()];

--- a/horovod/common/ops/mpi_cuda_operations.h
+++ b/horovod/common/ops/mpi_cuda_operations.h
@@ -34,6 +34,17 @@ protected:
   MPIContext* mpi_context_;
 };
 
+class MPI_CUDAAllgather : public CUDAAllgather {
+public:
+  MPI_CUDAAllgather(MPIContext* mpi_context, CUDAContext* cuda_context, HorovodGlobalState* global_state);
+  virtual ~MPI_CUDAAllgather()=default;
+
+  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+
+protected:
+  MPIContext* mpi_context_;
+};
+
 } // namespace common
 } // namespace horovod
 


### PR DESCRIPTION
Allgather with CUDA tensors does not always work with tensor fusion/CUDA.

1. Build Horovod without HOROVOD_GPU_*
```
import torch
import horovod.torch as hvd

hvd.init()

// The following allgather will succeed because it will run on the CPU (manually cudaMemcpy to CPU, run CPU allgather) in pytorch/tensorflow/etc.
tensor = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
result = hvd.allgather(tensor)

// Tensor fusion works because the CUDA memory is manually copied to/from CPU
// and AllgatherOp uses std::memcpy for tensor fusion
tensor1 = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
tensor2 = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
handle1 = hvd.allgather_async(tensor1)
handle2 = hvd.allgather_async(tensor2)
result1 = hvd.synchronize(handle1)
result2 = hvd.synchronize(handle2)
```

2. Build OpenMPI with CUDA support.  Build Horovod with HOROVOD_GPU_ALLREDUCE=MPI and HOROVOD_GPU_ALLGATHER=MPI.
```
import torch
import horovod.torch as hvd

hvd.init()

// The following allgather will fail because CUDA is not initialized
tensor = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
result = hvd.allgather(tensor)

// The following allgather will succeed because MPI_CUDAAllreduce will first initialize CUDA
tensor = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
dummy = hvd.allreduce(tensor)
result = hvd.allgather(tensor)

// The following allgather using tensor fusion will fail
// This will invoke AllgatherOp, which unconditionally calls std::memcpy on the pointers, even if they are allocated on a CUDA device
tensor1 = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
tensor2 = torch.cuda.FloatTensor(*([4])).fill_(hvd.rank())
handle1 = hvd.allgather_async(tensor1)
handle2 = hvd.allgather_async(tensor2)
result1 = hvd.synchronize(handle1)
result2 = hvd.synchronize(handle2)
```
