### PR TITLE
Updated governance details and added members to the TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,38 @@ You can find Horovod Charter [here](https://wiki.lfai.foundation/download/attach
 
 ### Technical Steering Committee
 
-Horovod development is governed by Horovod Technical Steering Committee (TSC).
+Horovod development is governed by the Horovod Technical Steering Committee (TSC). The TSC consists of voting and
+non-voting members, in addition to a chairman responsible for running TSC meetings, setting the meeting agenda, and
+calling votes on proposals.
 
 Current voting members of the Horovod TSC:
-* Alex Sergeev (@alsrgv)
+* Alex Sergeev (@alsrgv) - Chairman
 * Travis Addair (@tgaddair)
 * Can Karakus (@karakusc)
 
-Horovod TSC publishes meeting notes via [mailing list](https://lists.lfai.foundation/g/horovod-tsc).
-This mailing list can also be utilized to reach out to the TSC.
+Current maintainers within the Horovod TSC:
+* Josh Romero (@romerojosh)
+* Yuxi Hu (@yuxihu)
+* Lin Yuan (@apeforest)
+* Jaliya Ekanayake (@jaliyae)
+* Todd Mytkowicz (@klipto)
+
+Non-voting members of the TSC ("maintainers") have commit access to the Horovod GitHub repository, and take part in the
+standing TSC meetings and mailing lists.
+
+The Horovod TSC meets monthly and publishes meeting notes via [mailing list](https://lists.lfai.foundation/g/horovod-tsc).
+This mailing list can also be utilized to reach out to the TSC.  Major decisions regarding the technical directions of
+the Horovod project will be brought before the TSC for discussion, with an accompanying proposal document termed an RFC
+(Request for Comments).
+
+Technical decisions made by the TSC should be unanimous, with each voting and non-voting member either agreeing to the
+proposal or abstaining for it to pass.  If consensus cannot be reached, then the proposal is to be put to a vote
+among the voting members of the TSC, at which point a majority of the voting TSC must agree to the proposal for it to
+pass.
+
+Decisions to add or change members of the TSC in either a voting or non-voting capacity are handled the same as other
+proposals (without an RFC): an attempt is made to reach a unanimous decision among the entire TSC, followed by a vote
+among the voting members if no consensus can be reached.
 
 ### Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Current voting members of the Horovod TSC:
 * Travis Addair (@tgaddair)
 * Can Karakus (@karakusc)
 
-Current maintainers within the Horovod TSC:
+Current non-voting members of the Horovod TSC:
 * Josh Romero (@romerojosh)
 * Yuxi Hu (@yuxihu)
 * Lin Yuan (@apeforest)
@@ -33,7 +33,7 @@ Current maintainers within the Horovod TSC:
 Non-voting members of the TSC ("maintainers") have commit access to the Horovod GitHub repository, and take part in the
 standing TSC meetings and mailing lists.
 
-The Horovod TSC meets monthly and publishes meeting notes via [mailing list](https://lists.lfai.foundation/g/horovod-tsc).
+The Horovod TSC meets monthly and publishes meeting notes via a [mailing list](https://lists.lfai.foundation/g/horovod-tsc).
 This mailing list can also be utilized to reach out to the TSC.  Major decisions regarding the technical directions of
 the Horovod project will be brought before the TSC for discussion, with an accompanying proposal document termed an RFC
 (Request for Comments).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,16 +19,18 @@ non-voting members, in addition to a chairman responsible for running TSC meetin
 calling votes on proposals.
 
 Current voting members of the Horovod TSC:
-* Alex Sergeev (@alsrgv) - Chairman
-* Travis Addair (@tgaddair)
+* Alex Sergeev (@alsrgv)
+* Travis Addair (@tgaddair) - Chairman
 * Can Karakus (@karakusc)
+* Josh Romero (@romerojosh)
+* Jaliya Ekanayake (@jaliyae)
 
 Current non-voting members of the Horovod TSC:
-* Josh Romero (@romerojosh)
 * Yuxi Hu (@yuxihu)
 * Lin Yuan (@apeforest)
-* Jaliya Ekanayake (@jaliyae)
 * Todd Mytkowicz (@klipto)
+* Emad Barsoum (@ebarsoum)
+* Kaarthik Sivashanmugam (@skaarthik)
 
 Non-voting members of the TSC ("maintainers") have commit access to the Horovod GitHub repository, and take part in the
 standing TSC meetings and mailing lists.


### PR DESCRIPTION
Changes to Horovod's governance:

- Added @romerojosh and @jaliyae as voting members of the TSC
- Added @ebarsoum and @skaarthik as non-voting members of the TSC
- Changed chairman of the TSC from @alsrgv to @tgaddair 
- Formalized TSC procedures and responsibilities of voting / non-voting members