### PR TITLE
Fixed GPU check to run lazily to prevent recursive subprocess creation

### DIFF
--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -98,12 +98,30 @@ def extension_available(ext_base_name, verbose=False):
         ext_base_name, available_fn, 'built', verbose) or False
 
 
+def _cache(f):
+    cache = dict()
+
+    def wrapper(*args, **kwargs):
+        key = (args, kwargs)
+
+        if key in cache:
+            return cache[key]
+        else:
+            retval = f(*args, **kwargs)
+            cache[key] = retval
+            return retval
+
+    return wrapper
+
+
+@_cache
 def gpu_available(ext_base_name, verbose=False):
     available_fn = lambda ext: ext._check_has_gpu()
     return _check_extension_lambda(
         ext_base_name, available_fn, 'running with GPU', verbose) or False
 
 
+@_cache
 def mpi_built(verbose=False):
     for ext_base_name in EXTENSIONS:
         built_fn = lambda ext: ext.mpi_built()
@@ -114,6 +132,7 @@ def mpi_built(verbose=False):
     return False
 
 
+@_cache
 def gloo_built(verbose=False):
     for ext_base_name in EXTENSIONS:
         built_fn = lambda ext: ext.gloo_built()
@@ -125,6 +144,7 @@ def gloo_built(verbose=False):
                        'Run again with --verbose for more details.')
 
 
+@_cache
 def nccl_built(verbose=False):
     for ext_base_name in EXTENSIONS:
         built_fn = lambda ext: ext.nccl_built()
@@ -136,6 +156,7 @@ def nccl_built(verbose=False):
                        'Run again with --verbose for more details.')
 
 
+@_cache
 def ddl_built(verbose=False):
     for ext_base_name in EXTENSIONS:
         built_fn = lambda ext: ext.ddl_built()
@@ -147,6 +168,7 @@ def ddl_built(verbose=False):
                        'Run again with --verbose for more details.')
 
 
+@_cache
 def mlsl_built(verbose=False):
     for ext_base_name in EXTENSIONS:
         built_fn = lambda ext: ext.mlsl_built()

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -102,7 +102,7 @@ def _cache(f):
     cache = dict()
 
     def wrapper(*args, **kwargs):
-        key = (args, kwargs)
+        key = (args, frozenset(kwargs.items()))
 
         if key in cache:
             return cache[key]

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -32,7 +32,6 @@ from horovod.tensorflow.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_b
 from horovod.tensorflow.mpi_ops import gloo_enabled, gloo_built
 from horovod.tensorflow.mpi_ops import nccl_built, ddl_built, mlsl_built
 from horovod.tensorflow.mpi_ops import Average, Sum, Adasum
-from horovod.tensorflow.mpi_ops import _check_has_gpu
 from horovod.tensorflow.mpi_ops import handle_average_backwards_compatibility, check_num_rank_power_of_2
 
 from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache
@@ -40,7 +39,7 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache
 import tensorflow as tf
 import warnings
 
