### PR TITLE
support user specify the NIC

### DIFF
--- a/horovod/run/common/service/driver_service.py
+++ b/horovod/run/common/service/driver_service.py
@@ -41,8 +41,8 @@ class AllTaskAddressesResponse(object):
 
 
 class BasicDriverService(network.BasicService):
-    def __init__(self, num_proc, name, key):
-        super(BasicDriverService, self).__init__(name, key)
+    def __init__(self, num_proc, name, key, nic):
+        super(BasicDriverService, self).__init__(name, key, nic)
         self._num_proc = num_proc
         self._all_task_addresses = {}
         self._task_addresses_for_driver = {}

--- a/horovod/run/common/service/task_service.py
+++ b/horovod/run/common/service/task_service.py
@@ -52,8 +52,8 @@ class RegisterCodeResultRequest(object):
 
 
 class BasicTaskService(network.BasicService):
-    def __init__(self, name, key):
-        super(BasicTaskService, self).__init__(name, key)
+    def __init__(self, name, key, nic):
+        super(BasicTaskService, self).__init__(name, key, nic)
         self._initial_registration_complete = False
         self._wait_cond = threading.Condition()
         self._command_thread = None

--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -85,13 +85,15 @@ class Wire(object):
 
 
 class BasicService(object):
-    def __init__(self, service_name, key):
+    def __init__(self, service_name, key, nic):
         self._service_name = service_name
         self._wire = Wire(key)
+        self._nic = nic
         self._server, _ = find_port(
             lambda addr: socketserver.ThreadingTCPServer(
                 addr, self._make_handler()))
         self._port = self._server.socket.getsockname()[1]
+        self._addresses = self._get_local_addresses()
         self._thread = threading.Thread(target=self._server.serve_forever)
         self._thread.daemon = True
         self._thread.start()
@@ -119,15 +121,23 @@ class BasicService(object):
 
         raise NotImplementedError(req)
 
-    def addresses(self):
+    def _get_local_addresses(self):
         result = {}
         for intf, intf_addresses in psutil.net_if_addrs().items():
+            if self._nic and intf != self._nic:
+                continue
             for addr in intf_addresses:
                 if addr.family == socket.AF_INET:
                     if intf not in result:
                         result[intf] = []
                     result[intf].append((addr.address, self._port))
+        if not result:
+            raise NoValidAddressesFound(
+                'Can not find a available NIC matches the given one: {}'.format(self._nic))
         return result
+
+    def addresses(self):
+        return self._addresses
 
     def shutdown(self):
         self._server.shutdown()

--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -131,9 +131,9 @@ class BasicService(object):
                     if intf not in result:
                         result[intf] = []
                     result[intf].append((addr.address, self._port))
-        if not result:
+        if not result and self._nic:
             raise NoValidAddressesFound(
-                'Can not find a available NIC matches the given one: {}'.format(self._nic))
+                'No available network interface found matching user provided interface: {}'.format(self._nic))
         return result
 
     def addresses(self):

--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -18,7 +18,7 @@ class Settings(object):
 
     def __init__(self, verbose=0, ssh_port=None, extra_mpi_args=None, key=None, timeout=None,
                  num_hosts=None, num_proc=None, hosts=None, output_filename=None,
-                 run_func_mode=None):
+                 run_func_mode=None, nic=None):
         """
         :param verbose: level of verbosity
         :type verbose: int
@@ -38,9 +38,11 @@ class Settings(object):
         :param hosts: string of hostname with slots number
         :type hosts: string
         :param output_filename: optional filename to redirect stdout / stderr by process
-        :try output_filename: string
+        :type output_filename: string
         :param run_func_mode: whether it is run function mode
         :type run_func_mode: boolean
+        :param nic: specify the NIC for tcp network communication.
+        :type nic: string
         """
         self.verbose = verbose
         self.ssh_port = ssh_port
@@ -52,4 +54,5 @@ class Settings(object):
         self.hosts = hosts
         self.output_filename = output_filename
         self.run_func_mode = run_func_mode
+        self.nic = nic
 

--- a/horovod/run/driver/driver_service.py
+++ b/horovod/run/driver/driver_service.py
@@ -19,10 +19,10 @@ from horovod.run.common.service import driver_service
 class HorovodRunDriverService(driver_service.BasicDriverService):
     NAME = 'horovodrun driver service'
 
-    def __init__(self, num_hosts, key):
+    def __init__(self, num_hosts, key, nic):
         super(HorovodRunDriverService, self).__init__(num_hosts,
                                                       HorovodRunDriverService.NAME,
-                                                      key)
+                                                      key, nic)
 
 
 class HorovodRunDriverClient(driver_service.BasicDriverClient):

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -427,8 +427,8 @@ def parse_args():
                              'HOROVOD_START_TIMEOUT can also be used to '
                              'specify the initialization timeout.')
 
