### PR TITLE
Remove cache coordinated trace message.

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -121,7 +121,6 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
     // a shutdown. This function removes any invalid cache entries, if they
     // exist.
     CoordinateCacheAndState(cache_coordinator);
-    LOG(TRACE) << "Cache coordinated.";
     // Remove uncommon cached tensors from queue and replace to state
     // queue for next cycle. Skip adding common cached tensors to
     // queue as they are handled separately.


### PR DESCRIPTION
Remove "Cache coordinated" tracing message when running with `HOROVOD_LOG_LEVEL=trace` to limit excessive logging output. 