### PR TITLE
Initial support for ROCm: rename CUDA to GPU et al, pimpl for GPU details

### DIFF
--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -87,10 +87,10 @@ struct HorovodGlobalState {
   // Number of responses that can be cached
   uint32_t cache_capacity = 1024;
 
-  // Number of CUDA streams to use
+  // Number of GPU streams to use
   int num_nccl_streams = 1;
 
-  // Index of current CUDA stream to use
+  // Index of current GPU stream to use
   int current_nccl_stream = 0;
 
   // A LibType indicating what framework we are using to perform CPU operations.

--- a/horovod/common/mpi/ddl_mpi_context_manager.cc
+++ b/horovod/common/mpi/ddl_mpi_context_manager.cc
@@ -20,7 +20,7 @@ namespace common {
 
 void DDL_MPIContextManager::EnvInitialize(int required) {
   // DDLInit calls MPI_Init
-  DDLAllreduce::DDLInit(&ddl_context_, &cuda_context_);
+  DDLAllreduce::DDLInit(&ddl_context_, &gpu_context_);
 }
 
 void DDL_MPIContextManager::EnvFinalize() {

--- a/horovod/common/mpi/ddl_mpi_context_manager.h
+++ b/horovod/common/mpi/ddl_mpi_context_manager.h
@@ -17,7 +17,7 @@
 #define HOROVOD_DDL_MPI_CONTEXT_MANAGER_H
 
 #include "mpi_context.h"
-#include "../ops/cuda_operations.h"
+#include "../ops/gpu_operations.h"
 #include "../ops/ddl_operations.h"
 
 namespace horovod {
@@ -27,9 +27,9 @@ namespace common {
 // (initialization and finalization).
 class DDL_MPIContextManager : public MPIContextManager {
 public:
-  // Constructor, store the reference of ddl context and cuda context.
-  DDL_MPIContextManager(DDLContext& ddl_context, CUDAContext& cuda_context)
-      : ddl_context_(ddl_context), cuda_context_(cuda_context){};
+  // Constructor, store the reference of ddl context and gpu context.
+  DDL_MPIContextManager(DDLContext& ddl_context, GPUContext& gpu_context)
+      : ddl_context_(ddl_context), gpu_context_(gpu_context){};
 
   // Initialize MPI environment with DDLInit().
   void EnvInitialize(int required) override;
@@ -38,7 +38,7 @@ public:
   void EnvFinalize() override;
 
   DDLContext& ddl_context_;
-  CUDAContext& cuda_context_;
+  GPUContext& gpu_context_;
 };
 
 } // namespace common

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -50,17 +50,17 @@
 #include "ops/adasum_mpi_operations.h"
 #endif
 
-#if HAVE_CUDA
-#include "ops/cuda_operations.h"
+#if HAVE_GPU
+#include "ops/gpu_operations.h"
 #if HAVE_MPI
-#include "ops/mpi_cuda_operations.h"
+#include "ops/mpi_gpu_operations.h"
 #endif
 #endif
 
 #if HAVE_NCCL
 #include "ops/nccl_operations.h"
 #if HAVE_MPI
-#include "ops/adasum_cuda_operations.h"
+#include "ops/adasum_gpu_operations.h"
 #endif
 #endif
 
@@ -86,8 +86,8 @@
  * whichever hardware-optimized communication libraries are enabled.
  *
  * The primary logic of the allreduce, allgather and broadcast currently
- * support in MPI, NCCL, CUDA, Gloo, oneCCL, DDL. The background thread which
- * facilitates controller operations is run in BackgroundThreadLoop().
+ * support in MPI, NCCL, CUDA/ROCm, Gloo, oneCCL, DDL. The background thread
+ * which facilitates controller operations is run in BackgroundThreadLoop().
  * The provided ops are:
  *      - HorovodAllreduce:
  *          Perform an allreduce on a Tensor, returning the sum
@@ -121,8 +121,8 @@ MPIContext mpi_context;
 GlooContext gloo_context;
 #endif
 
-#if HAVE_CUDA
-CUDAContext cuda_context;
+#if HAVE_GPU
+GPUContext gpu_context;
 #endif
 
 #if HAVE_NCCL
@@ -148,27 +148,27 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
   std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops;
   std::vector<std::shared_ptr<AllreduceOp>> adasum_ops;
 
-#if HAVE_MPI && HAVE_CUDA
+#if HAVE_MPI && HAVE_GPU
   if (mpi_context.IsEnabled()) {
 #if HOROVOD_GPU_ALLREDUCE == 'M'
     allreduce_ops.push_back(std::shared_ptr<AllreduceOp>(
-        new MPI_CUDAAllreduce(&mpi_context, &cuda_context, &state)));
+        new MPI_GPUAllreduce(&mpi_context, &gpu_context, &state)));
 
 #elif HAVE_NCCL && HOROVOD_GPU_ALLREDUCE == 'N'
-    adasum_ops.push_back(std::shared_ptr<AllreduceOp>(new AdasumCudaAllreduceOp(&mpi_context, &nccl_context, &cuda_context, &state)));
+    adasum_ops.push_back(std::shared_ptr<AllreduceOp>(new AdasumGpuAllreduceOp(&mpi_context, &nccl_context, &gpu_context, &state)));
 
     allreduce_ops.push_back(
         std::shared_ptr<AllreduceOp>(new NCCLHierarchicalAllreduce(
-            &nccl_context, &mpi_context, &cuda_context, &state)));
+            &nccl_context, &mpi_context, &gpu_context, &state)));
 
 #elif HAVE_DDL && HOROVOD_GPU_ALLREDUCE == 'D'
     allreduce_ops.push_back(std::shared_ptr<AllreduceOp>(
-        new DDLAllreduce(&ddl_context, &cuda_context, &state)));
+        new DDLAllreduce(&ddl_context, &gpu_context, &state)));
 #endif
 
 #if HOROVOD_GPU_ALLGATHER == 'M'
     allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
-        new MPI_CUDAAllgather(&mpi_context, &cuda_context, &state)));
+        new MPI_GPUAllgather(&mpi_context, &gpu_context, &state)));
 #endif
     allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
         new MPIHierarchicalAllgather(&mpi_context, &state)));
@@ -177,12 +177,12 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
 
 #if HAVE_NCCL && HOROVOD_GPU_ALLREDUCE == 'N'
   allreduce_ops.push_back(std::shared_ptr<AllreduceOp>(
-      new NCCLAllreduce(&nccl_context, &cuda_context, &state)));
+      new NCCLAllreduce(&nccl_context, &gpu_context, &state)));
 #endif
 
 #if HAVE_NCCL && HOROVOD_GPU_BROADCAST == 'N'
     broadcast_ops.push_back(
-        std::shared_ptr<BroadcastOp>(new NCCLBroadcast(&nccl_context, &cuda_context, &state)));
+        std::shared_ptr<BroadcastOp>(new NCCLBroadcast(&nccl_context, &gpu_context, &state)));
 #endif
 
 #if HAVE_GLOO
@@ -342,7 +342,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   // Initialize mpi context
 #if HAVE_DDL
   // If DDL is enabled, let DDL ops manage MPI environment.
-  auto mpi_ctx_manager = DDL_MPIContextManager(ddl_context, cuda_context);
+  auto mpi_ctx_manager = DDL_MPIContextManager(ddl_context, gpu_context);
 #else
   // Otherwise, let MPI ops be in charge.
   auto mpi_ctx_manager = MPIContextManager();
@@ -371,8 +371,8 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   int size = state.controller->GetSize();
   int local_size = state.controller->GetLocalSize();
 
