### PR TITLE
Makes github check summary and readme sync.

### DIFF
--- a/.github/workflows/docs-summary.yml
+++ b/.github/workflows/docs-summary.yml
@@ -17,10 +17,12 @@ jobs:
         then
           echo
           echo "Unexpected differences are:"
-          diff docs/summary.rst.as-readme --label README.rst docs/summary.rst
+          diff docs/summary.rst.as-readme --label README.rst docs/summary.rst || true
 
           echo
           echo "Use the following as docs/summary.rst.patch to accept those changes:"
-          diff docs/README.rst --label README.rst docs/summary.rst
+          diff docs/README.rst --label README.rst docs/summary.rst || true
+
+          false
         fi
 

--- a/.github/workflows/docs-summary.yml
+++ b/.github/workflows/docs-summary.yml
@@ -1,0 +1,26 @@
+name: Docs Summary Sync
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Diffing README.rst with docs/summary.rst
+      run: |
+        sed -e "s/docs\///g" README.rst > docs/README.rst
+        patch --quiet -p0 docs/README.rst docs/summary.rst.patch -o docs/summary.rst.as-readme
+        if ! diff -q docs/summary.rst.as-readme --label README.rst docs/summary.rst
+        then
+          echo
+          echo "Unexpected differences are:"
+          diff docs/summary.rst.as-readme --label README.rst docs/summary.rst
+
+          echo
+          echo "Use the following as docs/summary.rst.patch to accept those changes:"
+          diff docs/README.rst --label README.rst docs/summary.rst
+        fi
+


### PR DESCRIPTION
Adds a github workflow that checks that `README.rst` and `summary.rst` are in sync.

This PR for some reason does not execute this workflow, but [PR #2](https://github.com/G-Research/horovod/pull/2) does. That check will succeed once #1538 is merged into master.

The check also allows for expected differences between `README.rst` and `docs/summary.rst`, provided in `docs/summary.rst.patch`.