### PR TITLE
Upgrade NCCL to 2.5.6, unpin CUDA docker digest

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -345,9 +345,9 @@ services:
     extends: test-gpu-base
     build:
       args:
-        CUDA_DOCKER_VERSION: 10.1-devel-ubuntu18.04@sha256:68efc9bbe07715c54ff30850aeb2e6f0d0b692af3c8dd40f13c0b179bfc0bc15
+        CUDA_DOCKER_VERSION: 10.1-devel-ubuntu18.04
         CUDNN_VERSION: 7.6.5.32-1+cuda10.1
-        NCCL_VERSION_OVERRIDE: 2.4.8-1+cuda10.1
+        NCCL_VERSION_OVERRIDE: 2.5.6-1+cuda10.1
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203


### PR DESCRIPTION
Issues fixed in https://github.com/NVIDIA/nccl/issues/269 and https://github.com/NVIDIA/nvidia-docker/issues/1143

Signed-off-by: Travis Addair <taddair@uber.com>