### PR TITLE
Improve documentation build and reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Horovod
 |
 
 Horovod is a distributed training framework for TensorFlow, Keras, PyTorch, and MXNet. The goal of Horovod is to make
-distributed Deep Learning fast and easy to use.
+distributed Deep Learning fast and easy to use. Full documentation can be found at https://horovod.readthedocs.io/en/latest.
 
 
 .. raw:: html
@@ -115,6 +115,13 @@ This basic installation is good for laptops and for getting to know Horovod.
 If you're installing Horovod on a server with GPUs, read the `Horovod on GPU <docs/gpus.rst>`_ page.
 
 If you want to use Docker, read the `Horovod in Docker <docs/docker.rst>`_ page.
+
+
+Compiling
+---------
+
+To compile Horovod from sources follow the instructions of the `Contributor Guide <docs/contributors.rst>`_ in `docs`
+or at https://horovod.readthedocs.io/en/latest/contributors_include.html.
 
 
 Concepts

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Horovod
 |
 
 Horovod is a distributed training framework for TensorFlow, Keras, PyTorch, and MXNet. The goal of Horovod is to make
-distributed Deep Learning fast and easy to use. Full documentation can be found at https://horovod.readthedocs.io/en/latest.
+distributed Deep Learning fast and easy to use.
 
 
 .. raw:: html
@@ -52,7 +52,11 @@ about who's involved and how Horovod plays a role, read the LF AI `announcement 
 
 .. contents::
 
+
+See the full documentation and an API reference at https://horovod.readthedocs.io/en/latest.
+
 |
+
 
 Why not traditional Distributed TensorFlow?
 -------------------------------------------
@@ -116,12 +120,7 @@ If you're installing Horovod on a server with GPUs, read the `Horovod on GPU <do
 
 If you want to use Docker, read the `Horovod in Docker <docs/docker.rst>`_ page.
 
-
-Compiling
----------
-
-To compile Horovod from sources follow the instructions of the `Contributor Guide <docs/contributors.rst>`_ in `docs`
-or at https://horovod.readthedocs.io/en/latest/contributors_include.html.
+To compile Horovod from source, follow the instructions in the `Contributor Guide <docs/contributors.rst>`_.
 
 
 Concepts

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -74,6 +74,31 @@ Horovod has unit tests for all frameworks you can run from the tests directory:
 **IMPORTANT:** Some tests contain GPU-only codepaths that will be skipped if running without GPU support.
 
 
+Documentation
+-------------
+
+The Horovod documentation is available at https://horovod.readthedocs.io/.
+
+Those html pages can be rendered from ``.rst`` files located in the `docs` directory.
+You need to setup Sphinx before you compile the documentation the first time:
+
+.. code-block:: bash
+
+    $ cd docs
+    $ pip install -r requirements.txt
+    $ make clean
+
+Then you can build the html pages and open ``docs/_build/html/index.html``:
+
+.. code-block:: bash
+
+    $ cd docs
+    $ make html
+    $ open _build/html/index.html
+
+Sphinx can render the documentation in many other formats, just type ``make`` to get a list of available formats.
+
+
 Adding Custom Operations
 ------------------------
 

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -77,10 +77,10 @@ Horovod has unit tests for all frameworks you can run from the tests directory:
 Documentation
 -------------
 
-The Horovod documentation is available at https://horovod.readthedocs.io/.
+The Horovod documentation is published to https://horovod.readthedocs.io/.
 
-Those html pages can be rendered from ``.rst`` files located in the `docs` directory.
-You need to setup Sphinx before you compile the documentation the first time:
+Those HTML pages can be rendered from ``.rst`` files located in the `docs` directory.
+You need to set up Sphinx before you compile the documentation the first time:
 
 .. code-block:: bash
 
@@ -88,7 +88,7 @@ You need to setup Sphinx before you compile the documentation the first time:
     $ pip install -r requirements.txt
     $ make clean
 
-Then you can build the html pages and open ``docs/_build/html/index.html``:
+Then you can build the HTML pages and open ``docs/_build/html/index.html``:
 
 .. code-block:: bash
 
@@ -96,7 +96,7 @@ Then you can build the html pages and open ``docs/_build/html/index.html``:
     $ make html
     $ open _build/html/index.html
 
-Sphinx can render the documentation in many other formats, just type ``make`` to get a list of available formats.
+Sphinx can render the documentation in many other formats. Type ``make`` to get a list of available formats.
 
 
 Adding Custom Operations

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -111,6 +111,8 @@ If you're installing Horovod on a server with GPUs, read `Horovod on GPU <gpus.r
 
 If you want to use Docker, read `Horovod in Docker <docker.rst>`_.
 
+To compile Horovod from source, follow the instructions in the `Contributor Guide <contributors.rst>`_.
+
 
 Concepts
 --------

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -16,7 +16,7 @@
 import atexit
 import ctypes
 
-import horovod.common.util as util
+from horovod.common import util as util
 
 
 class HorovodBasics(object):


### PR DESCRIPTION
* Adds documentation on how to build the docs
* Links the online documentation from prominent location in README.rst
* Links to the Contributors Guide from new section `Compiling`
* Makes imports robust against possible doc build failure:
```
autodoc: failed to import module 'tensorflow' from module 'horovod'; the following exception was raised:
Traceback (most recent call last):
  ...
  File ".../horovod/common/basics.py", line 19, in <module>
    import horovod.common.util as util
AttributeError: module 'horovod.common' has no attribute 'util'
```