### PR TITLE
Fix a crash bug in MXNet due to early free of tensor object

### DIFF
--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -55,6 +55,19 @@ MXPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
 
 MXTensor::MXTensor(NDArray* tensor) : tensor_(tensor) {}
 
+MXTensor::MXTensor(int device, int dtype) {
+  int dev_type = gpu::kDevMask;
+  if (device == CPU_DEVICE_ID) {
+    dev_type = cpu::kDevMask;
+    device = 0;
+  }
+
+  NDArrayHandle array_handle;
+  MXNDArrayCreateEx(nullptr, 0, dev_type, device, false, dtype, &array_handle);
+  tensor_(*(static_cast<NDArray *>(array_handle)));
+  MXNDArrayFree(array_handle);
+}
+
 const DataType MXTensor::dtype() const {
   return TensorUtil::GetDType(tensor_);
 }
@@ -80,7 +93,7 @@ int64_t MXTensor::size() const {
 }
 
 MXOpContext::MXOpContext(int device, NDArray* output)
-    : device_(device), output_(output) {}
+    : device_(device), output_(*output) {}
 
 Status MXOpContext::AllocatePersistent(int64_t size,
   std::shared_ptr<PersistentBuffer>* tensor) {

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -82,8 +82,9 @@ int64_t MXTensor::size() const {
 MXOpContext::MXOpContext(int device, NDArray* output)
     : device_(device), output_(output) {}
 
-Status MXOpContext::AllocatePersistent(int64_t size,
-  std::shared_ptr<PersistentBuffer>* tensor) {
+Status
+MXOpContext::AllocatePersistent(int64_t size,
+                                std::shared_ptr<PersistentBuffer>* tensor) {
   // Allocation errors are handled using PyMX exceptions.
   *tensor = std::make_shared<MXPersistentBuffer>(device_, size);
   return Status::OK();

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -55,19 +55,6 @@ MXPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
 
 MXTensor::MXTensor(NDArray* tensor) : tensor_(tensor) {}
 
-MXTensor::MXTensor(int device, int dtype) {
-  int dev_type = gpu::kDevMask;
-  if (device == CPU_DEVICE_ID) {
-    dev_type = cpu::kDevMask;
-    device = 0;
-  }
-
-  NDArrayHandle array_handle;
-  MXNDArrayCreateEx(nullptr, 0, dev_type, device, false, dtype, &array_handle);
-  tensor_(*(static_cast<NDArray *>(array_handle)));
-  MXNDArrayFree(array_handle);
-}
-
 const DataType MXTensor::dtype() const {
   return TensorUtil::GetDType(tensor_);
 }
@@ -92,22 +79,8 @@ int64_t MXTensor::size() const {
   return TensorUtil::GetSize(tensor_);
 }
 
-MXTemporaryBuffer::MXTemporaryBuffer(int device, int dtype)
-    : MXTensor(nullptr) {
-  this->tensor_ = TensorUtil::New(device, dtype);
-}
-
-MXTemporaryBuffer::MXTemporaryBuffer(NDArray* tensor)
-    : MXTensor(nullptr) {
-  this->tensor_ = tensor;
-}
-
-MXTemporaryBuffer::~MXTemporaryBuffer() {
-  TensorUtil::Free(this->tensor_);
-}
-
 MXOpContext::MXOpContext(int device, NDArray* output)
-    : device_(device), output_(*output) {}
+    : device_(device), output_(output) {}
 
 Status MXOpContext::AllocatePersistent(int64_t size,
   std::shared_ptr<PersistentBuffer>* tensor) {

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -55,19 +55,6 @@ MXPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
 
 MXTensor::MXTensor(NDArray* tensor) : tensor_(tensor) {}
 
-MXTensor::MXTensor(int device, int dtype) {
-  int dev_type = gpu::kDevMask;
-  if (device == CPU_DEVICE_ID) {
-    dev_type = cpu::kDevMask;
-    device = 0;
-  }
-
-  NDArrayHandle array_handle;
-  MXNDArrayCreateEx(nullptr, 0, dev_type, device, false, dtype, &array_handle);
-  tensor_(*(static_cast<NDArray *>(array_handle)));
-  MXNDArrayFree(array_handle);
-}
-
 const DataType MXTensor::dtype() const {
   return TensorUtil::GetDType(tensor_);
 }
@@ -93,7 +80,7 @@ int64_t MXTensor::size() const {
 }
 
 MXOpContext::MXOpContext(int device, NDArray* output)
-    : device_(device), output_(*output) {}
+    : device_(device), output_(output) {}
 
 Status MXOpContext::AllocatePersistent(int64_t size,
   std::shared_ptr<PersistentBuffer>* tensor) {

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -53,13 +53,13 @@ MXPersistentBuffer::AccessData(std::shared_ptr<OpContext> context) const {
   return buffer_;
 }
 
-template <class T> MXTensor<T>::MXTensor(T* tensor) : tensor_(tensor) {}
+MXTensor::MXTensor(NDArray* tensor) : tensor_(tensor) {}
 
-template <class T> const DataType MXTensor<T>::dtype() const {
+const DataType MXTensor::dtype() const {
   return TensorUtil::GetDType(tensor_);
 }
 
-template <class T> const TensorShape MXTensor<T>::shape() const {
+const TensorShape MXTensor::shape() const {
   auto shape = TensorUtil::GetShape(tensor_);
   if (shape.dims() == 0) {
     // Tensor with empty shape is a Tensor with no values in MXNet, unlike a
@@ -70,76 +70,81 @@ template <class T> const TensorShape MXTensor<T>::shape() const {
   return shape;
 }
 
-template <class T> const void* MXTensor<T>::data() const {
+const void* MXTensor::data() const {
   // returns the raw data instead of NDArray Tensor
   return TensorUtil::GetData(tensor_);
 }
 
-template <class T> int64_t MXTensor<T>::size() const {
+int64_t MXTensor::size() const {
   return TensorUtil::GetSize(tensor_);
 }
 
-template <class T> T* MXTensor<T>::tensor() const {
+NDArray* MXTensor::tensor() const {
   return this->tensor_;
 }
 
-template <class T>
-MXTemporaryBuffer<T>::MXTemporaryBuffer(int device, int dtype)
-    : MXTensor<T>(nullptr) {
+MXTemporaryBuffer::MXTemporaryBuffer(int device, int dtype)
+    : MXTensor(nullptr) {
   this->tensor_ = TensorUtil::New(device, dtype);
 }
 
-template <class T>
-MXTemporaryBuffer<T>::MXTemporaryBuffer(T* tensor)
-    : MXTensor<T>(nullptr) {
+MXTemporaryBuffer::MXTemporaryBuffer(NDArray* tensor)
+    : MXTensor(nullptr) {
   this->tensor_ = tensor;
 }
 
-template <class T> MXTemporaryBuffer<T>::~MXTemporaryBuffer() {
+MXTemporaryBuffer::~MXTemporaryBuffer() {
   TensorUtil::Free(this->tensor_);
 }
 
-template <class T>
-MXOpContext<T>::MXOpContext(int device, T* output)
+MXOpContext::MXOpContext(int device, NDArray* output)
     : device_(device), output_(output) {}
 
-template <class T>
 Status
-MXOpContext<T>::AllocatePersistent(int64_t size,
-                                   std::shared_ptr<PersistentBuffer>* tensor) {
+MXOpContext::AllocatePersistent(int64_t size,
+                                std::shared_ptr<PersistentBuffer>* tensor) {
   // Allocation errors are handled using PyMX exceptions.
   *tensor = std::make_shared<MXPersistentBuffer>(device_, size);
   return Status::OK();
 }
 
-template <class T>
-Status MXOpContext<T>::AllocateOutput(TensorShape shape,
-                                      std::shared_ptr<Tensor>* tensor) {
+Status MXOpContext::AllocateOutput(TensorShape shape,
+                                   std::shared_ptr<Tensor>* tensor) {
   int64_t* shape_array = new int64_t[shape.dims()];
   for (int idx = 0; idx < shape.dims(); idx++) {
     shape_array[idx] = shape.dim_size(idx);
   }
   TensorUtil::ResizeNd(output_, shape.dims(), shape_array);
   delete[] shape_array;
-  *tensor = std::make_shared<MXTensor<T>>(output_);
+  *tensor = std::make_shared<MXTensor>(output_);
   return Status::OK();
 }
 
-template <class T>
 Status
-MXOpContext<T>::AllocateZeros(int64_t num_elements, DataType dtype,
-                                          std::shared_ptr<Tensor>* tensor) {
+MXOpContext::AllocateZeros(int64_t num_elements, DataType dtype,
+                           std::shared_ptr<Tensor>* tensor) {
   return Status::PreconditionError(
       "AllocateZeros is not supported for MXNet yet.");
 }
 
-template <class T> Framework MXOpContext<T>::framework() const {
+Framework MXOpContext::framework() const {
   return Framework::MXNET;
 }
 
-template class MXTensor<NDArray>;
-template class MXTemporaryBuffer<NDArray>;
-template class MXOpContext<NDArray>;
+void ThrowIfError(const Status& status) {
+  switch (status.type()) {
+  case StatusType::OK:
+    return;
+  case StatusType::PRECONDITION_ERROR:
+    throw std::logic_error(status.reason());
+  case StatusType::ABORTED:
+    throw std::runtime_error(status.reason());
+  case StatusType::INVALID_ARGUMENT:
+    throw std::invalid_argument(status.reason());
+  default: // Includes UNKNOWN_ERROR
+    throw std::runtime_error(status.reason());
+  }
+}
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -40,7 +40,6 @@ private:
 class MXTensor : public Tensor {
 public:
   MXTensor(NDArray *tensor);
-  MXTensor(int device, int dtype);
   virtual const DataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -44,7 +44,6 @@ public:
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
-  virtual NDArray* tensor() const;
 
 protected:
   NDArray* tensor_;

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -40,7 +40,6 @@ private:
 class MXTensor : public Tensor {
 public:
   MXTensor(NDArray *tensor);
-  MXTensor(int device, int dtype);
   virtual const DataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
@@ -49,13 +48,6 @@ public:
 
 protected:
   NDArray* tensor_;
-};
-
-class MXTemporaryBuffer : public MXTensor {
-public:
-  MXTemporaryBuffer(int device, int dtype);
-  MXTemporaryBuffer(NDArray* tensor);
-  ~MXTemporaryBuffer();
 };
 
 class MXOpContext : public OpContext {

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -17,13 +17,14 @@
 #define HOROVOD_MXNET_ADAPTER_H
 
 #include <mxnet/base.h>
-
 #include "../common/common.h"
 
 namespace horovod {
 namespace mxnet {
 
 using namespace horovod::common;
+
+typedef ::mxnet::NDArray NDArray;
 
 class MXPersistentBuffer : public PersistentBuffer {
 public:
@@ -36,29 +37,29 @@ private:
   void* buffer_;
 };
 
-template <class T> class MXTensor : public Tensor {
+class MXTensor : public Tensor {
 public:
-  MXTensor(T* tensor);
+  MXTensor(NDArray *tensor);
   virtual const DataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
-  virtual T* tensor() const;
+  virtual NDArray* tensor() const;
 
 protected:
-  T* tensor_;
+  NDArray* tensor_;
 };
 
-template <class T> class MXTemporaryBuffer : public MXTensor<T> {
+class MXTemporaryBuffer : public MXTensor {
 public:
   MXTemporaryBuffer(int device, int dtype);
-  MXTemporaryBuffer(T* tensor);
+  MXTemporaryBuffer(NDArray* tensor);
   ~MXTemporaryBuffer();
 };
 
-template <class T> class MXOpContext : public OpContext {
+class MXOpContext : public OpContext {
 public:
-  MXOpContext(int device, T* output);
+  MXOpContext(int device, NDArray* output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
@@ -70,14 +71,10 @@ public:
 
 private:
   int device_;
-  T* output_;
+  NDArray* output_;
 };
 
-inline void ThrowIfError(const Status& status) {
-  if (!status.ok()) {
-    throw dmlc::Error(status.reason());
-  }
-}
+void ThrowIfError(const Status& status);
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -40,6 +40,7 @@ private:
 class MXTensor : public Tensor {
 public:
   MXTensor(NDArray *tensor);
+  MXTensor(int device, int dtype);
   virtual const DataType dtype() const override;
   virtual const TensorShape shape() const override;
   virtual const void* data() const override;

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -81,7 +81,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
   Status enqueue_result;
   switch (ops_param->op_type) {
     case OperationType::ALLREDUCE:
-      auto hvd_output = std::make_shared<MXTensor>(output);
+      hvd_output = std::make_shared<MXTensor>(output);
       enqueue_result = EnqueueTensorAllreduce(
           hvd_context, hvd_tensor, hvd_output, nullptr, name, device,
           [on_complete](const Status& status) {
@@ -102,7 +102,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
           TensorUtil::Copy(output, tensor);
         }
       } else {
-        auto hvd_output = std::make_shared<MXTensor>(output);
+        hvd_output = std::make_shared<MXTensor>(output);
       }
 
       enqueue_result = EnqueueTensorBroadcast(
@@ -238,7 +238,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 #endif
 
   if (average) {
-    *(static_cast<NDArray *>(output)) /= horovod_size();
+    *output /= horovod_size();
   }
 
   MX_API_END();

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -119,8 +119,8 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
   ThrowIfError(enqueue_result);
 }
 
-inline void PushHorovodOperation(OperationType op_type, NDArray* input,
-                                 NDArray* output, const char* name,
+inline void PushHorovodOperation(OperationType op_type, NDArrayHandle input,
+                                 NDArrayHandle output, const char* name,
                                  int priority, int root_rank = -1) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
@@ -129,26 +129,24 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   // shallow copy to prevent from NDArray object being freed
   // before MXNet engine process it
   // See: https://github.com/horovod/horovod/issues/1533
-  auto input_copy = std::make_shared<NDArray>(*input);
-  auto output_copy = std::make_shared<NDArray>(*output);
+  // auto input_copy = std::make_shared<NDArray>(*input);
+  // auto output_copy = std::make_shared<NDArray>(*output);
+  auto input_tensor = static_cast<NDArray *>(input);
+  auto output_tensor = static_cast<NDArray *>(output);
 
-  auto ops_param = CreateMpiOpsParam(input_copy.get(), output_copy.get(),
+  auto ops_param = CreateMpiOpsParam(input_tensor, output_tensor,
     nullptr /* cpu_buffer */, op_type, op_name, root_rank);
 
-  // Not in-place
-  auto input_var = input_copy->var();
-  auto output_var = output_copy->var();
-  if (input_var != output_var) {
-    MXEnginePushAsync(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
-                      &MX_EXEC_CTX, &input_var, 1, &output_var, 1,
-                      &MX_FUNC_PROP, priority, op_type_name);
-  // In-place
+  if (input_tensor->IsSame(*output_tensor)) {
+    // In-place
+    MXEnginePushAsyncND(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
+                        &MX_EXEC_CTX, nullptr, 0, &output, 1,
+                        &MX_FUNC_PROP, priority, op_type_name);
   } else {
-    MXEnginePushAsync(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
-                      &MX_EXEC_CTX, nullptr, 0, &output_var, 1,
-                      &MX_FUNC_PROP, priority, op_type_name);
+    MXEnginePushAsyncND(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
+                        &MX_EXEC_CTX, &input, 1, &output, 1,
+                        &MX_FUNC_PROP, priority, op_type_name);
   }
-  *output = *output_copy;
 }
 
 #if HAVE_CUDA
@@ -193,46 +191,45 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   ThrowIfError(enqueue_result);
 }
 
-inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
-                                          NDArray* output, const char* name,
+inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArrayHandle input,
+                                          NDArrayHandle output, const char* name,
                                           int priority, int root_rank = -1) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
+
+  auto input_tensor = static_cast<NDArray *>(input);
+  auto output_tensor = static_cast<NDArray *>(output);
   auto hvd_cpu_buffer = std::make_shared<MXTemporaryBuffer>(
-      CPU_DEVICE_ID, input->dtype());
+      CPU_DEVICE_ID, input_tensor->dtype());
   auto ops_param = CreateMpiOpsParam(nullptr, nullptr, hvd_cpu_buffer,
                                      op_type, op_name, root_rank);
 
-  // We need to create a shared_ptr to NDArray object with
-  // shallow copy to prevent from NDArray object being freed
-  // before MXNet engine process it
-  // See: https://github.com/horovod/horovod/issues/1533
-  auto input_copy = std::make_shared<NDArray>(*input);
-  auto output_copy = std::make_shared<NDArray>(*output);
-
   // Make async copy of input tensor to CPU tensor.
-  TensorUtil::AsyncCopyCudaToCPU(input_copy.get(), hvd_cpu_buffer->tensor());
+  TensorUtil::AsyncCopyCudaToCPU(input_tensor, hvd_cpu_buffer->tensor());
 
-  // In-place
-  auto cpu_tensor_var = hvd_cpu_buffer->tensor()->var();
-  MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
-                    &MX_EXEC_CTX, nullptr, 0, &cpu_tensor_var, 1,
-                    &MX_FUNC_PROP, priority, op_type_name);
+  // In-place on the cpu buffer
+  auto cpu_tensor_handle = static_cast<NDArrayHandle>(hvd_cpu_buffer->tensor());
+  MXEnginePushAsyncND(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
+                      &MX_EXEC_CTX, nullptr, 0,
+                      &cpu_tensor_handle, 1,
+                      &MX_FUNC_PROP, priority, op_type_name);
 
   // Make async copy of CPU tensor to output tensor.
-  TensorUtil::AsyncCopyCPUToCuda(hvd_cpu_buffer->tensor(), output_copy.get());
-  *output = *output_copy;
+  TensorUtil::AsyncCopyCPUToCuda(hvd_cpu_buffer->tensor(), output_tensor);
 }
 #endif
 
-extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
+bool IsTensorOnCPU(NDArrayHandle handle) {
+  return static_cast<NDArray *>(handle)->ctx().dev_mask() == cpu::kDevMask;
+}
+
+extern "C" int horovod_mxnet_allreduce_async(NDArrayHandle input, NDArrayHandle output,
                                              const char* name, bool average,
                                              int priority) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLREDUCE
-  if (input->ctx().dev_mask() == cpu::kDevMask &&
-      output->ctx().dev_mask() == cpu::kDevMask) {
+  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLREDUCE, input, output,
                          name, priority);
   } else {
@@ -245,19 +242,19 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 #endif
 
   if (average) {
-    *output /= horovod_size();
+    *(static_cast<NDArray *>(output)) /= horovod_size();
   }
 
   MX_API_END();
 }
 
-extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
+extern "C" int horovod_mxnet_allgather_async(NDArrayHandle input,
+                                             NDArrayHandle output,
                                              const char* name, int priority) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLGATHER
-  if (input->ctx().dev_mask() == cpu::kDevMask &&
-      output->ctx().dev_mask() == cpu::kDevMask) {
+  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLGATHER, input, output,
                          name, priority);
   } else {
@@ -272,14 +269,14 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
   MX_API_END();
 }
 
-extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
+extern "C" int horovod_mxnet_broadcast_async(NDArrayHandle input,
+                                             NDArrayHandle output,
                                              const char* name, int root_rank,
                                              int priority) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_BROADCAST
-  if (input->ctx().dev_mask() == cpu::kDevMask &&
-      output->ctx().dev_mask() == cpu::kDevMask) {
+  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::BROADCAST, input, output,
                          name, priority, root_rank);
 

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -75,14 +75,14 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 
   auto device = TensorUtil::GetDevice(tensor);
   LOG(INFO) << "device is " << device << " before allreduce";
-  auto hvd_tensor = std::make_shared<MXTensor<NDArray>>(tensor);
-  auto hvd_context = std::make_shared<MXOpContext<NDArray>>(device, output);
+  auto hvd_tensor = std::make_shared<MXTensor>(tensor);
+  auto hvd_context = std::make_shared<MXOpContext>(device, output);
   std::shared_ptr<Tensor> hvd_output = nullptr;
 
   Status enqueue_result;
   switch (ops_param->op_type) {
     case OperationType::ALLREDUCE:
-      hvd_output = std::make_shared<MXTensor<NDArray>>(output);
+      hvd_output = std::make_shared<MXTensor>(output);
       enqueue_result = EnqueueTensorAllreduce(
           hvd_context, hvd_tensor, hvd_output, nullptr, name, device,
           [on_complete](const Status& status) {
@@ -102,7 +102,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
           TensorUtil::Copy(output, tensor);
         }
       } else {
-        hvd_output = std::make_shared<MXTensor<NDArray>>(output);
+        hvd_output = std::make_shared<MXTensor>(output);
       }
 
       enqueue_result = EnqueueTensorBroadcast(
@@ -159,8 +159,8 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   auto ops_param = static_cast<MpiOpsParam*>(param);
   auto name = ops_param->op_name;
   auto hvd_cpu_buffer = ops_param->cpu_tensor;
-  auto hvd_context = std::make_shared<MXOpContext<NDArray>>(
-      CPU_DEVICE_ID, hvd_cpu_buffer->tensor());
+  auto hvd_context = std::make_shared<MXOpContext>(
+    CPU_DEVICE_ID, hvd_cpu_buffer->tensor());
 
   Status enqueue_result;
   switch (ops_param->op_type) {
@@ -198,7 +198,7 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
                                           int priority, int root_rank = -1) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
-  auto hvd_cpu_buffer = std::make_shared<MXTemporaryBuffer<NDArray>>(
+  auto hvd_cpu_buffer = std::make_shared<MXTemporaryBuffer>(
       CPU_DEVICE_ID, input->dtype());
   auto ops_param = CreateMpiOpsParam(nullptr, nullptr, hvd_cpu_buffer,
                                      op_type, op_name, root_rank);

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -211,7 +211,7 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
   auto output_copy = std::make_shared<NDArray>(*output);
 
   // Make async copy of input tensor to CPU tensor.
-  TensorUtil::AsyncCopyCudaToCPU(input_copy, hvd_cpu_buffer->tensor());
+  TensorUtil::AsyncCopyCudaToCPU(input_copy.get(), hvd_cpu_buffer->tensor());
 
   // In-place
   auto cpu_tensor_var = hvd_cpu_buffer->tensor()->var();
@@ -220,7 +220,7 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
                     &MX_FUNC_PROP, priority, op_type_name);
 
   // Make async copy of CPU tensor to output tensor.
-  TensorUtil::AsyncCopyCPUToCuda(hvd_cpu_buffer->tensor(), output_copy);
+  TensorUtil::AsyncCopyCPUToCuda(hvd_cpu_buffer->tensor(), output_copy.get());
   *output = *output_copy;
 }
 #endif

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -128,7 +128,6 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   // We need to create a shared_ptr to NDArray object with
   // shallow copy to prevent from NDArray object being freed
   // before MXNet engine process it
-  // See: https://github.com/horovod/horovod/issues/1533
   auto input_copy = std::make_shared<NDArray>(*input);
   auto output_copy = std::make_shared<NDArray>(*output);
   auto ops_param = CreateMpiOpsParam(input_copy, output_copy,

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -89,7 +89,6 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
       });
       break;
     case OperationType::ALLGATHER:
-      hvd_output = std::make_shared<MXTensor>(output);
       enqueue_result = EnqueueTensorAllgather(
           hvd_context, hvd_tensor, nullptr, name, device,
           [on_complete](const Status& status) {

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -134,8 +134,8 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
     nullptr /* cpu_buffer */, op_type, op_name, root_rank);
 
   // Not in-place
-  auto input_var = input->var();
-  auto output_var = output->var();
+  auto input_var = input_tensor->var();
+  auto output_var = output_tensor->var();
   if (input_var != output_var) {
     MXEnginePushAsync(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
                       &MX_EXEC_CTX, &input_var, 1, &output_var, 1,
@@ -146,6 +146,7 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
                       &MX_EXEC_CTX, nullptr, 0, &output_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);
   }
+  *output = *output_tensor;
 }
 
 #if HAVE_CUDA

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -33,7 +33,7 @@ using namespace horovod::common;
 typedef ::mxnet::NDArray NDArray;
 typedef ::mxnet::Engine::CallbackOnComplete CallbackOnComplete;
 typedef Request::RequestType OperationType;
-typedef std::shared_ptr<MXTensor<NDArray>> MXTensorSharedPtr;
+typedef std::shared_ptr<MXTensor> MXTensorSharedPtr;
 
 struct MpiOpsParam {
   NDArray* input;

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -69,12 +69,15 @@ void DeleteMpiOpsParam(void* param) {
   delete ops_param;
 }
 
-extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
+extern "C" int horovod_mxnet_allreduce_async(NDArrayHandle input,
+                                             NDArrayHandle output,
                                              const char* name, bool average,
                                              int priority);
-extern "C" int horovod_mxnet_allgather_async(NDArray* input, NDArray* output,
+extern "C" int horovod_mxnet_allgather_async(NDArrayHandle input,
+                                             NDArrayHandle output,
                                              const char* name, int priority);
-extern "C" int horovod_mxnet_broadcast_async(NDArray* input, NDArray* output,
+extern "C" int horovod_mxnet_broadcast_async(NDArrayHandle input,
+                                             NDArrayHandle output,
                                              const char* name, int root_rank,
                                              int priority);
 

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -73,15 +73,15 @@ void DeleteMpiOpsParam(void* param) {
   delete ops_param;
 }
 
-extern "C" int horovod_mxnet_allreduce_async(NDArrayHandle input,
-                                             NDArrayHandle output,
+extern "C" int horovod_mxnet_allreduce_async(NDArray* input,
+                                             NDArray* output,
                                              const char* name, bool average,
                                              int priority);
-extern "C" int horovod_mxnet_allgather_async(NDArrayHandle input,
-                                             NDArrayHandle output,
+extern "C" int horovod_mxnet_allgather_async(NDArray* input,
+                                             NDArray* output,
                                              const char* name, int priority);
-extern "C" int horovod_mxnet_broadcast_async(NDArrayHandle input,
-                                             NDArrayHandle output,
+extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
+                                             NDArray* output,
                                              const char* name, int root_rank,
                                              int priority);
 

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -34,21 +34,23 @@ typedef ::mxnet::NDArray NDArray;
 typedef ::mxnet::Engine::CallbackOnComplete CallbackOnComplete;
 typedef Request::RequestType OperationType;
 typedef std::shared_ptr<MXTensor> MXTensorSharedPtr;
+typedef std::shared_ptr<NDArray> NDArraySharedPtr;
 
 struct MpiOpsParam {
-  NDArray* input;
-  NDArray* output;
-  MXTensorSharedPtr cpu_tensor;
+  NDArraySharedPtr input_tensor;
+  NDArraySharedPtr output_tensor;
+  NDArraySharedPtr cpu_tensor;
   OperationType op_type;
   std::string op_name;
   int root_rank;
 
-  MpiOpsParam(NDArray* input, NDArray* output,
-              MXTensorSharedPtr cpu_tensor,
+  MpiOpsParam(NDArraySharedPtr input_tensor,
+              NDArraySharedPtr output_tensor,
+              NDArraySharedPtr cpu_tensor,
               const OperationType& op_type, const std::string& op_name,
               int root_rank)
-      : input(input),
-        output(output),
+      : input_tensor(input_tensor),
+        output_tensor(output_tensor),
         cpu_tensor(cpu_tensor),
         op_type(op_type),
         op_name(op_name),
@@ -56,12 +58,14 @@ struct MpiOpsParam {
   }
 };
 
-inline MpiOpsParam* CreateMpiOpsParam(NDArray* input, NDArray* output,
-                                      MXTensorSharedPtr cpu_tensor,
+inline MpiOpsParam* CreateMpiOpsParam(NDArraySharedPtr input_tensor,
+                                      NDArraySharedPtr output_tensor,
+                                      NDArraySharedPtr cpu_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
                                       int root_rank) {
-  return new MpiOpsParam(input, output, cpu_tensor, op_type, op_name, root_rank);
+  return new MpiOpsParam(input_tensor, output_tensor, cpu_tensor,
+    op_type, op_name, root_rank);
 }
 
 void DeleteMpiOpsParam(void* param) {

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -21,8 +21,8 @@ namespace horovod {
 namespace mxnet {
 
 // Define all types for TensorUtil.
-const DataType TensorUtil::GetDType(const NDArray& tensor) {
-  switch (tensor.dtype()) {
+const DataType TensorUtil::GetDType(NDArray* tensor) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
     return DataType::HOROVOD_FLOAT32;
   case mshadow::kFloat64:
@@ -38,15 +38,15 @@ const DataType TensorUtil::GetDType(const NDArray& tensor) {
   case mshadow::kInt64:
     return DataType::HOROVOD_INT64;
   default:
-    throw std::logic_error("GetDType: Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("GetDType: Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return shape of tensor (similar to TShape)
-const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
+const TensorShape TensorUtil::GetShape(NDArray* tensor) {
   TensorShape shape;
-  TShape mx_shape = tensor.shape();
+  TShape mx_shape = tensor->shape();
   for (int idx = 0; idx < (int)mx_shape.ndim(); idx++) {
     shape.AddDim(mx_shape[idx]);
   }
@@ -54,34 +54,34 @@ const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
 }
 
 // Return data of tensor
-const void* TensorUtil::GetData(const NDArray& tensor) {
+const void* TensorUtil::GetData(NDArray* tensor) {
   // The following returns an error:
   // return tensor->data().dptr<void>();
-  switch (tensor.dtype()) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
-    return static_cast<void*>(tensor.data().dptr<float>());
+    return static_cast<void*>(tensor->data().dptr<float>());
   case mshadow::kFloat64:
-    return static_cast<void*>(tensor.data().dptr<double>());
+    return static_cast<void*>(tensor->data().dptr<double>());
   case mshadow::kFloat16:
-    return static_cast<void*>(tensor.data().dptr<mshadow::half::half_t>());
+    return static_cast<void*>(tensor->data().dptr<mshadow::half::half_t>());
   case mshadow::kUint8:
-    return static_cast<void*>(tensor.data().dptr<uint8_t>());
+    return static_cast<void*>(tensor->data().dptr<uint8_t>());
   case mshadow::kInt32:
-    return static_cast<void*>(tensor.data().dptr<int32_t>());
+    return static_cast<void*>(tensor->data().dptr<int32_t>());
   case mshadow::kInt8:
-    return static_cast<void*>(tensor.data().dptr<int8_t>());
+    return static_cast<void*>(tensor->data().dptr<int8_t>());
   case mshadow::kInt64:
-    return static_cast<void*>(tensor.data().dptr<int64_t>());
+    return static_cast<void*>(tensor->data().dptr<int64_t>());
   default:
-    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return size of tensor in bytes
-int64_t TensorUtil::GetSize(const NDArray& tensor) {
+int64_t TensorUtil::GetSize(NDArray* tensor) {
   int64_t element_size = 0;
-  switch (tensor.dtype()) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
     element_size = kFloat32Size;
     break;
@@ -104,10 +104,10 @@ int64_t TensorUtil::GetSize(const NDArray& tensor) {
     element_size = kInt64Size;
     break;
   default:
-    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
-  return (int64_t)(tensor.shape().Size()) * element_size;
+  return (int64_t)(tensor->shape().Size()) * element_size;
 }
 
 // If Tensor on GPU, return device id

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -21,8 +21,8 @@ namespace horovod {
 namespace mxnet {
 
 // Define all types for TensorUtil.
-const DataType TensorUtil::GetDType(const NDArray& tensor) {
-  switch (tensor.dtype()) {
+const DataType TensorUtil::GetDType(NDArray* tensor) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
     return DataType::HOROVOD_FLOAT32;
   case mshadow::kFloat64:
@@ -38,15 +38,15 @@ const DataType TensorUtil::GetDType(const NDArray& tensor) {
   case mshadow::kInt64:
     return DataType::HOROVOD_INT64;
   default:
-    throw std::logic_error("GetDType: Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("GetDType: Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return shape of tensor (similar to TShape)
-const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
+const TensorShape TensorUtil::GetShape(NDArray* tensor) {
   TensorShape shape;
-  TShape mx_shape = tensor.shape();
+  TShape mx_shape = tensor->shape();
   for (int idx = 0; idx < (int)mx_shape.ndim(); idx++) {
     shape.AddDim(mx_shape[idx]);
   }
@@ -54,34 +54,34 @@ const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
 }
 
 // Return data of tensor
-const void* TensorUtil::GetData(const NDArray& tensor) {
+const void* TensorUtil::GetData(NDArray* tensor) {
   // The following returns an error:
   // return tensor->data().dptr<void>();
-  switch (tensor.dtype()) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
-    return static_cast<void*>(tensor.data().dptr<float>());
+    return static_cast<void*>(tensor->data().dptr<float>());
   case mshadow::kFloat64:
-    return static_cast<void*>(tensor.data().dptr<double>());
+    return static_cast<void*>(tensor->data().dptr<double>());
   case mshadow::kFloat16:
-    return static_cast<void*>(tensor.data().dptr<mshadow::half::half_t>());
+    return static_cast<void*>(tensor->data().dptr<mshadow::half::half_t>());
   case mshadow::kUint8:
-    return static_cast<void*>(tensor.data().dptr<uint8_t>());
+    return static_cast<void*>(tensor->data().dptr<uint8_t>());
   case mshadow::kInt32:
-    return static_cast<void*>(tensor.data().dptr<int32_t>());
+    return static_cast<void*>(tensor->data().dptr<int32_t>());
   case mshadow::kInt8:
-    return static_cast<void*>(tensor.data().dptr<int8_t>());
+    return static_cast<void*>(tensor->data().dptr<int8_t>());
   case mshadow::kInt64:
-    return static_cast<void*>(tensor.data().dptr<int64_t>());
+    return static_cast<void*>(tensor->data().dptr<int64_t>());
   default:
-    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return size of tensor in bytes
-int64_t TensorUtil::GetSize(const NDArray& tensor) {
+int64_t TensorUtil::GetSize(NDArray* tensor) {
   int64_t element_size = 0;
-  switch (tensor.dtype()) {
+  switch (tensor->dtype()) {
   case mshadow::kFloat32:
     element_size = kFloat32Size;
     break;
@@ -104,10 +104,10 @@ int64_t TensorUtil::GetSize(const NDArray& tensor) {
     element_size = kInt64Size;
     break;
   default:
-    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
                            " is not supported in MPI mode.");
   }
-  return (int64_t)(tensor.shape().Size()) * element_size;
+  return (int64_t)(tensor->shape().Size()) * element_size;
 }
 
 // If Tensor on GPU, return device id
@@ -119,26 +119,12 @@ int TensorUtil::GetDevice(NDArray* tensor) {
   return CPU_DEVICE_ID;
 }
 
-NDArray TensorUtil::CreateNDArray(int device, int dtype) {
-  int dev_type = gpu::kDevMask;
-  if (device == CPU_DEVICE_ID) {
-    dev_type = cpu::kDevMask;
-    device = 0;
-  }
-
-  NDArrayHandle output_handle;
-  MXNDArrayCreateEx64(nullptr, 0, dev_type, device, false, dtype, &output_handle);
-
-
-}
-
 // Resize tensor to nDimension with length size[i] in dimension i
-void TensorUtil::ResizeNd(NDArray &tensor, int nDimension, int64_t* size) {
-  NDArrayHandle input_handle = static_cast<NDArrayHandle>(&tensor);
+// TODO (lnyuan): fix the bug in this function
+void TensorUtil::ResizeNd(NDArray *tensor, int nDimension, int64_t* size) {
   NDArrayHandle output_handle;
-  MXNDArrayReshape64(input_handle, nDimension, size, false, &output_handle);
-  tensor = *(static_cast<NDArray *>(output_handle));
-  MXNDArrayFree(output_handle);
+  MXNDArrayReshape64(tensor, nDimension, size, false, &output_handle);
+  tensor = static_cast<NDArray *>(output_handle);
 }
 
 // Copy from tensor to output

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -119,12 +119,10 @@ int TensorUtil::GetDevice(NDArray* tensor) {
   return CPU_DEVICE_ID;
 }
 
-// Resize tensor to nDimension with length size[i] in dimension i
-// TODO (lnyuan): fix the bug in this function
-void TensorUtil::ResizeNd(NDArray *tensor, int nDimension, int64_t* size) {
-  NDArrayHandle output_handle;
-  MXNDArrayReshape64(tensor, nDimension, size, false, &output_handle);
-  tensor = static_cast<NDArray *>(output_handle);
+// Resize tensor to ndim with length dims[i] in dimension i
+void TensorUtil::ResizeNd(NDArray *tensor, int ndim, int64_t* dims) {
+  TShape shape(dims, dims + ndim);
+  tensor->ReshapeAndAlloc(shape);
 }
 
 // Copy from tensor to output

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -21,8 +21,8 @@ namespace horovod {
 namespace mxnet {
 
 // Define all types for TensorUtil.
-const DataType TensorUtil::GetDType(NDArray* tensor) {
-  switch (tensor->dtype()) {
+const DataType TensorUtil::GetDType(const NDArray& tensor) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
     return DataType::HOROVOD_FLOAT32;
   case mshadow::kFloat64:
@@ -38,15 +38,15 @@ const DataType TensorUtil::GetDType(NDArray* tensor) {
   case mshadow::kInt64:
     return DataType::HOROVOD_INT64;
   default:
-    throw std::logic_error("GetDType: Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("GetDType: Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return shape of tensor (similar to TShape)
-const TensorShape TensorUtil::GetShape(NDArray* tensor) {
+const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
   TensorShape shape;
-  TShape mx_shape = tensor->shape();
+  TShape mx_shape = tensor.shape();
   for (int idx = 0; idx < (int)mx_shape.ndim(); idx++) {
     shape.AddDim(mx_shape[idx]);
   }
@@ -54,34 +54,34 @@ const TensorShape TensorUtil::GetShape(NDArray* tensor) {
 }
 
 // Return data of tensor
-const void* TensorUtil::GetData(NDArray* tensor) {
+const void* TensorUtil::GetData(const NDArray& tensor) {
   // The following returns an error:
   // return tensor->data().dptr<void>();
-  switch (tensor->dtype()) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
-    return static_cast<void*>(tensor->data().dptr<float>());
+    return static_cast<void*>(tensor.data().dptr<float>());
   case mshadow::kFloat64:
-    return static_cast<void*>(tensor->data().dptr<double>());
+    return static_cast<void*>(tensor.data().dptr<double>());
   case mshadow::kFloat16:
-    return static_cast<void*>(tensor->data().dptr<mshadow::half::half_t>());
+    return static_cast<void*>(tensor.data().dptr<mshadow::half::half_t>());
   case mshadow::kUint8:
-    return static_cast<void*>(tensor->data().dptr<uint8_t>());
+    return static_cast<void*>(tensor.data().dptr<uint8_t>());
   case mshadow::kInt32:
-    return static_cast<void*>(tensor->data().dptr<int32_t>());
+    return static_cast<void*>(tensor.data().dptr<int32_t>());
   case mshadow::kInt8:
-    return static_cast<void*>(tensor->data().dptr<int8_t>());
+    return static_cast<void*>(tensor.data().dptr<int8_t>());
   case mshadow::kInt64:
-    return static_cast<void*>(tensor->data().dptr<int64_t>());
+    return static_cast<void*>(tensor.data().dptr<int64_t>());
   default:
-    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return size of tensor in bytes
-int64_t TensorUtil::GetSize(NDArray* tensor) {
+int64_t TensorUtil::GetSize(const NDArray& tensor) {
   int64_t element_size = 0;
-  switch (tensor->dtype()) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
     element_size = kFloat32Size;
     break;
@@ -104,10 +104,10 @@ int64_t TensorUtil::GetSize(NDArray* tensor) {
     element_size = kInt64Size;
     break;
   default:
-    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
-  return (int64_t)(tensor->shape().Size()) * element_size;
+  return (int64_t)(tensor.shape().Size()) * element_size;
 }
 
 // If Tensor on GPU, return device id
@@ -119,27 +119,26 @@ int TensorUtil::GetDevice(NDArray* tensor) {
   return CPU_DEVICE_ID;
 }
 
-// Returns pointer to newly created NDArray
-// If dev_id equal to CPU_DEVICE_ID, construct Tensor on CPU
-// Otherwise construct on GPU
-NDArray* TensorUtil::New(int device, int dtype) {
+NDArray TensorUtil::CreateNDArray(int device, int dtype) {
   int dev_type = gpu::kDevMask;
   if (device == CPU_DEVICE_ID) {
     dev_type = cpu::kDevMask;
     device = 0;
   }
-  NDArrayHandle array;
-  MXNDArrayCreateEx(nullptr, 0, dev_type, device, false, dtype, &array);
-  return static_cast<NDArray*>(array);
+
+  NDArrayHandle output_handle;
+  MXNDArrayCreateEx64(nullptr, 0, dev_type, device, false, dtype, &output_handle);
+
+
 }
 
-void TensorUtil::Free(NDArray* tensor) { delete tensor; }
-
 // Resize tensor to nDimension with length size[i] in dimension i
-void TensorUtil::ResizeNd(NDArray* tensor, int nDimension, int64_t* size) {
-  void* temp_out;
-  MXNDArrayReshape64(tensor, nDimension, size, false, &temp_out);
-  tensor = static_cast<NDArray*>(temp_out);
+void TensorUtil::ResizeNd(NDArray &tensor, int nDimension, int64_t* size) {
+  NDArrayHandle input_handle = static_cast<NDArrayHandle>(&tensor);
+  NDArrayHandle output_handle;
+  MXNDArrayReshape64(input_handle, nDimension, size, false, &output_handle);
+  tensor = *(static_cast<NDArray *>(output_handle));
+  MXNDArrayFree(output_handle);
 }
 
 // Copy from tensor to output

--- a/horovod/mxnet/tensor_util.cc
+++ b/horovod/mxnet/tensor_util.cc
@@ -21,8 +21,8 @@ namespace horovod {
 namespace mxnet {
 
 // Define all types for TensorUtil.
-const DataType TensorUtil::GetDType(NDArray* tensor) {
-  switch (tensor->dtype()) {
+const DataType TensorUtil::GetDType(const NDArray& tensor) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
     return DataType::HOROVOD_FLOAT32;
   case mshadow::kFloat64:
@@ -38,15 +38,15 @@ const DataType TensorUtil::GetDType(NDArray* tensor) {
   case mshadow::kInt64:
     return DataType::HOROVOD_INT64;
   default:
-    throw std::logic_error("GetDType: Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("GetDType: Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return shape of tensor (similar to TShape)
-const TensorShape TensorUtil::GetShape(NDArray* tensor) {
+const TensorShape TensorUtil::GetShape(const NDArray& tensor) {
   TensorShape shape;
-  TShape mx_shape = tensor->shape();
+  TShape mx_shape = tensor.shape();
   for (int idx = 0; idx < (int)mx_shape.ndim(); idx++) {
     shape.AddDim(mx_shape[idx]);
   }
@@ -54,34 +54,34 @@ const TensorShape TensorUtil::GetShape(NDArray* tensor) {
 }
 
 // Return data of tensor
-const void* TensorUtil::GetData(NDArray* tensor) {
+const void* TensorUtil::GetData(const NDArray& tensor) {
   // The following returns an error:
   // return tensor->data().dptr<void>();
-  switch (tensor->dtype()) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
-    return static_cast<void*>(tensor->data().dptr<float>());
+    return static_cast<void*>(tensor.data().dptr<float>());
   case mshadow::kFloat64:
-    return static_cast<void*>(tensor->data().dptr<double>());
+    return static_cast<void*>(tensor.data().dptr<double>());
   case mshadow::kFloat16:
-    return static_cast<void*>(tensor->data().dptr<mshadow::half::half_t>());
+    return static_cast<void*>(tensor.data().dptr<mshadow::half::half_t>());
   case mshadow::kUint8:
-    return static_cast<void*>(tensor->data().dptr<uint8_t>());
+    return static_cast<void*>(tensor.data().dptr<uint8_t>());
   case mshadow::kInt32:
-    return static_cast<void*>(tensor->data().dptr<int32_t>());
+    return static_cast<void*>(tensor.data().dptr<int32_t>());
   case mshadow::kInt8:
-    return static_cast<void*>(tensor->data().dptr<int8_t>());
+    return static_cast<void*>(tensor.data().dptr<int8_t>());
   case mshadow::kInt64:
-    return static_cast<void*>(tensor->data().dptr<int64_t>());
+    return static_cast<void*>(tensor.data().dptr<int64_t>());
   default:
-    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
 }
 
 // Return size of tensor in bytes
-int64_t TensorUtil::GetSize(NDArray* tensor) {
+int64_t TensorUtil::GetSize(const NDArray& tensor) {
   int64_t element_size = 0;
-  switch (tensor->dtype()) {
+  switch (tensor.dtype()) {
   case mshadow::kFloat32:
     element_size = kFloat32Size;
     break;
@@ -104,10 +104,10 @@ int64_t TensorUtil::GetSize(NDArray* tensor) {
     element_size = kInt64Size;
     break;
   default:
-    throw std::logic_error("Type " + std::to_string(tensor->dtype()) +
+    throw std::logic_error("Type " + std::to_string(tensor.dtype()) +
                            " is not supported in MPI mode.");
   }
-  return (int64_t)(tensor->shape().Size()) * element_size;
+  return (int64_t)(tensor.shape().Size()) * element_size;
 }
 
 // If Tensor on GPU, return device id

--- a/horovod/mxnet/tensor_util.h
+++ b/horovod/mxnet/tensor_util.h
@@ -32,19 +32,19 @@ using namespace ::mxnet;
 
 class TensorUtil {
 public:
-  static const DataType GetDType(const NDArray& tensor);
-  static const TensorShape GetShape(const NDArray& tensor);
-  static const void* GetData(const NDArray& tensor);
-  static int64_t GetSize(const NDArray& tensor);
-  static int GetDevice(const NDArray& tensor);
+  static const DataType GetDType(NDArray* tensor);
+  static const TensorShape GetShape(NDArray* tensor);
+  static const void* GetData(NDArray* tensor);
+  static int64_t GetSize(NDArray* tensor);
+  static int GetDevice(NDArray* tensor);
 
   static void ResizeNd(NDArray* tensor, int ndim, int64_t* dims);
   static void Copy(NDArray* output, NDArray* tensor);
   static void DivideTensorInPlace(NDArray* tensor, int value);
 
 #if HAVE_CUDA
-  static void AsyncCopyCPUToCuda(const NDArray& cpu, NDArray& cuda);
-  static void AsyncCopyCudaToCPU(const NDArray& cuda, NDArray& cpu);
+  static void AsyncCopyCPUToCuda(NDArray* cpu, NDArray* cuda);
+  static void AsyncCopyCudaToCPU(NDArray* cuda, NDArray* cpu);
 #endif
 
 private:

--- a/horovod/mxnet/tensor_util.h
+++ b/horovod/mxnet/tensor_util.h
@@ -38,7 +38,7 @@ public:
   static int64_t GetSize(NDArray* tensor);
   static int GetDevice(NDArray* tensor);
 
-  static void ResizeNd(NDArray* tensor, int nDimension, int64_t* size);
+  static void ResizeNd(NDArray* tensor, int ndim, int64_t* dims);
   static void Copy(NDArray* output, NDArray* tensor);
   static void DivideTensorInPlace(NDArray* tensor, int value);
 

--- a/horovod/mxnet/tensor_util.h
+++ b/horovod/mxnet/tensor_util.h
@@ -32,19 +32,19 @@ using namespace ::mxnet;
 
 class TensorUtil {
 public:
-  static const DataType GetDType(NDArray* tensor);
-  static const TensorShape GetShape(NDArray* tensor);
-  static const void* GetData(NDArray* tensor);
-  static int64_t GetSize(NDArray* tensor);
-  static int GetDevice(NDArray* tensor);
+  static const DataType GetDType(const NDArray& tensor);
+  static const TensorShape GetShape(const NDArray& tensor);
+  static const void* GetData(const NDArray& tensor);
+  static int64_t GetSize(const NDArray& tensor);
+  static int GetDevice(const NDArray& tensor);
 
   static void ResizeNd(NDArray* tensor, int ndim, int64_t* dims);
   static void Copy(NDArray* output, NDArray* tensor);
   static void DivideTensorInPlace(NDArray* tensor, int value);
 
 #if HAVE_CUDA
-  static void AsyncCopyCPUToCuda(NDArray* cpu, NDArray* cuda);
-  static void AsyncCopyCudaToCPU(NDArray* cuda, NDArray* cpu);
+  static void AsyncCopyCPUToCuda(const NDArray& cpu, NDArray& cuda);
+  static void AsyncCopyCudaToCPU(const NDArray& cuda, NDArray& cpu);
 #endif
 
 private:

--- a/horovod/mxnet/tensor_util.h
+++ b/horovod/mxnet/tensor_util.h
@@ -32,19 +32,19 @@ using namespace ::mxnet;
 
 class TensorUtil {
 public:
-  static const DataType GetDType(const NDArray& tensor);
-  static const TensorShape GetShape(const NDArray& tensor);
-  static const void* GetData(const NDArray& tensor);
-  static int64_t GetSize(const NDArray& tensor);
-  static int GetDevice(const NDArray& tensor);
+  static const DataType GetDType(NDArray* tensor);
+  static const TensorShape GetShape(NDArray* tensor);
+  static const void* GetData(NDArray* tensor);
+  static int64_t GetSize(NDArray* tensor);
+  static int GetDevice(NDArray* tensor);
 
   static void ResizeNd(NDArray* tensor, int nDimension, int64_t* size);
   static void Copy(NDArray* output, NDArray* tensor);
   static void DivideTensorInPlace(NDArray* tensor, int value);
 
 #if HAVE_CUDA
-  static void AsyncCopyCPUToCuda(const NDArray& cpu, NDArray& cuda);
-  static void AsyncCopyCudaToCPU(const NDArray& cuda, NDArray& cpu);
+  static void AsyncCopyCPUToCuda(NDArray* cpu, NDArray* cuda);
+  static void AsyncCopyCudaToCPU(NDArray* cuda, NDArray* cpu);
 #endif
 
 private:

--- a/horovod/mxnet/tensor_util.h
+++ b/horovod/mxnet/tensor_util.h
@@ -32,21 +32,19 @@ using namespace ::mxnet;
 
 class TensorUtil {
 public:
-  static const DataType GetDType(NDArray* tensor);
-  static const TensorShape GetShape(NDArray* tensor);
-  static const void* GetData(NDArray* tensor);
-  static int64_t GetSize(NDArray* tensor);
-  static int GetDevice(NDArray* tensor);
+  static const DataType GetDType(const NDArray& tensor);
+  static const TensorShape GetShape(const NDArray& tensor);
+  static const void* GetData(const NDArray& tensor);
+  static int64_t GetSize(const NDArray& tensor);
+  static int GetDevice(const NDArray& tensor);
 
-  static NDArray* New(int device, int dtype);
-  static void Free(NDArray* tensor);
   static void ResizeNd(NDArray* tensor, int nDimension, int64_t* size);
   static void Copy(NDArray* output, NDArray* tensor);
   static void DivideTensorInPlace(NDArray* tensor, int value);
 
 #if HAVE_CUDA
-  static void AsyncCopyCPUToCuda(NDArray* cpu, NDArray* cuda);
-  static void AsyncCopyCudaToCPU(NDArray* cuda, NDArray* cpu);
+  static void AsyncCopyCPUToCuda(const NDArray& cpu, NDArray& cuda);
+  static void AsyncCopyCudaToCPU(const NDArray& cuda, NDArray& cpu);
 #endif
 
 private:

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -17,14 +17,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import horovod.mxnet as hvd
-import itertools
-import mxnet as mx
 import os
+import itertools
 import unittest
+import numpy as np
+import mxnet as mx
+
 from mxnet.base import MXNetError
 from mxnet.test_utils import same
 
+import horovod.mxnet as hvd
 
 has_gpu = mx.context.num_gpus() > 0
 
@@ -499,6 +501,83 @@ class MXTests(unittest.TestCase):
         for tensor, root_tensor in zip(tensors, root_tensors):
             assert same(tensor.asnumpy(), root_tensor.asnumpy()), \
                 'horovod did not broadcast deferred initialized parameter correctly'
+
+
+    def test_gluon_trainer(self):
+        """Test using horovod allreduce in MXNet Gluon trainer."""
+        from mxnet import gluon
+        from mxnet.gluon import Block, nn, HybridBlock
+
+        hvd.init()
+        rank = hvd.rank()
+        np.random.seed(1000 + 10 * rank)
+        mx.random.seed(1000 + 10 * rank)
+        ctx = mx.gpu(rank)
+
+        def gen_random_dataset(batch_size=64, dim=32, min_len=20, max_len=100,
+                               size=1000):
+            for _ in range(size):
+                length = np.random.randint(min_len, max_len + 1)
+                rand_src = mx.nd.random.normal(0, 1, (length, dim))
+                rand_dst = mx.nd.random.normal(0, 1, (length, dim))
+                yield rand_src, rand_dst
+
+        class SimpleNet(HybridBlock):
+            def __init__(self, layer_num=6, **kwargs):
+                super(SimpleNet, self).__init__(**kwargs)
+                self._layer_num = layer_num
+                with self.name_scope():
+                    self.ln_l = nn.HybridSequential()
+                    self.dense_l = nn.HybridSequential()
+                    for i in range(layer_num):
+                        self.dense_l.add(nn.Dense(units=32 + layer_num - 1 - i,
+                            flatten=False))
+                        self.ln_l.add(nn.LayerNorm())
+
+            def hybrid_forward(self, F, data):
+                """
+
+                Parameters
+                ----------
+                data :
+                    Shape (batch_size, seq_len, fea_dim)
+
+                Returns
+                -------
+                out :
+                    Shape (batch_size, seq_len, fea_dim)
+                """
+                for i in range(self._layer_num):
+                   data = self.ln_l[i](data)
+                   data = self.dense_l[i](data)
+                return data
+
+        net = SimpleNet()
+        net.initialize(ctx=ctx)
+        net.hybridize(static_alloc=True)
+
+        params = net.collect_params()
+        cnt = 0
+        lr = 1E-4
+        trainer = gluon.Trainer(params, 'adam', {'learning_rate': lr},
+            update_on_kvstore=False)
+
+        data_gen = gen_random_dataset()
+        for (src_data, dst_data) in data_gen:
+            src_data = src_data.as_in_context(ctx).astype(np.float32)
+            dst_data = dst_data.as_in_context(ctx).astype(np.float32)
+            with mx.autograd.record():
+                pred = net(src_data)
+                loss = mx.nd.abs(pred - dst_data).mean()
+                loss.backward()
+            # Begin to update the parameter
+            trainer.step(1.0)
+            cnt += 1
+            l = loss.asscalar()
+            if cnt >= 10:
+                for key, param in params.items():
+                    hvd.allreduce_(param.list_data()[0])
+                cnt = 0
 
 
 if __name__ == '__main__':

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -502,7 +502,7 @@ class MXTests(unittest.TestCase):
             assert same(tensor.asnumpy(), root_tensor.asnumpy()), \
                 'horovod did not broadcast deferred initialized parameter correctly'
 
-
+    @unittest.skipUnless(has_gpu, "no gpu detected")
     def test_gluon_trainer(self):
         """Test using horovod allreduce in MXNet Gluon trainer."""
         from mxnet import gluon

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -258,7 +258,6 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
-
     def test_horovod_allreduce_ndarray_lifetime(self):
         """Test that the input NDArray remains valid during async allreduce"""
         hvd.init()

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -258,7 +258,7 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
-    @unittest.skip('BYPASS FOR NOW')
+
     def test_horovod_allreduce_ndarray_lifetime(self):
         """Test that the input NDArray remains valid during async allreduce"""
         hvd.init()

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -258,6 +258,7 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
+    @unittest.skip('BYPASS FOR NOW')
     def test_horovod_allreduce_ndarray_lifetime(self):
         """Test that the NDArray passed in maintains live during allreduce"""
         hvd.init()

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -258,6 +258,7 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
+    @unittest.skip('BYPASS FOR NOW')
     def test_horovod_allreduce_ndarray_lifetime(self):
         """Test that the input NDArray remains valid during async allreduce"""
         hvd.init()

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -258,7 +258,7 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
-    @unittest.skip('BYPASS FOR NOW')
+
     def test_horovod_allreduce_ndarray_lifetime(self):
         """Test that the NDArray passed in maintains live during allreduce"""
         hvd.init()


### PR DESCRIPTION
This PR includes the following changes:
1) Avoid early destruction of NDArray invoked by Python garbage collection by making a copy using shared_ptr
2) Simplify code by removing unnecessary template class
3) Code refactoring
4) Fixed a bug in ResizeND mentioned in https://github.com/horovod/horovod/issues/1409

This PR fixes https://github.com/horovod/horovod/issues/1533

@eric-haibin-lin @karan6181 @yuxihu Please help review!