-#if HAVE_CUDA
-  // Set number of CUDA streams to use
+#if HAVE_GPU
+  // Set number of GPU streams to use
   auto horovod_num_nccl_streams =
       std::getenv(HOROVOD_NUM_NCCL_STREAMS);
   if (horovod_num_nccl_streams != nullptr &&
@@ -383,10 +383,10 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
 #if HAVE_NCCL
   nccl_context.nccl_comms.resize(state.num_nccl_streams);
 #endif
-  cuda_context.streams.resize(state.num_nccl_streams);
+  gpu_context.streams.resize(state.num_nccl_streams);
 
   // Create finalizer thread pool (one thread per stream)
-  cuda_context.finalizer_thread_pool.create(state.num_nccl_streams);
+  gpu_context.finalizer_thread_pool.create(state.num_nccl_streams);
 #endif
 
   // Open the timeline file on coordinator.
@@ -520,8 +520,8 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
     cb(SHUT_DOWN_ERROR);
   }
 
-#if HAVE_CUDA
-  cuda_context.Finalize();
+#if HAVE_GPU
+  gpu_context.Finalize();
 #endif
 
 #if HAVE_MPI

--- a/horovod/common/ops/adasum_gpu_operations.cc
+++ b/horovod/common/ops/adasum_gpu_operations.cc
@@ -13,30 +13,30 @@
 // limitations under the License.
 // =============================================================================
 
-#include "adasum_cuda_operations.h"
+#include "adasum_gpu_operations.h"
 
 namespace horovod {
 namespace common {
 
-AdasumCudaAllreduceOp::AdasumCudaAllreduceOp(MPIContext* mpi_context,
-                                             NCCLContext* nccl_context,
-                                             CUDAContext* cuda_context,
-                                             HorovodGlobalState* global_state)
+AdasumGpuAllreduceOp::AdasumGpuAllreduceOp(MPIContext* mpi_context,
+                                           NCCLContext* nccl_context,
+                                           GPUContext* gpu_context,
+                                           HorovodGlobalState* global_state)
     : AdasumMPI(mpi_context, global_state),
-      NCCLAllreduce(nccl_context, cuda_context, global_state, Communicator::LOCAL) {
+      NCCLAllreduce(nccl_context, gpu_context, global_state, Communicator::LOCAL) {
   // Pre-allocate host buffer size equal to the fusion buffer length
   current_host_buffer_length =
       global_state->parameter_manager.TensorFusionThresholdBytes();
-  cuda_op_context_.host_buffer = (uint8_t*)malloc(current_host_buffer_length);
+  gpu_op_context_.host_buffer = (uint8_t*)malloc(current_host_buffer_length);
 }
 
-AdasumCudaAllreduceOp::~AdasumCudaAllreduceOp() {
-  if (cuda_op_context_.host_buffer != nullptr) {
-    free(cuda_op_context_.host_buffer);
+AdasumGpuAllreduceOp::~AdasumGpuAllreduceOp() {
+  if (gpu_op_context_.host_buffer != nullptr) {
+    free(gpu_op_context_.host_buffer);
   }
 }
-Status AdasumCudaAllreduceOp::Execute(std::vector<TensorTableEntry>& entries,
-                                      const Response& response) {
+Status AdasumGpuAllreduceOp::Execute(std::vector<TensorTableEntry>& entries,
+                                     const Response& response) {
   if (entries.empty()) {
     return Status::OK();
   }
@@ -48,14 +48,14 @@ Status AdasumCudaAllreduceOp::Execute(std::vector<TensorTableEntry>& entries,
   return NcclHierarchical(entries, response);
 }
 
-uint8_t* AdasumCudaAllreduceOp::GetHostBuffer(uint64_t buffer_length) {
-  return CheckBufferAndReallocate((uint8_t**)&cuda_op_context_.host_buffer,
+uint8_t* AdasumGpuAllreduceOp::GetHostBuffer(uint64_t buffer_length) {
+  return CheckBufferAndReallocate((uint8_t**)&gpu_op_context_.host_buffer,
                                   buffer_length, current_host_buffer_length);
 }
 
 Status
-AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
-                                        const Response& response) {
+AdasumGpuAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
+                                       const Response& response) {
   auto& first_entry = entries[0];
 
   // Determine GPU IDs of the devices participating in this communicator.
@@ -65,9 +65,9 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
   for (size_t rank : global_state_->controller->GetLocalCommRanks()) {
     nccl_device_map.push_back(response.devices()[rank]);
   }
-  cuda_op_context_.InitCUDA(entries);
+  gpu_op_context_.InitGPU(entries);
   nccl_op_context_.InitNCCLComm(entries, nccl_device_map);
-  cuda_op_context_.InitCUDAQueue(entries, response);
+  gpu_op_context_.InitGPUQueue(entries, response);
   const void* fused_input_data;
   void* buffer_data;
   size_t buffer_len;
@@ -76,9 +76,9 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
   if (entries.size() > 1) {
     MemcpyInFusionBuffer(entries, fused_input_data, buffer_data, buffer_len);
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue,
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue,
                                  MEMCPY_IN_FUSION_BUFFER,
-                                 *cuda_op_context_.stream);
+                                 *gpu_op_context_.stream);
     }
   } else {
     fused_input_data = first_entry.tensor->data();
@@ -157,12 +157,12 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     auto nccl_result = ncclReduceScatter(
         fused_input_data, buffer_data_at_rank_offset,
         (size_t)num_elements_per_rank, GetNCCLDataType(first_entry.tensor),
-        ncclSum, *nccl_op_context_.nccl_comm_, *cuda_op_context_.stream);
+        ncclSum, *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream);
 
     nccl_context_->ErrorCheck("ncclReduceScatter", nccl_result);
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue,
-                                 NCCL_REDUCESCATTER, *cuda_op_context_.stream);
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue,
+                                 NCCL_REDUCESCATTER, *gpu_op_context_.stream);
     }
   }
 
@@ -172,12 +172,12 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     auto nccl_result = ncclReduce(
         fused_input_data_remainder, buffer_data_remainder,
         (size_t)num_elements_remaining, GetNCCLDataType(first_entry.tensor),
-        ncclSum, root_rank, *nccl_op_context_.nccl_comm_, *cuda_op_context_.stream);
+        ncclSum, root_rank, *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream);
 
     nccl_context_->ErrorCheck("ncclReduce", nccl_result);
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue, NCCL_REDUCE,
-                                 *cuda_op_context_.stream);
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_REDUCE,
+                                 *gpu_op_context_.stream);
     }
   }
 
@@ -186,7 +186,7 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     // a buffer is not safe since the tensor can be arbitrarily large.
     host_buffer = GetHostBuffer((uint64_t)total_buffer_len);
     // Synchronize.
-    cuda_context_->WaitForEvents(cuda_op_context_.event_queue, entries,
+    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries,
                                  timeline);
 
     // According to https://docs.nvidia.com/cuda/cuda-runtime-api/
@@ -194,11 +194,8 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     // cudaMemcpyAsync is synchronous with respect to the host, so we
     // memcpy (effectively) synchronously to generate an accurate timeline
     timeline.ActivityStartAll(entries, MEMCPY_IN_HOST_BUFFER);
-    cuda_context_->ErrorCheck(
-        "cudaMemcpyAsync",
-        cudaMemcpyAsync(host_buffer, buffer_data_at_rank_offset,
-                        total_buffer_len, cudaMemcpyDeviceToHost,
-                        *cuda_op_context_.stream));
+    gpu_context_->MemcpyAsyncD2H(host_buffer, buffer_data_at_rank_offset,
+                                 total_buffer_len, *gpu_op_context_.stream);
 
     timeline.ActivityEndAll(entries);
 
