### PR TITLE
Upgrade tests to TensorFlow==1.15, PyTorch==1.3.0, Keras==2.3.1, and TensorFlow tests 2.0 to use release version

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -17,19 +17,19 @@ tests=( \
        test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
        test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py3_5-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py3_5-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
        test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_5-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-mlsl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-mlsl-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
        test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
        test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -14,28 +14,28 @@ tests=( \
        test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
        test-cpu-openmpi-py3_5-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
        test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py2_7-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-openmpi-py3_5-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py3_5-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-cpu-mpich-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-mlsl-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0 \
-       test-gpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-openmpi-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-mlsl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-mixed-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0 \
+       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
 )
 
 build_test() {

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -106,11 +106,11 @@ RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 # Install PyTorch.
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        pip install --pre torch torchvision -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
     else \
-        pip install ${PYTORCH_PACKAGE}; \
+        pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
-RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
+RUN pip install Pillow --no-deps
 
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -106,7 +106,7 @@ RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 # Install PyTorch.
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch torchvision -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,11 +88,11 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch torchvision -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
-        pip install ${PYTORCH_PACKAGE}; \
+        pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
-RUN pip install ${TORCHVISION_PACKAGE} Pillow --no-deps
+RUN pip install Pillow --no-deps
 
 # Install MXNet.
 RUN pip install ${MXNET_PACKAGE}

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch torchvision -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -196,7 +196,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
+        TENSORFLOW_PACKAGE: tensorflow==2.0.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
         TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
@@ -208,7 +208,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.5
-        TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
+        TENSORFLOW_PACKAGE: tensorflow==2.0.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
         TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
@@ -221,7 +221,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-2.0-preview
+        TENSORFLOW_PACKAGE: tensorflow==2.0.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
         TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
@@ -233,7 +233,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly
+        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191104
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -246,7 +246,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly
+        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191104
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -335,7 +335,7 @@ services:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu-2.0-preview
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.0.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.2.0-cp36-cp36m-manylinux1_x86_64.whl
         TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.4.0-cp36-cp36m-manylinux1_x86_64.whl

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -88,7 +88,7 @@ services:
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.3.0
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
@@ -100,7 +100,7 @@ services:
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.3.0
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
@@ -113,7 +113,7 @@ services:
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
         PYTORCH_PACKAGE: torch==1.2.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.3.0
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -233,7 +233,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191104
+        TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -246,7 +246,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191104
+        TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
@@ -348,7 +348,7 @@ services:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191104
+        TENSORFLOW_PACKAGE: tf-nightly-gpu
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -348,7 +348,7 @@ services:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191104
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -79,7 +79,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.3.2
-  test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -87,11 +87,11 @@ services:
         PYTHON_VERSION: 2.7
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp27-cp27mu-linux_x86_64.whl
+        PYTORCH_PACKAGE: torch==1.2.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.3.0
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-py3_5-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -99,11 +99,11 @@ services:
         PYTHON_VERSION: 3.5
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp35-cp35m-linux_x86_64.whl
+        PYTORCH_PACKAGE: torch==1.2.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.3.0
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -112,109 +112,109 @@ services:
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        PYTORCH_PACKAGE: torch==1.2.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.3.0
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp27-cp27mu-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.5
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp35-cp35m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py2_7-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: None
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp27-cp27mu-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py3_5-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: None
         PYTHON_VERSION: 3.5
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp35-cp35m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: None
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py2_7-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
         TENSORFLOW_PACKAGE: tensorflow==2.0.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp27-cp27mu-manylinux1_x86_64.whl
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py3_5-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-openmpi-py3_5-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.5
         TENSORFLOW_PACKAGE: tensorflow==2.0.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp35-cp35m-manylinux1_x86_64.whl
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -222,9 +222,9 @@ services:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tensorflow==2.0.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.2.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.4.0%2Bcpu-cp36-cp36m-manylinux1_x86_64.whl
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -236,7 +236,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
+        TORCHVISION_PACKAGE: torchvision-nightly
         MXNET_PACKAGE: mxnet==1.6.0b20190926
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -249,33 +249,33 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
+        TORCHVISION_PACKAGE: torchvision-nightly
         MXNET_PACKAGE: mxnet==1.6.0b20190926
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-mpich-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: MPICH
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-mlsl-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-mlsl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: MLSL
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
 
@@ -289,46 +289,46 @@ services:
     environment:
       - CUDA_VISIBLE_DEVICES
     privileged: true
-  test-gpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow-gpu==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cu100
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cu100
         MXNET_PACKAGE: mxnet-cu100==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-gpu-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: None
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow-gpu==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cu100
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cu100
         MXNET_PACKAGE: mxnet-cu100==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-gpu-openmpi-gloo-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_4_1-pyspark2_4_0:
+  test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow-gpu==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cu100
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cu100
         MXNET_PACKAGE: mxnet-cu100==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-gpu-openmpi-py3_6-tf2_0_0-keras2_2_4-torch1_2_0-mxnet1_5_0-pyspark2_4_0:
+  test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -336,9 +336,9 @@ services:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tensorflow-gpu==2.0.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.2.0-cp36-cp36m-manylinux1_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.4.0-cp36-cp36m-manylinux1_x86_64.whl
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cu100
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cu100
         MXNET_PACKAGE: mxnet-cu100==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -351,20 +351,20 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: git+https://github.com/pytorch/vision.git
+        TORCHVISION_PACKAGE: torchvision-nightly
         MXNET_PACKAGE: mxnet-cu100==1.6.0b20190817
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-mixed-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_1_0-mxnet1_5_0-pyspark2_4_0:
+  test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 10.0-devel-ubuntu18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==1.14.0
-        KERAS_PACKAGE: keras==2.2.4
-        PYTORCH_PACKAGE: https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-        TORCHVISION_PACKAGE: https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
+        TENSORFLOW_PACKAGE: tensorflow-gpu==1.15.0
+        KERAS_PACKAGE: keras==2.3.1
+        PYTORCH_PACKAGE: torch==1.3.0+cu100
+        TORCHVISION_PACKAGE: torchvision==0.4.1+cu100
         MXNET_PACKAGE: mxnet-cu100==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
         HOROVOD_BUILD_FLAGS: ""

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -116,75 +116,75 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py3_5-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.5
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: None
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py3_5-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py3_5-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: None
         PYTHON_VERSION: 3.5
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
+  test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: None
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
@@ -252,27 +252,27 @@ services:
         TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet==1.6.0b20190926
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: MPICH
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-mlsl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
+  test-cpu-mlsl-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
       args:
         UBUNTU_VERSION: 18.04
         MPI_KIND: MLSL
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tensorflow==1.15.0
+        TENSORFLOW_PACKAGE: tensorflow==1.14.0
         KERAS_PACKAGE: keras==2.3.1
         PYTORCH_PACKAGE: torch==1.3.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -236,7 +236,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision-nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet==1.6.0b20190926
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
@@ -249,7 +249,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision-nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet==1.6.0b20190926
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
@@ -351,7 +351,7 @@ services:
         TENSORFLOW_PACKAGE: tf-nightly-gpu
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision-nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet-cu100==1.6.0b20190817
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:


### PR DESCRIPTION
Signed-off-by: Travis Addair <taddair@uber.com>