-    parser.add_argument('--nic', action='store', dest='nic',
-                        help='Specify the network interface card used for communication.')
+    parser.add_argument('--network-interface', action='store', dest='nic',
+                        help='Specify the network interface used for communication.')
 
     parser.add_argument('--output-filename', action='store',
                         help='For Gloo, writes stdout / stderr of all processes to a filename of the form '
@@ -874,7 +874,7 @@ def run(
         verbose=None,
         use_gloo=None,
         use_mpi=None,
-        nic=None):
+        network_interface=None):
     """
     Launch a Horovod job to run the specified process function and get the return value.
 
@@ -912,7 +912,7 @@ def run(
                      be the default if Horovod was not built with MPI support.
     :param use_mpi: Run Horovod using the MPI controller. This will
                     be the default if Horovod was built with MPI support.
-    :param nic: Specify the NIC for communication.
+    :param network_interface: Specify the network interface for communication.
 
     :return: Return a list which contains values return by all Horovod processes.
              The index of the list corresponds to the rank of each Horovod process.
@@ -942,7 +942,7 @@ def run(
     hargs.verbose = verbose
     hargs.use_gloo = use_gloo
     hargs.use_mpi = use_mpi
-    hargs.nic = nic
+    hargs.nic = network_interface
 
     hargs.run_func = wrapped_func
 

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -628,6 +628,7 @@ class HorovodArgs(object):
         self.command = None
         self.run_func = None
         self.config_file = None
+        self.nic = None
 
         # tuneable parameter arguments
         self.fusion_threshold_mb = None
@@ -872,7 +873,8 @@ def run(
         output_filename=None,
         verbose=None,
         use_gloo=None,
-        use_mpi=None):
+        use_mpi=None,
+        nic=None):
     """
     Launch a Horovod job to run the specified process function and get the return value.
 
@@ -910,6 +912,7 @@ def run(
                      be the default if Horovod was not built with MPI support.
     :param use_mpi: Run Horovod using the MPI controller. This will
                     be the default if Horovod was built with MPI support.
+    :param nic: Specify the NIC for communication.
 
     :return: Return a list which contains values return by all Horovod processes.
              The index of the list corresponds to the rank of each Horovod process.
@@ -939,6 +942,7 @@ def run(
     hargs.verbose = verbose
     hargs.use_gloo = use_gloo
     hargs.use_mpi = use_mpi
+    hargs.nic = nic
 
     hargs.run_func = wrapped_func
 

--- a/horovod/run/task/task_service.py
+++ b/horovod/run/task/task_service.py
@@ -31,10 +31,10 @@ class TaskToTaskAddressCheckFinishedSignalResponse(object):
 class HorovodRunTaskService(task_service.BasicTaskService):
     NAME_FORMAT = 'horovodrun task service #%d'
 
-    def __init__(self, index, key):
+    def __init__(self, index, key, nic):
         super(HorovodRunTaskService, self).__init__(
             HorovodRunTaskService.NAME_FORMAT % index,
-            key)
+            key, nic)
         self.index = index
         self._task_to_task_address_check_completed = False
 

--- a/horovod/run/task_fn.py
+++ b/horovod/run/task_fn.py
@@ -21,7 +21,7 @@ from horovod.run.task import task_service
 
 
 def _task_fn(index, driver_addresses, settings):
-    task = task_service.HorovodRunTaskService(index, settings.key)
+    task = task_service.HorovodRunTaskService(index, settings.key, settings.nic)
     try:
         driver = driver_service.HorovodRunDriverClient(
             driver_addresses, settings.key, settings.verbose)

--- a/horovod/spark/driver/driver_service.py
+++ b/horovod/spark/driver/driver_service.py
@@ -60,9 +60,10 @@ class CodeResponse(object):
 class SparkDriverService(driver_service.BasicDriverService):
     NAME = 'driver service'
 
-    def __init__(self, num_proc, fn, args, kwargs, key):
+    def __init__(self, num_proc, fn, args, kwargs, key, nic):
         super(SparkDriverService, self).__init__(num_proc,
-                                                 SparkDriverService.NAME, key)
+                                                 SparkDriverService.NAME,
+                                                 key, nic)
 
         self._fn = fn
         self._args = args

--- a/horovod/spark/task/task_service.py
+++ b/horovod/spark/task/task_service.py
@@ -19,8 +19,8 @@ from horovod.run.common.service import task_service
 class SparkTaskService(task_service.BasicTaskService):
     NAME_FORMAT = 'task service #%d'
 
-    def __init__(self, index, key):
-        super(SparkTaskService, self).__init__(SparkTaskService.NAME_FORMAT % index, key)
+    def __init__(self, index, key, nic):
+        super(SparkTaskService, self).__init__(SparkTaskService.NAME_FORMAT % index, key, nic)
 
 
 class SparkTaskClient(task_service.BasicTaskClient):


### PR DESCRIPTION
I have run horovod.spark in a three nodes cluster. However, it got the following warning:
```
WARNING: Open MPI failed to TCP connect to a peer MPI process.  This
should not happen.

Your Open MPI job may now hang or fail.

  Local host: sr505
  PID:        86258
  Message:    connect() to 10.1.2.104:1053 failed
  Error:      Operation now in progress (115)
```

And the job got to hang. This may be related to [link](https://github.com/open-mpi/ompi/issues/4963).

And also, different NIC can provide different performance. So, we could specify the NIC for using in this patch.