@@ -259,11 +256,9 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     timeline.ActivityEndAll(entries);
 
     timeline.ActivityStartAll(entries, MEMCPY_OUT_HOST_BUFFER);
-    cuda_context_->ErrorCheck("cudaMemcpyAsync",
-                              cudaMemcpyAsync(buffer_data_at_rank_offset,
-                                              host_buffer, total_buffer_len,
-                                              cudaMemcpyHostToDevice,
-                                              *cuda_op_context_.stream));
+    gpu_context_->MemcpyAsyncH2D(buffer_data_at_rank_offset,
+                                 host_buffer, total_buffer_len,
+                                 *gpu_op_context_.stream);
     timeline.ActivityEndAll(entries);
   }
 
@@ -272,10 +267,10 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
         "ncclAllGather", ncclAllGather(buffer_data_at_rank_offset, buffer_data,
                                        (size_t)num_elements_per_rank,
                                        GetNCCLDataType(first_entry.tensor),
-                                       *nccl_op_context_.nccl_comm_, *cuda_op_context_.stream));
+                                       *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream));
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue, NCCL_ALLGATHER,
-                                 *cuda_op_context_.stream);
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_ALLGATHER,
+                                *gpu_op_context_.stream);
     }
   }
   if (num_elements_remaining > 0) {
@@ -283,10 +278,10 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
         "ncclBcast",
         ncclBcast(buffer_data_remainder, (size_t)num_elements_remaining,
                   GetNCCLDataType(first_entry.tensor), root_rank, *nccl_op_context_.nccl_comm_,
-                  *cuda_op_context_.stream));
+                  *gpu_op_context_.stream));
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue, NCCL_BCAST,
-                                 *cuda_op_context_.stream);
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST,
+                                *gpu_op_context_.stream);
     }
   }
 
@@ -295,16 +290,16 @@ AdasumCudaAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     MemcpyOutFusionBuffer(buffer_data, entries);
 
     if (global_state_->timeline.Initialized()) {
-      cuda_context_->RecordEvent(cuda_op_context_.event_queue,
-                                 MEMCPY_OUT_FUSION_BUFFER,
-                                 *cuda_op_context_.stream);
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue,
+                                MEMCPY_OUT_FUSION_BUFFER,
+                                *gpu_op_context_.stream);
     }
   }
 
-  return cuda_op_context_.FinalizeCUDAQueue(entries, false);
+  return gpu_op_context_.FinalizeGPUQueue(entries, false);
 }
 
