### PR TITLE
[ROCm] initial ROCm support

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -366,7 +366,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   int size = state.controller->GetSize();
   int local_size = state.controller->GetLocalSize();
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
   // Set number of CUDA streams to use
   auto horovod_num_nccl_streams =
       std::getenv(HOROVOD_NUM_NCCL_STREAMS);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -50,7 +50,7 @@
 #include "ops/adasum_mpi_operations.h"
 #endif
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
 #include "ops/cuda_operations.h"
 #if HAVE_MPI
 #include "ops/mpi_cuda_operations.h"
@@ -121,7 +121,7 @@ MPIContext mpi_context;
 GlooContext gloo_context;
 #endif
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
 CUDAContext cuda_context;
 #endif
 
@@ -148,7 +148,7 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
   std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops;
   std::vector<std::shared_ptr<AllreduceOp>> adasum_ops;
 
-#if HAVE_MPI && HAVE_CUDA
+#if HAVE_MPI && (HAVE_CUDA || HAVE_ROCM)
   if (mpi_context.IsEnabled()) {
 #if HOROVOD_GPU_ALLREDUCE == 'M'
     allreduce_ops.push_back(std::shared_ptr<AllreduceOp>(

--- a/horovod/common/ops/cuda_operations.h
+++ b/horovod/common/ops/cuda_operations.h
@@ -21,7 +21,34 @@
 #include <unordered_map>
 #include <vector>
 
+#if HAVE_CUDA
 #include <cuda_runtime.h>
+#elif HAVE_ROCM
+#include <hip/hip_runtime_api.h>
+// local hipify
+#define cudaDeviceGetStreamPriorityRange hipDeviceGetStreamPriorityRange
+#define cudaError_t hipError_t
+#define cudaEventBlockingSync hipEventBlockingSync
+#define cudaEventCreateWithFlags hipEventCreateWithFlags
+#define cudaEventDisableTiming hipEventDisableTiming
+#define cudaEventRecord hipEventRecord
+#define cudaEventSynchronize hipEventSynchronize
+#define cudaEvent_t hipEvent_t
+#define cudaGetDevice hipGetDevice
+#define cudaGetErrorString hipGetErrorString
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaSetDevice hipSetDevice
+#define cudaStreamCreateWithPriority hipStreamCreateWithPriority
+#define cudaStreamNonBlocking hipStreamNonBlocking
+#define cudaStreamSynchronize hipStreamSynchronize
+#define cudaStream_t hipStream_t
+#define cudaSuccess hipSuccess
+#else
+#error Must define either HAVE_CUDA or HAVE_ROCM
+#endif
 
 #include "collective_operations.h"
 #include "../thread_pool.h"

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -17,7 +17,11 @@
 #ifndef HOROVOD_NCCL_OPERATIONS_H
 #define HOROVOD_NCCL_OPERATIONS_H
 
+#if HAVE_ROCM
+#include <rccl.h>
+#else
 #include <nccl.h>
+#endif
 
 #if HAVE_MPI
 #include "../mpi/mpi_context.h"

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_THREADS
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
 #include "tensorflow/stream_executor/stream.h"
 #endif
 
@@ -75,7 +75,7 @@ common::Status ConvertStatus(const Status& status) {
   }
 }
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
 class TFReadyEvent : public common::ReadyEvent {
 public:
   TFReadyEvent(DeviceContext* device_context);
@@ -126,7 +126,7 @@ private:
   OpKernelContext* context_ = nullptr;
 };
 
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
 TFReadyEvent::TFReadyEvent(DeviceContext* device_context) {
   auto executor = device_context->stream()->parent();
   auto ready_event = new perftools::gputools::Event(executor);
@@ -151,7 +151,7 @@ TFPersistentBuffer::TFPersistentBuffer(OpKernelContext* context, int64_t size) {
   if (!status.ok()) {
     throw status;
   }
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
   // On GPU allocation is asynchronous, we need to wait for it to
   // complete.
   auto device_context = context->op_device_context();
@@ -237,7 +237,7 @@ TFOpContext::AllocateOutput(common::TensorShape shape,
   if (status.ok()) {
     *tensor = std::make_shared<TFTensor>(*tf_tensor);
   }
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
   // On GPU allocation is asynchronous, we need to wait for it to
   // complete.
   auto device_context = context_->op_device_context();
@@ -273,7 +273,7 @@ int GetDeviceID(OpKernelContext* context) {
 // On GPU this event will signal that data is ready, and tensors are
 // allocated.
 common::ReadyEvent* RecordReadyEvent(OpKernelContext* context) {
-#if HAVE_CUDA
+#if HAVE_CUDA || HAVE_ROCM
   auto device_context = context->op_device_context();
   if (device_context != nullptr) {
     return new TFReadyEvent(device_context);

--- a/setup.py
+++ b/setup.py
@@ -431,7 +431,7 @@ def get_rocm_dirs(build_ext, cpp_flags):
     rocm_libs = ['hip_hcc']
     rocm_macros = [('__HIP_PLATFORM_HCC__',1)]
 
-    rocm_path = os.environ.get('HOROVOD_ROCM_PATH', '/opt/rocm')
+    rocm_path = os.environ.get('HOROVOD_ROCM_HOME', '/opt/rocm')
     rocm_include_dirs += [
             '%s/include' % rocm_path,
             '%s/hcc/include' % rocm_path,
@@ -454,7 +454,7 @@ def get_rocm_dirs(build_ext, cpp_flags):
     except (CompileError, LinkError):
         raise DistutilsPlatformError(
             'HIP library and/or ROCm header files not found (see error above).\n'
-            'Please specify correct ROCm location with the HOROVOD_ROCM_PATH environment variable')
+            'Please specify correct ROCm location with the HOROVOD_ROCM_HOME environment variable')
 
     return rocm_include_dirs, rocm_lib_dirs, rocm_macros
 
@@ -477,7 +477,7 @@ def get_nccl_vals(build_ext, cuda_include_dirs, cuda_lib_dirs, cuda_macros, cpp_
     if nccl_lib_dir:
         nccl_lib_dirs += [nccl_lib_dir]
 
-    nccl_link_mode = os.environ.get('HOROVOD_NCCL_LINK', have_rocm and 'SHARED' or 'STATIC')
+    nccl_link_mode = os.environ.get('HOROVOD_NCCL_LINK', 'SHARED' if have_rocm else 'STATIC')
     if nccl_link_mode.upper() == 'SHARED':
         if have_rocm:
             nccl_libs += ['rccl']
@@ -503,7 +503,7 @@ def get_nccl_vals(build_ext, cuda_include_dirs, cuda_lib_dirs, cuda_macros, cpp_
                 ncclUniqueId nccl_id;
                 ncclGetUniqueId(&nccl_id);
             }
-            '''%(have_rocm and 'rccl.h' or 'nccl.h')))
+            '''%('rccl.h' if have_rocm else 'nccl.h')))
     except (CompileError, LinkError):
         raise DistutilsPlatformError(
             'NCCL 2.0 library or its later version was not found (see error above).\n'


### PR DESCRIPTION
This adds appropriate hooks to setup.py and swaps CUDA APIs for HIP APIs via the preprocessor at build time.  Currently only supports TensorFlow build target.  A successful ROCm build uses the following environment variables
```
export HOROVOD_WITHOUT_MXNET=1
export HOROVOD_WITHOUT_PYTORCH=1
export HOROVOD_GPU_ROCM=1
export HOROVOD_WITH_TENSORFLOW=1
export HOROVOD_ROCM_PATH=/opt/rocm
export HOROVOD_GPU_ALLREDUCE=NCCL
```