### PR TITLE
Correction to tensor size used for fusion in #1594

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -639,7 +639,7 @@ ResponseList Controller::FuseResponses(std::deque<Response>& responses) {
         response.response_type() == Response::ResponseType::ADASUM) {
       // Attempt to add more responses to this fused response.
 
-      tensor_size = response.tensor_sizes()[0];
+      tensor_size = response.tensor_sizes()[0] * GetTypeSize(response.tensor_type());
       std::deque<Response> skipped_responses;
       int64_t skipped_size = 0;
       while (!responses.empty()) {
@@ -648,7 +648,8 @@ ResponseList Controller::FuseResponses(std::deque<Response>& responses) {
 
         int64_t new_tensor_size = new_response.tensor_sizes().empty()
                                       ? 0
-                                      : new_response.tensor_sizes()[0];
+                                      : new_response.tensor_sizes()[0] *
+                                        GetTypeSize(new_response.tensor_type());
         if (response.response_type() == new_response.response_type() &&
             response.devices() == new_response.devices() &&
             response.tensor_type() == new_response.tensor_type() &&


### PR DESCRIPTION
The updated code in #1594 that was merged introduced another error in fusion. In particular, based on my suggestion to simplify, it was modified to use `response.tensor_sizes()` to compute sizes for fusion instead of generating new tensor entries. However, entries in `response.tensor_sizes()` are in elements, not bytes, causing the fusion logic for allreduce to be incorrect (may create fused responses larger than allocated buffer).  

~~I have reverted to the original version of #1594 to deal with this.~~
Multiplication of `response.tensor_sizes()` by `GetTypeSize()` corrects this.