-bool AdasumCudaAllreduceOp::Enabled(
+bool AdasumGpuAllreduceOp::Enabled(
     const ParameterManager& param_manager,
     const std::vector<TensorTableEntry>& entries,
     const Response& response) const {

--- a/horovod/common/ops/adasum_gpu_operations.h
+++ b/horovod/common/ops/adasum_gpu_operations.h
@@ -13,8 +13,8 @@
 // limitations under the License.
 // =============================================================================
 
-#ifndef HOROVOD_ADASUM_CUDA_OPERATIONS_H
-#define HOROVOD_ADASUM_CUDA_OPERATIONS_H
+#ifndef HOROVOD_ADASUM_GPU_OPERATIONS_H
+#define HOROVOD_ADASUM_GPU_OPERATIONS_H
 
 #include "adasum/adasum_mpi.h"
 #include "nccl_operations.h"
@@ -23,13 +23,13 @@
 namespace horovod {
 namespace common {
 
-class AdasumCudaAllreduceOp : public AdasumMPI, public NCCLAllreduce {
+class AdasumGpuAllreduceOp : public AdasumMPI, public NCCLAllreduce {
 public:
-  AdasumCudaAllreduceOp(MPIContext* mpi_context, NCCLContext* nccl_context,
-                        CUDAContext* cuda_context,
-                        HorovodGlobalState* global_state);
+  AdasumGpuAllreduceOp(MPIContext* mpi_context, NCCLContext* nccl_context,
+                       GPUContext* gpu_context,
+                       HorovodGlobalState* global_state);
 
-  ~AdasumCudaAllreduceOp();
+  ~AdasumGpuAllreduceOp();
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -50,4 +50,4 @@ private:
 };
 } // namespace common
 } // namespace horovod
-#endif // HOROVOD_ADASUM_CUDA_OPERATIONS_H
+#endif // HOROVOD_ADASUM_GPU_OPERATIONS_H

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -14,224 +14,125 @@
 // limitations under the License.
 // =============================================================================
 
-#include "cuda_operations.h"
+#include "gpu_operations.h"
 
 #include <thread>
 
 namespace horovod {
 namespace common {
 
-void CUDAContext::Finalize() {
-  finalizer_thread_pool.reset();
-}
-
-cudaError_t CUDAContext::GetCudaEvent(cudaEvent_t* event) {
-  int device;
-  auto status = cudaGetDevice(&device);
-  if (status != cudaSuccess) {
-    return status;
-  }
-
-  auto& mutex = cuda_events_mutex;
-  {
-    std::lock_guard<std::mutex> guard(mutex);
-    auto& queue = cuda_events[device];
-    if (!queue.empty()) {
-      *event = queue.front();
-      queue.pop();
-      return cudaSuccess;
-    }
-  }
-
-  return cudaEventCreateWithFlags(event, cudaEventBlockingSync |
-                                         cudaEventDisableTiming);
-}
-
-cudaError_t CUDAContext::ReleaseCudaEvent(cudaEvent_t event) {
-  int device;
-  auto status = cudaGetDevice(&device);
-  if (status != cudaSuccess) {
-    return status;
-  }
-
-  auto& mutex = cuda_events_mutex;
-  {
-    std::lock_guard<std::mutex> guard(mutex);
-    auto& queue = cuda_events[device];
-    queue.push(event);
-  }
-
-  return cudaSuccess;
-}
-
-void CUDAContext::ErrorCheck(std::string op_name, cudaError_t cuda_result) {
-  if (cuda_result != cudaSuccess) {
-    throw std::logic_error(std::string(op_name) + " failed: " + cudaGetErrorString(cuda_result));
-  }
-}
-
-void CUDAContext::RecordEvent(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
-                              std::string name, cudaStream_t& stream) {
-  cudaEvent_t event;
-  ErrorCheck("GetCudaEvent", GetCudaEvent(&event));
-  ErrorCheck("cudaEventRecord", cudaEventRecord(event, stream));
-  event_queue.emplace(name, event);
-}
-
-void CUDAContext::WaitForEvents(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
-                                const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
-  while (!event_queue.empty()) {
-    std::string name;
-    cudaEvent_t event;
-    std::tie(name, event) = event_queue.front();
-    event_queue.pop();
-    if (name != "") {
-      timeline.ActivityStartAll(entries, name);
-    }
-    ErrorCheck("cudaEventSynchronize", cudaEventSynchronize(event));
-    if (name != "") {
-      timeline.ActivityEndAll(entries);
-    }
-    ErrorCheck("ReleaseCudaEvent", ReleaseCudaEvent(event));
-  }
-}
-
-CUDAOpContext::CUDAOpContext(struct CUDAContext* context,
-                             HorovodGlobalState* global_state)
-    : cuda_context_(context), global_state_(global_state) {}
-
-void CUDAOpContext::InitCUDA(const std::vector<TensorTableEntry>& entries) {
-  auto& first_entry = entries[0];
-  cuda_context_->ErrorCheck("cudaSetDevice", cudaSetDevice(first_entry.device));
-
-  // Ensure stream is in the map before executing reduction.
-  cudaStream_t& stream = cuda_context_->streams[global_state_->current_nccl_stream][first_entry.device];
-  if (stream == nullptr) {
-    int greatest_priority;
-    cuda_context_->ErrorCheck("cudaDeviceGetStreamPriorityRange",
-                              cudaDeviceGetStreamPriorityRange(NULL, &greatest_priority));
-    cuda_context_->ErrorCheck("cudaStreamCreateWithPriority",
-                              cudaStreamCreateWithPriority(&stream, cudaStreamNonBlocking, greatest_priority));
-  }
-}
-
-void CUDAOpContext::InitCUDAQueue(const std::vector<TensorTableEntry>& entries, const Response& response) {
-  event_queue = std::queue<std::pair<std::string, cudaEvent_t>>();
-  stream = &cuda_context_->streams[global_state_->current_nccl_stream][entries[0].device];
-
-  if (global_state_->timeline.Initialized()) {
-    cuda_context_->RecordEvent(event_queue, QUEUE, *stream);
-  }
-}
-
-Status CUDAOpContext::FinalizeCUDAQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer /*= true*/) {
-  // Use completion marker via event because it's faster than
-  // blocking cudaStreamSynchronize() in this thread.
-  cuda_context_->RecordEvent(event_queue, "", *stream);
-
-  auto& first_entry = entries[0];
-  void* cpu_buffer = host_buffer;
-  auto& evt_queue = event_queue;
-  auto& timeline = global_state_->timeline;
-  auto& cuda_context = cuda_context_;
-
-  // Claim a std::shared_ptr to the fusion buffer to prevent its memory from being reclaimed
-  // during finalization.
-  auto fusion_buffer = global_state_->fusion_buffer.GetBuffer(
-      first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
-
-  cuda_context_->finalizer_thread_pool.execute([entries, first_entry, cpu_buffer, fusion_buffer, free_host_buffer,
-                                                evt_queue, &timeline, &cuda_context]() mutable {
-    auto cuda_result = cudaSetDevice(first_entry.device);
-    cuda_context->ErrorCheck("cudaSetDevice", cuda_result);
-
-    cuda_context->WaitForEvents(evt_queue, entries, timeline);
-    if (free_host_buffer && cpu_buffer != nullptr) {
-      free(cpu_buffer);
+class GPUContext::impl {
+public:
+  cudaError_t GetGpuEvent(cudaEvent_t* event) {
+    int device;
+    auto status = cudaGetDevice(&device);
+    if (status != cudaSuccess) {
+      return status;
     }
 
-    for (auto& e : entries) {
-      timeline.End(e.tensor_name, e.output);
-      // Callback can be null if the rank sent Join request.
-      if (e.callback != nullptr) {
-        e.callback(Status::OK());
+    auto& mutex = cuda_events_mutex;
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      auto& queue = cuda_events[device];
+      if (!queue.empty()) {
+        *event = queue.front();
+        queue.pop();
+        return cudaSuccess;
       }
     }
-  });
 
-  // Update current stream
-  global_state_->current_nccl_stream = (global_state_->current_nccl_stream + 1) %
-                                  global_state_->num_nccl_streams;
+    return cudaEventCreateWithFlags(event, cudaEventBlockingSync | cudaEventDisableTiming);
+  }
 
-  return Status::InProgress();
-}
+  cudaError_t ReleaseGpuEvent(cudaEvent_t event) {
+    int device;
+    auto status = cudaGetDevice(&device);
+    if (status != cudaSuccess) {
+      return status;
+    }
 
-CUDAAllreduce::CUDAAllreduce(CUDAContext* context,
-                             HorovodGlobalState* global_state)
-    : AllreduceOp(global_state), cuda_context_(context), cuda_op_context_(context, global_state) {}
+    auto& mutex = cuda_events_mutex;
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      auto& queue = cuda_events[device];
+      queue.push(event);
+    }
 
-bool CUDAAllreduce::Enabled(const ParameterManager& param_manager,
-                            const std::vector<TensorTableEntry>& entries,
-                            const Response& response) const {
-  return entries[0].device != CPU_DEVICE_ID;
-}
+    return cudaSuccess;
+  }
 
-void CUDAAllreduce::MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
-                                              const TensorTableEntry& e, void* buffer_data_at_offset) {
-  auto& first_entry = entries[0];
-  auto cuda_result = cudaMemcpyAsync(buffer_data_at_offset, e.tensor->data(),
-                                     (size_t) e.tensor->size(), cudaMemcpyDeviceToDevice,
-                                     cuda_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
-  cuda_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
-}
+  void ErrorCheck(std::string op_name, cudaError_t cuda_result) {
+    if (cuda_result != cudaSuccess) {
+      throw std::logic_error(std::string(op_name) + " failed: " + cudaGetErrorString(cuda_result));
+    }
+  }
 
-void CUDAAllreduce::MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
-                                               const void* buffer_data_at_offset, TensorTableEntry& e) {
-  auto& first_entry = entries[0];
-  auto cuda_result = cudaMemcpyAsync((void*) e.output->data(), buffer_data_at_offset,
-                                     (size_t) e.tensor->size(), cudaMemcpyDeviceToDevice,
-                                     cuda_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
-  cuda_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
-}
+  void RecordEvent(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue, std::string name, cudaStream_t& stream) {
+    cudaEvent_t event;
+    ErrorCheck("GetGpuEvent", GetGpuEvent(&event));
+    ErrorCheck("cudaEventRecord", cudaEventRecord(event, stream));
+    event_queue.emplace(name, event);
+  }
 
-CUDAAllgather::CUDAAllgather(CUDAContext* context,
-                             HorovodGlobalState* global_state)
-    : AllgatherOp(global_state), cuda_context_(context), cuda_op_context_(context, global_state) {}
+  void WaitForEvents(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
+      const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
+    while (!event_queue.empty()) {
+      std::string name;
+      cudaEvent_t event;
+      std::tie(name, event) = event_queue.front();
+      event_queue.pop();
+      if (name != "") {
+        timeline.ActivityStartAll(entries, name);
+      }
+      ErrorCheck("cudaEventSynchronize", cudaEventSynchronize(event));
+      if (name != "") {
+        timeline.ActivityEndAll(entries);
+      }
+      ErrorCheck("ReleaseGpuEvent", ReleaseGpuEvent(event));
+    }
+  }
 
-bool CUDAAllgather::Enabled(const ParameterManager& param_manager,
-                            const std::vector<TensorTableEntry>& entries,
-                            const Response& response) const {
-  return entries[0].device != CPU_DEVICE_ID;
-}
+  void StreamCreate(cudaStream_t *stream) {
+    int greatest_priority;
+    ErrorCheck("cudaDeviceGetStreamPriorityRange",
+        cudaDeviceGetStreamPriorityRange(NULL, &greatest_priority));
+    ErrorCheck("cudaStreamCreateWithPriority",
+        cudaStreamCreateWithPriority(stream, cudaStreamNonBlocking, greatest_priority));
+  }
 
-void CUDAAllgather::MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
-                                              const TensorTableEntry& e, void* buffer_data_at_offset) {
-  auto& first_entry = entries[0];
-  auto cuda_result = cudaMemcpyAsync(buffer_data_at_offset, e.tensor->data(),
-                                     (size_t) e.tensor->size(), cudaMemcpyDeviceToDevice,
-                                     cuda_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
-  cuda_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
-}
+  void StreamSynchronize(cudaStream_t stream) {
+    ErrorCheck("cudaStreamSynchronize", cudaStreamSynchronize(stream));
+  }
 
-void CUDAAllgather::MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
-                                               const void* buffer_data_at_offset, TensorTableEntry& e,
-                                               int64_t entry_offset, size_t entry_size) {
-  auto& first_entry = entries[0];
-  auto cuda_result = cudaMemcpyAsync((int8_t*)e.output->data() + entry_offset, buffer_data_at_offset,
-                                     entry_size, cudaMemcpyDeviceToDevice,
-                                     cuda_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
-  cuda_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
-}
+  int GetDevice() {
+    int device;
+    ErrorCheck("cudaGetDevice", cudaGetDevice(&device));
+    return device;
+  }
 
-CUDABroadcast::CUDABroadcast(CUDAContext* context,
-                             HorovodGlobalState* global_state)
-    : BroadcastOp(global_state), cuda_context_(context), cuda_op_context_(context, global_state) {}
+  void SetDevice(int device) {
+    ErrorCheck("cudaSetDevice", cudaSetDevice(device));
+  }
 
-bool CUDABroadcast::Enabled(const ParameterManager& param_manager,
-                            const std::vector<TensorTableEntry>& entries,
-                            const Response& response) const {
-  return entries[0].device != CPU_DEVICE_ID;
-}
+  void MemcpyAsyncD2D(void* dst, const void* src, size_t count, cudaStream_t stream) {
+    ErrorCheck("cudaMemcpyAsync", cudaMemcpyAsync(dst, src, count, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  void MemcpyAsyncH2D(void* dst, const void* src, size_t count, cudaStream_t stream) {
+    ErrorCheck("cudaMemcpyAsync", cudaMemcpyAsync(dst, src, count, cudaMemcpyHostToDevice, stream));
+  }
+
+  void MemcpyAsyncD2H(void* dst, const void* src, size_t count, cudaStream_t stream) {
+    ErrorCheck("cudaMemcpyAsync", cudaMemcpyAsync(dst, src, count, cudaMemcpyDeviceToHost, stream));
+  }
+
+private:
+  // We reuse CUDA events as it appears that their creation carries non-zero cost.
+  std::unordered_map<int, std::queue<cudaEvent_t>> cuda_events;
+  std::mutex cuda_events_mutex;
+};
+
+#include "gpu_context_impl.cc"
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/ddl_operations.h
+++ b/horovod/common/ops/ddl_operations.h
@@ -19,7 +19,7 @@
 
 #include <ddl.hpp>
 
-#include "cuda_operations.h"
+#include "gpu_operations.h"
 
 namespace horovod {
 namespace common {
@@ -28,15 +28,15 @@ struct DDLContext {
   int32_t ddl_local_device_id = 0;
 };
 
-class DDLAllreduce : public CUDAAllreduce {
+class DDLAllreduce : public GPUAllreduce {
 public:
   DDLAllreduce(DDLContext* ddl_context,
-               CUDAContext* cuda_context,
+               GPUContext* gpu_context,
                HorovodGlobalState* global_state);
 
   Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
 
-  static void DDLInit(DDLContext* ddl_context, CUDAContext* cuda_context);
+  static void DDLInit(DDLContext* ddl_context, GPUContext* gpu_context);
 
 protected:
   DDLContext* ddl_context_;

--- a/horovod/common/ops/gpu_context_impl.cc
+++ b/horovod/common/ops/gpu_context_impl.cc
@@ -1,0 +1,47 @@
+GPUContext::GPUContext() : pimpl{new impl} {}
+GPUContext::~GPUContext() = default;
+
+void GPUContext::Finalize() {
+  finalizer_thread_pool.reset();
+}
+
+void GPUContext::ErrorCheck(std::string op_name, gpuError_t gpu_result) {
+  pimpl->ErrorCheck(op_name, gpu_result);
+}
+
+void GPUContext::RecordEvent(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, std::string name, gpuStream_t& stream) {
+  pimpl->RecordEvent(event_queue, name, stream);
+}
+
+void GPUContext::WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
+  pimpl->WaitForEvents(event_queue, entries, timeline);
+}
+
+void GPUContext::StreamCreate(gpuStream_t *stream) {
+  pimpl->StreamCreate(stream);
+}
+
+void GPUContext::StreamSynchronize(gpuStream_t stream) {
+  pimpl->StreamSynchronize(stream);
+}
+
+int GPUContext::GetDevice() {
+  return pimpl->GetDevice();
+}
+
+void GPUContext::SetDevice(int device) {
+  pimpl->SetDevice(device);
+}
+
+void GPUContext::MemcpyAsyncD2D(void* dst, const void* src, size_t count, gpuStream_t stream) {
+  pimpl->MemcpyAsyncD2D(dst, src, count, stream);
+}
+
+void GPUContext::MemcpyAsyncH2D(void* dst, const void* src, size_t count, gpuStream_t stream) {
+  pimpl->MemcpyAsyncH2D(dst, src, count, stream);
+}
+
+void GPUContext::MemcpyAsyncD2H(void* dst, const void* src, size_t count, gpuStream_t stream) {
+  pimpl->MemcpyAsyncD2H(dst, src, count, stream);
+}
+

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -1,0 +1,146 @@
+// Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+// Modifications copyright (C) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "gpu_operations.h"
+
+#include <thread>
+
+namespace horovod {
+namespace common {
+
+GPUOpContext::GPUOpContext(GPUContext* context, HorovodGlobalState* global_state)
+    : gpu_context_(context), global_state_(global_state) {}
+
+void GPUOpContext::InitGPU(const std::vector<TensorTableEntry>& entries) {
+  auto& first_entry = entries[0];
+  gpu_context_->SetDevice(first_entry.device);
+
+  // Ensure stream is in the map before executing reduction.
+  gpuStream_t& stream = gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device];
+  if (stream == nullptr) {
+    gpu_context_->StreamCreate(&stream);
+  }
+}
+
+void GPUOpContext::InitGPUQueue(const std::vector<TensorTableEntry>& entries, const Response& response) {
+  event_queue = std::queue<std::pair<std::string, gpuEvent_t>>();
+  stream = &gpu_context_->streams[global_state_->current_nccl_stream][entries[0].device];
+
+  if (global_state_->timeline.Initialized()) {
+    gpu_context_->RecordEvent(event_queue, QUEUE, *stream);
+  }
+}
+
+Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer /*= true*/) {
+  // Use completion marker via event because it's faster than
+  // blocking gpuStreamSynchronize() in this thread.
+  gpu_context_->RecordEvent(event_queue, "", *stream);
+
+  auto& first_entry = entries[0];
+  void* cpu_buffer = host_buffer;
+  auto& evt_queue = event_queue;
+  auto& timeline = global_state_->timeline;
+  auto& gpu_context = gpu_context_;
+
+  // Claim a std::shared_ptr to the fusion buffer to prevent its memory from being reclaimed
+  // during finalization.
+  auto fusion_buffer = global_state_->fusion_buffer.GetBuffer(
+      first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
+
+  gpu_context_->finalizer_thread_pool.execute([entries, first_entry, cpu_buffer, fusion_buffer, free_host_buffer,
+                                                evt_queue, &timeline, &gpu_context]() mutable {
+    gpu_context->SetDevice(first_entry.device);
+
+    gpu_context->WaitForEvents(evt_queue, entries, timeline);
+    if (free_host_buffer && cpu_buffer != nullptr) {
+      free(cpu_buffer);
+    }
+
+    for (auto& e : entries) {
+      timeline.End(e.tensor_name, e.output);
+      // Callback can be null if the rank sent Join request.
+      if (e.callback != nullptr) {
+        e.callback(Status::OK());
+      }
+    }
+  });
+
+  // Update current stream
+  global_state_->current_nccl_stream = (global_state_->current_nccl_stream + 1) %
+                                  global_state_->num_nccl_streams;
+
+  return Status::InProgress();
+}
+
+GPUAllreduce::GPUAllreduce(GPUContext* context, HorovodGlobalState* global_state)
+    : AllreduceOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
+
+bool GPUAllreduce::Enabled(const ParameterManager& param_manager,
+                            const std::vector<TensorTableEntry>& entries,
+                            const Response& response) const {
+  return entries[0].device != CPU_DEVICE_ID;
+}
+
+void GPUAllreduce::MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                             const TensorTableEntry& e, void* buffer_data_at_offset) {
+  auto& first_entry = entries[0];
+  gpu_context_->MemcpyAsyncD2D(buffer_data_at_offset, e.tensor->data(), (size_t) e.tensor->size(),
+                               gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+}
+
+void GPUAllreduce::MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                               const void* buffer_data_at_offset, TensorTableEntry& e) {
+  auto& first_entry = entries[0];
+  gpu_context_->MemcpyAsyncD2D((void*) e.output->data(), buffer_data_at_offset, (size_t) e.tensor->size(),
+                               gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+}
+
+GPUAllgather::GPUAllgather(GPUContext* context, HorovodGlobalState* global_state)
+    : AllgatherOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
+
+bool GPUAllgather::Enabled(const ParameterManager& param_manager,
+                           const std::vector<TensorTableEntry>& entries,
+                           const Response& response) const {
+  return entries[0].device != CPU_DEVICE_ID;
+}
+
+void GPUAllgather::MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                             const TensorTableEntry& e, void* buffer_data_at_offset) {
+  auto& first_entry = entries[0];
+  gpu_context_->MemcpyAsyncD2D(buffer_data_at_offset, e.tensor->data(), (size_t) e.tensor->size(),
+                               gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+}
+
+void GPUAllgather::MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
+                                              const void* buffer_data_at_offset, TensorTableEntry& e,
+                                              int64_t entry_offset, size_t entry_size) {
+  auto& first_entry = entries[0];
+  gpu_context_->MemcpyAsyncD2D((int8_t*)e.output->data() + entry_offset, buffer_data_at_offset, entry_size,
+                               gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+}
+
+GPUBroadcast::GPUBroadcast(GPUContext* context,
+                           HorovodGlobalState* global_state)
+    : BroadcastOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
+
+bool GPUBroadcast::Enabled(const ParameterManager& param_manager,
+                           const std::vector<TensorTableEntry>& entries,
+                           const Response& response) const {
+  return entries[0].device != CPU_DEVICE_ID;
+}
+
+} // namespace common
+} // namespace horovod

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -1,0 +1,138 @@
+// Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+// Modifications copyright (C) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "gpu_operations.h"
+
+#include <thread>
+
+namespace horovod {
+namespace common {
+
+class GPUContext::impl {
+public:
+  hipError_t GetGpuEvent(hipEvent_t* event) {
+    int device;
+    auto status = hipGetDevice(&device);
+    if (status != hipSuccess) {
+      return status;
+    }
+
+    auto& mutex = hip_events_mutex;
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      auto& queue = hip_events[device];
+      if (!queue.empty()) {
+        *event = queue.front();
+        queue.pop();
+        return hipSuccess;
+      }
+    }
+
+    return hipEventCreateWithFlags(event, hipEventBlockingSync | hipEventDisableTiming);
+  }
+
+  hipError_t ReleaseGpuEvent(hipEvent_t event) {
+    int device;
+    auto status = hipGetDevice(&device);
+    if (status != hipSuccess) {
+      return status;
+    }
+
+    auto& mutex = hip_events_mutex;
+    {
+      std::lock_guard<std::mutex> guard(mutex);
+      auto& queue = hip_events[device];
+      queue.push(event);
+    }
+
+    return hipSuccess;
+  }
+
+  void ErrorCheck(std::string op_name, hipError_t hip_result) {
+    if (hip_result != hipSuccess) {
+      throw std::logic_error(std::string(op_name) + " failed: " + hipGetErrorString(hip_result));
+    }
+  }
+
+  void RecordEvent(std::queue<std::pair<std::string, hipEvent_t>>& event_queue, std::string name, hipStream_t& stream) {
+    hipEvent_t event;
+    ErrorCheck("GetGpuEvent", GetGpuEvent(&event));
+    ErrorCheck("hipEventRecord", hipEventRecord(event, stream));
+    event_queue.emplace(name, event);
+  }
+
+  void WaitForEvents(std::queue<std::pair<std::string, hipEvent_t>>& event_queue,
+      const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
+    while (!event_queue.empty()) {
+      std::string name;
+      hipEvent_t event;
+      std::tie(name, event) = event_queue.front();
+      event_queue.pop();
+      if (name != "") {
+        timeline.ActivityStartAll(entries, name);
+      }
+      ErrorCheck("hipEventSynchronize", hipEventSynchronize(event));
+      if (name != "") {
+        timeline.ActivityEndAll(entries);
+      }
+      ErrorCheck("ReleaseGpuEvent", ReleaseGpuEvent(event));
+    }
+  }
+
+  void StreamCreate(hipStream_t *stream) {
+    int greatest_priority;
+    ErrorCheck("hipDeviceGetStreamPriorityRange",
+        hipDeviceGetStreamPriorityRange(NULL, &greatest_priority));
+    ErrorCheck("hipStreamCreateWithPriority",
+        hipStreamCreateWithPriority(stream, hipStreamNonBlocking, greatest_priority));
+  }
+
+  void StreamSynchronize(hipStream_t stream) {
+    ErrorCheck("hipStreamSynchronize", hipStreamSynchronize(stream));
+  }
+
+  int GetDevice() {
+    int device;
+    ErrorCheck("hipGetDevice", hipGetDevice(&device));
+    return device;
+  }
+
+  void SetDevice(int device) {
+    ErrorCheck("hipSetDevice", hipSetDevice(device));
+  }
+
+  void MemcpyAsyncD2D(void* dst, const void* src, size_t count, hipStream_t stream) {
+    ErrorCheck("hipMemcpyAsync", hipMemcpyAsync(dst, src, count, hipMemcpyDeviceToDevice, stream));
+  }
+
+  void MemcpyAsyncH2D(void* dst, const void* src, size_t count, hipStream_t stream) {
+    ErrorCheck("hipMemcpyAsync", hipMemcpyAsync(dst, src, count, hipMemcpyHostToDevice, stream));
+  }
+
+  void MemcpyAsyncD2H(void* dst, const void* src, size_t count, hipStream_t stream) {
+    ErrorCheck("hipMemcpyAsync", hipMemcpyAsync(dst, src, count, hipMemcpyDeviceToHost, stream));
+  }
+
+private:
+  // We reuse HIP events as it appears that their creation carries non-zero cost.
+  std::unordered_map<int, std::queue<hipEvent_t>> hip_events;
+  std::mutex hip_events_mutex;
+};
+
+#include "gpu_context_impl.cc"
+
+} // namespace common
+} // namespace horovod

--- a/horovod/common/ops/mpi_gpu_operations.h
+++ b/horovod/common/ops/mpi_gpu_operations.h
@@ -14,19 +14,19 @@
 // limitations under the License.
 // =============================================================================
 
-#ifndef HOROVOD_MPI_CUDA_OPERATIONS_H
-#define HOROVOD_MPI_CUDA_OPERATIONS_H
+#ifndef HOROVOD_MPI_GPU_OPERATIONS_H
+#define HOROVOD_MPI_GPU_OPERATIONS_H
 
-#include "cuda_operations.h"
+#include "gpu_operations.h"
 #include "../mpi/mpi_context.h"
 
 namespace horovod {
 namespace common {
 
-class MPI_CUDAAllreduce : public CUDAAllreduce {
+class MPI_GPUAllreduce : public GPUAllreduce {
 public:
-  MPI_CUDAAllreduce(MPIContext* mpi_context, CUDAContext* cuda_context, HorovodGlobalState* global_state);
-  virtual ~MPI_CUDAAllreduce()=default;
+  MPI_GPUAllreduce(MPIContext* mpi_context, GPUContext* gpu_context, HorovodGlobalState* global_state);
+  virtual ~MPI_GPUAllreduce()=default;
 
   Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
 
@@ -34,10 +34,10 @@ protected:
   MPIContext* mpi_context_;
 };
 
-class MPI_CUDAAllgather : public CUDAAllgather {
+class MPI_GPUAllgather : public GPUAllgather {
 public:
-  MPI_CUDAAllgather(MPIContext* mpi_context, CUDAContext* cuda_context, HorovodGlobalState* global_state);
-  virtual ~MPI_CUDAAllgather()=default;
+  MPI_GPUAllgather(MPIContext* mpi_context, GPUContext* gpu_context, HorovodGlobalState* global_state);
+  virtual ~MPI_GPUAllgather()=default;
 
   Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
 
@@ -48,4 +48,4 @@ protected:
 } // namespace common
 } // namespace horovod
 
-#endif //HOROVOD_MPI_CUDA_OPERATIONS_H
+#endif //HOROVOD_MPI_GPU_OPERATIONS_H

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -17,13 +17,17 @@
 #ifndef HOROVOD_NCCL_OPERATIONS_H
 #define HOROVOD_NCCL_OPERATIONS_H
 
+#if HAVE_CUDA
 #include <nccl.h>
+#elif HAVE_ROCM
+#include <rccl.h>
+#endif
 
 #if HAVE_MPI
 #include "../mpi/mpi_context.h"
 #endif
 
-#include "cuda_operations.h"
+#include "gpu_operations.h"
 
 namespace horovod {
 namespace common {
@@ -61,12 +65,12 @@ private:
   horovod::common::Communicator communicator_type_;
 };
 
-class NCCLAllreduce : public CUDAAllreduce {
+class NCCLAllreduce : public GPUAllreduce {
 public:
-  NCCLAllreduce(NCCLContext* nccl_context, CUDAContext* cuda_context,
+  NCCLAllreduce(NCCLContext* nccl_context, GPUContext* gpu_context,
                 HorovodGlobalState* global_state,
                 horovod::common::Communicator communicator_type = Communicator::GLOBAL)
-      : CUDAAllreduce(cuda_context, global_state),
+      : GPUAllreduce(gpu_context, global_state),
         nccl_context_(nccl_context),
         nccl_op_context_(nccl_context, global_state, communicator_type),
         global_state_(global_state){};
@@ -80,11 +84,11 @@ protected:
   HorovodGlobalState* global_state_;
 };
 
-class NCCLBroadcast : public CUDABroadcast {
+class NCCLBroadcast : public GPUBroadcast {
 public:
-  NCCLBroadcast(NCCLContext* nccl_context, CUDAContext* cuda_context,
+  NCCLBroadcast(NCCLContext* nccl_context, GPUContext* gpu_context,
                 HorovodGlobalState* global_state)
-      : CUDABroadcast(cuda_context, global_state),
+      : GPUBroadcast(gpu_context, global_state),
         nccl_context_(nccl_context),
         nccl_op_context_(nccl_context, global_state, Communicator::GLOBAL),
         global_state_(global_state){};
@@ -102,9 +106,9 @@ protected:
 class NCCLHierarchicalAllreduce : public NCCLAllreduce {
 public:
   NCCLHierarchicalAllreduce(NCCLContext* nccl_context, MPIContext* mpi_context,
-                            CUDAContext* cuda_context,
+                            GPUContext* gpu_context,
                             HorovodGlobalState* global_state)
-      : NCCLAllreduce(nccl_context, cuda_context, global_state, Communicator::LOCAL),
+      : NCCLAllreduce(nccl_context, gpu_context, global_state, Communicator::LOCAL),
         mpi_context_(mpi_context){};
 
   Status Execute(std::vector<TensorTableEntry>& entries,

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_THREADS
 
-#if HAVE_CUDA
+#if HAVE_GPU
 #include "tensorflow/stream_executor/stream.h"
 #endif
 
@@ -75,7 +75,7 @@ common::Status ConvertStatus(const Status& status) {
   }
 }
 
-#if HAVE_CUDA
+#if HAVE_GPU
 class TFReadyEvent : public common::ReadyEvent {
 public:
   TFReadyEvent(DeviceContext* device_context);
@@ -126,7 +126,7 @@ private:
   OpKernelContext* context_ = nullptr;
 };
 
-#if HAVE_CUDA
+#if HAVE_GPU
 TFReadyEvent::TFReadyEvent(DeviceContext* device_context) {
   auto executor = device_context->stream()->parent();
   auto ready_event = new perftools::gputools::Event(executor);
@@ -151,7 +151,7 @@ TFPersistentBuffer::TFPersistentBuffer(OpKernelContext* context, int64_t size) {
   if (!status.ok()) {
     throw status;
   }
-#if HAVE_CUDA
+#if HAVE_GPU
   // On GPU allocation is asynchronous, we need to wait for it to
   // complete.
   auto device_context = context->op_device_context();
@@ -237,7 +237,7 @@ TFOpContext::AllocateOutput(common::TensorShape shape,
   if (status.ok()) {
     *tensor = std::make_shared<TFTensor>(*tf_tensor);
   }
-#if HAVE_CUDA
+#if HAVE_GPU
   // On GPU allocation is asynchronous, we need to wait for it to
   // complete.
   auto device_context = context_->op_device_context();
@@ -273,7 +273,7 @@ int GetDeviceID(OpKernelContext* context) {
 // On GPU this event will signal that data is ready, and tensors are
 // allocated.
 common::ReadyEvent* RecordReadyEvent(OpKernelContext* context) {
-#if HAVE_CUDA
+#if HAVE_GPU
   auto device_context = context->op_device_context();
   if (device_context != nullptr) {
     return new TFReadyEvent(device_context);

--- a/setup.py
+++ b/setup.py
@@ -426,7 +426,41 @@ def get_cuda_dirs(build_ext, cpp_flags):
     return cuda_include_dirs, cuda_lib_dirs
 
 
-def get_nccl_vals(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
+def get_rocm_dirs(build_ext, cpp_flags):
+    rocm_include_dirs = []
+    rocm_lib_dirs = []
+    rocm_libs = ['hip_hcc']
+    rocm_macros = [('__HIP_PLATFORM_HCC__',1)]
+
+    rocm_path = os.environ.get('HOROVOD_ROCM_HOME', '/opt/rocm')
+    rocm_include_dirs += [
+            '%s/include' % rocm_path,
+            '%s/hcc/include' % rocm_path,
+            '%s/hip/include' % rocm_path,
+            '%s/hsa/include' % rocm_path,
+            ]
+    rocm_lib_dirs += [
+            '%s/lib' % rocm_path,
+            ]
+
+    try:
+        test_compile(build_ext, 'test_hip', libraries=rocm_libs, include_dirs=rocm_include_dirs,
+                     library_dirs=rocm_lib_dirs, extra_compile_preargs=cpp_flags, macros=rocm_macros,
+                     code=textwrap.dedent('''\
+            #include <hip/hip_runtime.h>
+            void test() {
+                hipSetDevice(0);
+            }
+            '''))
+    except (CompileError, LinkError):
+        raise DistutilsPlatformError(
+            'HIP library and/or ROCm header files not found (see error above).\n'
+            'Please specify correct ROCm location with the HOROVOD_ROCM_HOME environment variable')
+
+    return rocm_include_dirs, rocm_lib_dirs, rocm_macros
+
+
+def get_nccl_vals(build_ext, gpu_include_dirs, gpu_lib_dirs, gpu_macros, cpp_flags, have_rocm):
     nccl_include_dirs = []
     nccl_lib_dirs = []
     nccl_libs = []
@@ -444,19 +478,25 @@ def get_nccl_vals(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
     if nccl_lib_dir:
         nccl_lib_dirs += [nccl_lib_dir]
 
-    nccl_link_mode = os.environ.get('HOROVOD_NCCL_LINK', 'STATIC')
+    nccl_link_mode = os.environ.get('HOROVOD_NCCL_LINK', 'SHARED' if have_rocm else 'STATIC')
     if nccl_link_mode.upper() == 'SHARED':
-        nccl_libs += ['nccl']
+        if have_rocm:
+            nccl_libs += ['rccl']
+        else:
+            nccl_libs += ['nccl']
     else:
         nccl_libs += ['nccl_static']
+        if have_rocm:
+            raise DistutilsPlatformError('RCCL must be a shared library')
 
     try:
         test_compile(build_ext, 'test_nccl', libraries=nccl_libs,
-                     include_dirs=nccl_include_dirs + cuda_include_dirs,
-                     library_dirs=nccl_lib_dirs + cuda_lib_dirs,
+                     include_dirs=nccl_include_dirs + gpu_include_dirs,
+                     library_dirs=nccl_lib_dirs + gpu_lib_dirs,
                      extra_compile_preargs=cpp_flags,
+                     macros=gpu_macros,
                      code=textwrap.dedent('''\
-            #include <nccl.h>
+            #include <%s>
             #if NCCL_MAJOR < 2
             #error Horovod requires NCCL 2.0 or later version, please upgrade.
             #endif
@@ -464,7 +504,7 @@ def get_nccl_vals(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
                 ncclUniqueId nccl_id;
                 ncclGetUniqueId(&nccl_id);
             }
-            '''))
+            '''%('rccl.h' if have_rocm else 'nccl.h')))
     except (CompileError, LinkError):
         raise DistutilsPlatformError(
             'NCCL 2.0 library or its later version was not found (see error above).\n'
@@ -526,11 +566,12 @@ def get_ddl_dirs(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
 
 def set_cuda_options(build_ext, COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, BUILD_MPI, LIBRARY_DIRS, LIBRARIES, **kwargs):
     cuda_include_dirs, cuda_lib_dirs = get_cuda_dirs(build_ext, COMPILE_FLAGS)
-    MACROS += [('HAVE_CUDA', '1')]
+    MACROS += [('HAVE_CUDA', '1'), ('HAVE_GPU', '1')]
     INCLUDES += cuda_include_dirs
-    SOURCES += ['horovod/common/ops/cuda_operations.cc']
+    SOURCES += ['horovod/common/ops/cuda_operations.cc',
+                'horovod/common/ops/gpu_operations.cc']
     if BUILD_MPI:
-        SOURCES += ['horovod/common/ops/mpi_cuda_operations.cc']
+        SOURCES += ['horovod/common/ops/mpi_gpu_operations.cc']
     LIBRARY_DIRS += cuda_lib_dirs
     LIBRARIES += ['cudart']
 
@@ -608,17 +649,24 @@ def get_common_options(build_ext):
         raise DistutilsError('HOROVOD_GPU_BROADCAST=%s is invalid, supported '
                              'values are "", "MPI", "NCCL".' % gpu_broadcast)
 
+    have_cuda = False
+    have_rocm = False
+    gpu_include_dirs = gpu_lib_dirs = gpu_macros = []
     if gpu_allreduce or gpu_allgather or gpu_broadcast:
-        have_cuda = True
-        cuda_include_dirs, cuda_lib_dirs = get_cuda_dirs(build_ext, cpp_flags)
-    else:
-        have_cuda = False
-        cuda_include_dirs = cuda_lib_dirs = []
+        gpu_type = os.environ.get('HOROVOD_GPU', 'CUDA')
+        if gpu_type == 'CUDA':
+            have_cuda = True
+            gpu_include_dirs, gpu_lib_dirs = get_cuda_dirs(build_ext, cpp_flags)
+        elif gpu_type == 'ROCM':
+            have_rocm = True
+            gpu_include_dirs, gpu_lib_dirs, gpu_macros = get_rocm_dirs(build_ext, cpp_flags)
+        else:
+            raise DistutilsError("Unknown HOROVOD_GPU type '%s'" % gpu_type)
 
     if gpu_allreduce == 'NCCL':
         have_nccl = True
         nccl_include_dirs, nccl_lib_dirs, nccl_libs = get_nccl_vals(
-            build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags)
+            build_ext, gpu_include_dirs, gpu_lib_dirs, gpu_macros, cpp_flags, have_rocm)
     else:
         have_nccl = False
         nccl_include_dirs = nccl_lib_dirs = nccl_libs = []
@@ -628,8 +676,8 @@ def get_common_options(build_ext):
                       "by building Horovod with 'HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_GPU_BROADCAST=NCCL'.")
         have_ddl = True
         ddl_include_dirs, ddl_lib_dirs = get_ddl_dirs(build_ext,
-                                                      cuda_include_dirs,
-                                                      cuda_lib_dirs, cpp_flags)
+                                                      gpu_include_dirs,
+                                                      gpu_lib_dirs, cpp_flags)
     else:
         have_ddl = False
         ddl_include_dirs = ddl_lib_dirs = []
@@ -736,12 +784,22 @@ def get_common_options(build_ext):
         set_cuda_options(build_ext, COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, have_mpi, LIBRARY_DIRS, LIBRARIES)
         INCLUDES += ['horovod/common/ops/cuda']
 
+    if have_rocm:
+        MACROS += [('HAVE_ROCM', '1'), ('HAVE_GPU', '1')] + gpu_macros
+        INCLUDES += gpu_include_dirs
+        SOURCES += ['horovod/common/ops/hip_operations.cc',
+                    'horovod/common/ops/gpu_operations.cc']
+        if have_mpi:
+            SOURCES += ['horovod/common/ops/mpi_gpu_operations.cc']
+        LIBRARY_DIRS += gpu_lib_dirs
+        LIBRARIES += ['hip_hcc']
+
     if have_nccl:
         MACROS += [('HAVE_NCCL', '1')]
         INCLUDES += nccl_include_dirs
         SOURCES += ['horovod/common/ops/nccl_operations.cc']
         if have_mpi:
-            SOURCES += ['horovod/common/ops/adasum_cuda_operations.cc']
+            SOURCES += ['horovod/common/ops/adasum_gpu_operations.cc']
         LIBRARY_DIRS += nccl_lib_dirs
         LIBRARIES += nccl_libs
 


### PR DESCRIPTION
- add ROCm and ROCm TensorFlow support to setup.py
- Renamed symbols and files
  - CUDA -> GPU
  - Cuda -> Gpu
  - cuda -> gpu
  - HAVE_CUDA -> HAVE_GPU --- iff generically referring to any GPU device
- CUDAContext becomes GPUContext and uses pimpl pattern to decouple
  CUDA and HIP implementations of GPU interface.
- New GPUContext methods
  - StreamCreate
  - StreamSynchronize
  - GetDevice, SetDevice
  - MemcpyAsyncD2D, MemcpyAsyncH2D, MemcpyAsyncD2H

Signed-off-by: Jeff Daily <jeff.daily@amd.com>