-has_gpu = gpu_available('tensorflow')
+
 def allreduce(tensor, average=None, device_dense='', device_sparse='',
               compression=Compression.none, op=None):
     """Perform an allreduce on a tf.Tensor or tf.IndexedSlices.
@@ -75,9 +74,8 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
     if isinstance(tensor, tf.IndexedSlices):
         # TODO: Need to fix this to actuall call Adasum
         if op == Adasum:
-            raise NotImplementedError("The Adasum reduction does not currently support "
-                "sparse tensors. As a workaround please pass sparse_as_dense=True to "
-                "DistributedOptimizer")
+            raise NotImplementedError('The Adasum reduction does not currently support sparse tensors. As a '
+                                      'workaround please pass sparse_as_dense=True to DistributedOptimizer')
         with tf.device(device_sparse):
             # For IndexedSlices, do two allgathers instead of an allreduce.
             horovod_size = tf.cast(size(), tensor.values.dtype)
@@ -96,18 +94,20 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
             summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op)
             summed_tensor = compression.decompress(summed_tensor_compressed, ctx)
             if op == Adasum:
-                if ('CPU' not in tensor.device and has_gpu):
+                if 'CPU' not in tensor.device and gpu_available('tensorflow'):
                     if nccl_built():
                         if not is_homogeneous:
-                            raise NotImplementedError('Running GPU Adasum on heterogeneous cluster is not supported yet.')
+                            raise NotImplementedError(
+                                'Running GPU Adasum on heterogeneous cluster is not supported yet.')
                         elif not check_num_rank_power_of_2(int(size() / local_size())):
-                            raise NotImplementedError('Running GPU Adasum with non-power of 2 nodes is not supported yet.')
+                            raise NotImplementedError(
+                                'Running GPU Adasum with non-power of 2 nodes is not supported yet.')
                         horovod_local_size = tf.cast(local_size(), dtype=tensor.dtype)
                         new_tensor = summed_tensor / horovod_local_size
                     else:
-                        warnings.warn("Adasum reduction does not currently support "
-                            "GPU reduction using MPI. Tensors are copied to CPU memory instead."
-                            "To use Adasum for GPU reduction, please compile Horovod with HOROVOD_GPU_ALLREDUCE=NCCL.")
+                        warnings.warn('Adasum reduction does not currently support GPU reduction using MPI. Tensors '
+                                      'are copied to CPU memory instead. To use Adasum for GPU reduction, please '
+                                      'compile Horovod with HOROVOD_GPU_ALLREDUCE=NCCL.')
                         new_tensor = summed_tensor
                 else:
                     if not check_num_rank_power_of_2(size()):
@@ -405,6 +405,7 @@ if _LegacyOptimizer is not None:
         def variables(self, *args, **kwargs):
             """Calls this same method on the underlying optimizer."""
             return self._optimizer.variables(*args, **kwargs)
+
 
 def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='',
                          device_sparse='', compression=Compression.none,

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -26,7 +26,8 @@ from tensorflow.python.framework import load_library
 from tensorflow.python.framework import ops
 from tensorflow.python.platform import resource_loader
 
-from horovod.common.util import get_ext_suffix, get_average_backwards_compatibility_fun, num_rank_is_power_2
+from horovod.common.util import get_ext_suffix, get_average_backwards_compatibility_fun, gpu_available, \
+    num_rank_is_power_2
 from horovod.common.basics import HorovodBasics as _HorovodBasics
 from horovod.tensorflow.util import _executing_eagerly
 
@@ -76,11 +77,13 @@ handle_average_backwards_compatibility = get_average_backwards_compatibility_fun
 
 check_num_rank_power_of_2 = num_rank_is_power_2
 
+
 # This function will create a default device map which includes all visible devices.
 # Please run this function in a subprocess
 def _check_has_gpu():
-  import tensorflow as tf
-  return tf.test.is_gpu_available()
+    import tensorflow as tf
+    return tf.test.is_gpu_available()
+
 
 def _normalize_name(name):
     """Normalizes operation name to TensorFlow rules."""

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -30,10 +30,6 @@ except:
     check_extension('horovod.torch', 'HOROVOD_WITH_PYTORCH',
                     __file__, 'mpi_lib', '_mpi_lib')
 
-# Please run this function in a subprocess
-def _check_has_gpu():
-  import torch
-  return torch.cuda.is_available()
 
 from horovod.torch.compression import Compression
 from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allreduce_async_
@@ -50,6 +46,13 @@ from horovod.torch.mpi_ops import Average, Sum, Adasum
 
 import torch
 import collections
+
+
+# Please run this function in a subprocess
+def _check_has_gpu():
+    import torch
+    return torch.cuda.is_available()
+
 
 class _DistributedOptimizer(torch.optim.Optimizer):
     def __init__(self, params, named_parameters, compression,

--- a/test/test_adasum_tensorflow.py
+++ b/test/test_adasum_tensorflow.py
@@ -137,7 +137,7 @@ class MPITests(tf.test.TestCase):
         """Test on GPU using NCCL that the Adasum correctly computes 2D tensors."""
         hvd.init()
         # TODO support non-MPI Adasum operation
-        if not hvd.mpi_enabled() or not tf.test.is_gpu_available() or not hvd.nccl_built():
+        if not hvd.mpi_enabled() or not hvd.gpu_available('tensorflow') or not hvd.nccl_built():
             return
         rank = hvd.rank()
         rank_tensors = []

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -21,7 +21,7 @@ import os
 import unittest
 import warnings
 
-from horovod.common.util import extension_available, mpi_built, gloo_built
+from horovod.common.util import _cache, extension_available, mpi_built, gloo_built
 
 
 class CommonTests(unittest.TestCase):
@@ -68,3 +68,21 @@ class CommonTests(unittest.TestCase):
             self.assertTrue(available)
         except:
             self.assertFalse(available)
+
+    def test_cache(self):
+        """Test that caching of expensive functions only computes values once."""
+        state = {}
+
+        @_cache
+        def fn():
+            return state['key']
+
+        # Not yet cached
+        state['key'] = 1
+        value = fn()
+        assert value == 1
+
+        # Cached
+        state['key'] = 2
+        value = fn()
+        assert value == 1


### PR DESCRIPTION
Fixes #1564 and #1568

Running the GPU check during module import can result in errors of the following when only TensorFlow is installed:

```
AssertionError: daemonic processes are not allowed to have children
```

This change enforces that GPU checks are only performed when the `hvd.allreduce` call is made so Gloo / MPI checks can succeed.