### PR TITLE
Fix non-x86 build failures caused by #1485

### DIFF
--- a/horovod/common/ops/adasum/adasum.h
+++ b/horovod/common/ops/adasum/adasum.h
@@ -17,9 +17,12 @@
 #define HOROVOD_ADASUM_H
 
 #include <cstring>
-#include <emmintrin.h>
 #include <float.h>
+
+#if __AVX__ && __F16C__
+#include <emmintrin.h>
 #include <immintrin.h>
+#endif
 
 #include "../../common.h"
 #include "../../global_state.h"
@@ -101,10 +104,13 @@ protected:
                                               int count, double& dotProduct,
                                               double& anormsq, double& bnormsq,
                                               int layerid) {
+#if __AVX__ && __F16C__
     if (horovod_datatype == DataType::HOROVOD_FLOAT16) {
       ComputeDotAndNormSqrdsfp16((uint16_t*)a, (uint16_t*)b, count, dotProduct,
                                  anormsq, bnormsq, layerid);
-    } else if (horovod_datatype == DataType::HOROVOD_FLOAT32) {
+    } else
+#endif
+    if (horovod_datatype == DataType::HOROVOD_FLOAT32) {
       ComputeDotAndNormSqrds((float*)a, (float*)b, count, dotProduct, anormsq,
                              bnormsq, layerid);
     } else if (horovod_datatype == DataType::HOROVOD_FLOAT64) {
@@ -119,9 +125,12 @@ protected:
                                  double acoeff, void* __restrict__ a,
                                  double bcoeff, void* __restrict__ b,
                                  int layerid) {
+#if __AVX__ && __F16C__
     if (horovod_datatype == DataType::HOROVOD_FLOAT16) {
       ScaledAddfp16(count, acoeff, (uint16_t*)a, bcoeff, (uint16_t*)b, layerid);
-    } else if (horovod_datatype == DataType::HOROVOD_FLOAT32) {
+    } else
+#endif
+    if (horovod_datatype == DataType::HOROVOD_FLOAT32) {
       ScaledAdd(count, acoeff, (float*)a, bcoeff, (float*)b, layerid);
     } else if (horovod_datatype == DataType::HOROVOD_FLOAT64) {
       ScaledAdd(count, acoeff, (double*)a, bcoeff, (double*)b, layerid);
@@ -415,6 +424,8 @@ private:
     }
   }
 
+
+#if __AVX__ && __F16C__
   inline void ComputeDotAndNormSqrdsfp16(const uint16_t* __restrict__ a,
                                          const uint16_t* __restrict__ b,
                                          int len, double& dotProduct,
@@ -534,6 +545,7 @@ private:
     if (7 < len)
       a[7] = (short)_mm_extract_epi16(r, 7);
   }
+#endif
 };
 
 } // namespace common

--- a/setup.py
+++ b/setup.py
@@ -100,31 +100,33 @@ def check_mx_version():
             'Your MXNet version is outdated.  Horovod requires mxnet>1.3.0')
 
 
-def check_avx_supported():
+def get_supported_instruction_set_flags(flags_to_check):
+    supported = []
     try:
         flags_output = subprocess.check_output(
             'gcc -march=native -E -v - </dev/null 2>&1 | grep cc1',
             shell=True, universal_newlines=True).strip()
         flags = shlex.split(flags_output)
-        return '+f16c' in flags and '+avx' in flags
+        supported = [x for x in flags_to_check if x.replace('-m', '+') in flags]
     except subprocess.CalledProcessError:
-        # Fallback to non-AVX if were not able to get flag information.
-        return False
+        # Fallback to no advanced instruction set flags if were not able to get flag information.
+        pass
+    return supported
 
 
 def get_cpp_flags(build_ext):
     last_err = None
-    default_flags = ['-std=c++11', '-fPIC', '-O2', '-Wall', '-mf16c', '-mavx', '-mfma', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
-    avx_flags = ['-mf16c', '-mavx'] if check_avx_supported() else []
+    default_flags = ['-std=c++11', '-fPIC', '-O2', '-Wall', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
+    avx_fma_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma'])
     if sys.platform == 'darwin':
         # Darwin most likely will have Clang, which has libc++.
-        flags_to_try = [default_flags + ['-stdlib=libc++'] + avx_flags,
-                        default_flags + avx_flags,
+        flags_to_try = [default_flags + ['-stdlib=libc++'] + avx_fma_flags,
+                        default_flags + avx_fma_flags,
                         default_flags + ['-stdlib=libc++'],
                         default_flags]
     else:
-        flags_to_try = [default_flags + avx_flags + ['-fopt-info-vec-optimized'],
-                        default_flags + ['-stdlib=libc++'] + avx_flags,
+        flags_to_try = [default_flags + avx_fma_flags,
+                        default_flags + ['-stdlib=libc++'] + avx_fma_flags,
                         default_flags,
                         default_flags + ['-stdlib=libc++']]
     for cpp_flags in flags_to_try:

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def get_supported_instruction_set_flags(flags_to_check):
             'gcc -march=native -E -v - </dev/null 2>&1 | grep cc1',
             shell=True, universal_newlines=True).strip()
         flags = shlex.split(flags_output)
-        supported = [x for x in flags_to_check if x.replace('-m', '+') in flags]
+        supported = [x for x in flags_to_check if x or x.replace('-m', '+') in flags]
     except subprocess.CalledProcessError:
         # Fallback to no advanced instruction set flags if were not able to get flag information.
         pass


### PR DESCRIPTION
Add extra checks for x86 compiler flags and x86 AVX headers/functions