### PR TITLE
Use thread pool for finalizer threads.

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -383,6 +383,9 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   nccl_context.nccl_comms.resize(state.num_nccl_streams);
 #endif
   cuda_context.streams.resize(state.num_nccl_streams);
+
+  // Create finalizer thread pool (one thread per stream)
+  cuda_context.finalizer_thread_pool.create(state.num_nccl_streams);
 #endif
 
   // Open the timeline file on coordinator.

--- a/horovod/common/ops/cuda_operations.h
+++ b/horovod/common/ops/cuda_operations.h
@@ -24,6 +24,7 @@
 #include <cuda_runtime.h>
 
 #include "collective_operations.h"
+#include "../thread_pool.h"
 
 namespace horovod {
 namespace common {
@@ -60,6 +61,9 @@ struct CUDAContext {
 
   void WaitForEvents(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
                      const std::vector<TensorTableEntry>& entries, Timeline& timeline);
+
+  // Thread pool for finalizer threads
+  ThreadPool finalizer_thread_pool;
 };
 
 class CUDAOpContext {

--- a/horovod/common/thread_pool.cc
+++ b/horovod/common/thread_pool.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "thread_pool.h"
+
+namespace horovod {
+namespace common {
+
+void ThreadPool::create(int num_threads) {
+  running_ = true;
+  threads_.resize(num_threads);
+  for (int i = 0; i < num_threads; ++i) {
+    threads_[i] = std::thread(&ThreadPool::loop, this);
+  }
+}
+
+ThreadPool::~ThreadPool() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  running_ = false;
+  cond_.notify_all();
+  lock.unlock();
+
+  for (auto& thread: threads_) {
+    thread.join();
+  }
+}
+
+void ThreadPool::execute(std::function<void(void)> f) {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    work_queue_.push(f);
+  }
+  cond_.notify_one();
+}
+
+void ThreadPool::loop() {
+  while (running_) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this] {return !(running_ && work_queue_.empty());});
+    if (!running_) break;
+
+    auto f = work_queue_.front();
+    work_queue_.pop();
+    lock.unlock();
+
+    f();
+  }
+}
+
+} // namespace common
+} // namespace horovod

--- a/horovod/common/thread_pool.h
+++ b/horovod/common/thread_pool.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HOROVOD_THREAD_POOL_H
+#define HOROVOD_THREAD_POOL_H
+
+#include <condition_variable>
+#include <functional>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace horovod {
+namespace common {
+class ThreadPool {
+  public:
+    ~ThreadPool();
+    void create(int num_threads);
+    void execute(std::function<void(void)> f);
+
+  private:
+    void loop();
+    bool running_;
+    std::queue<std::function<void(void)>> work_queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+    std::vector<std::thread> threads_;
+};
+
+} // namespace common
+} // namespace horovod
+
+#endif // HOROVOD_THREAD_POOL_H

--- a/setup.py
+++ b/setup.py
@@ -652,6 +652,7 @@ def get_common_options(build_ext):
                'horovod/common/parameter_manager.cc',
                'horovod/common/response_cache.cc',
                'horovod/common/stall_inspector.cc',
+               'horovod/common/thread_pool.cc',
                'horovod/common/timeline.cc',
                'horovod/common/tensor_queue.cc',
                'horovod/common/ops/collective_operations.cc',


### PR DESCRIPTION
Currently, Horovod creates a new thread to wait on CUDA events and trigger callbacks every time it performs an operation with NCCL. This PR adds a thread pool to reuse threads. 