### PR TITLE
Enable GPU inference for e2e example keras_spark3_rossmann.py

### DIFF
--- a/examples/keras_spark3_rossmann.py
+++ b/examples/keras_spark3_rossmann.py
@@ -56,6 +56,12 @@ LR = 1e-4
 # HDFS driver to use with Petastorm.
 PETASTORM_HDFS_DRIVER = 'libhdfs'
 
+# Whether to infer on GPU.
+GPU_INFERENCE_ENABLED = False
+
+# Cluster for GPU inference.
+GPU_INFERENCE_CLUSTER = 'local-cluster[2,1,1024]'  # or 'spark://hostname:7077'
+
 # ================ #
 # DATA PREPARATION #
 # ================ #
@@ -543,8 +549,35 @@ print('================')
 conf = SparkConf().setAppName('prediction') \
     .setExecutorEnv('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH')) \
     .setExecutorEnv('PATH', os.environ.get('PATH'))
-if LIGHT_PROCESSING_CLUSTER:
-    conf.setMaster(LIGHT_PROCESSING_CLUSTER)
+
+if GPU_INFERENCE_ENABLED:
+    if GPU_INFERENCE_CLUSTER:
+        conf.setMaster(GPU_INFERENCE_CLUSTER)
+    # This config will change depending on your cluster setup.
+    #
+    # 1. Standalone Cluster
+    # - Must configure spark.worker.* configs as below.
+    #
+    # 2. YARN
+    # - Requires YARN 3.1 or higher to support GPUs
+    # - Cluster should be configured to have isolation on so that
+    #   multiple executors don’t see the same GPU on the same host.
+    # - If you don’t have isolation then you would require a different discovery script
+    #   or other way to make sure that 2 executors don’t try to use same GPU.
+    #
+    # 3. Kubernetes
+    # - Requires GPU support and isolation.
+    # - Add conf.set(“spark.executor.resource.gpu.discoveryScript”, DISCOVERY_SCRIPT)
+    # - Add conf.set(“spark.executor.resource.gpu.vendor”, “nvidia”)
+    conf = conf.set("spark.test.home", os.environ.get('SPARK_HOME'))
+    conf = conf.set("spark.worker.resource.gpu.discoveryScript", DISCOVERY_SCRIPT)
+    conf = conf.set("spark.worker.resource.gpu.amount", 1)
+    conf = conf.set("spark.task.resource.gpu.amount", "1")
+    conf = conf.set("spark.executor.resource.gpu.amount", "1")
+else:
+    if LIGHT_PROCESSING_CLUSTER:
+        conf.setMaster(LIGHT_PROCESSING_CLUSTER)
+
 spark = SparkSession.builder.config(conf=conf).getOrCreate()
 
 
@@ -554,11 +587,18 @@ def predict_fn(model_bytes):
         import tensorflow as tf
         import tensorflow.keras.backend as K
 
-        # Do not use GPUs for prediction, use single CPU core per task.
-        config = tf.ConfigProto(device_count={'GPU': 0})
-        config.inter_op_parallelism_threads = 1
-        config.intra_op_parallelism_threads = 1
-        K.set_session(tf.Session(config=config))
+        if GPU_INFERENCE_ENABLED:
+            from pyspark import TaskContext
+            config = tf.ConfigProto()
+            config.gpu_options.allow_growth = True
+            config.gpu_options.visible_device_list = TaskContext.get().resources()['gpu'].addresses[0]
+            K.set_session(tf.Session(config=config))
+        else:
+            # Do not use GPUs for prediction, use single CPU core per task.
+            config = tf.ConfigProto(device_count={'GPU': 0})
+            config.inter_op_parallelism_threads = 1
+            config.intra_op_parallelism_threads = 1
+            K.set_session(tf.Session(config=config))
 
         # Restore from checkpoint.
         model = deserialize_model(model_bytes, tf.keras.models.load_model)

--- a/examples/keras_spark3_rossmann.py
+++ b/examples/keras_spark3_rossmann.py
@@ -568,7 +568,7 @@ if GPU_INFERENCE_ENABLED:
     # 3. Kubernetes
     # - Requires GPU support and isolation.
     # - Add conf.set(“spark.executor.resource.gpu.discoveryScript”, DISCOVERY_SCRIPT)
-    # - Add conf.set(“spark.executor.resource.gpu.vendor”, “nvidia”)
+    # - Add conf.set(“spark.executor.resource.gpu.vendor”, “nvidia.com”)
     conf = conf.set("spark.test.home", os.environ.get('SPARK_HOME'))
     conf = conf.set("spark.worker.resource.gpu.discoveryScript", DISCOVERY_SCRIPT)
     conf = conf.set("spark.worker.resource.gpu.amount", 1)

--- a/examples/keras_spark3_rossmann.py
+++ b/examples/keras_spark3_rossmann.py
@@ -598,6 +598,7 @@ def predict_fn(model_bytes):
     return fn
 
 
+# Submit a Spark job to do inference. Horovod framework is not involved here.
 pred_df = spark.read.parquet('%s/test_df.parquet' % DATA_LOCATION) \
     .rdd.mapPartitions(predict_fn(best_model_bytes)).toDF()
 submission_df = pred_df.select(pred_df.Id.cast(T.IntegerType()), pred_df.Sales).toPandas()

--- a/examples/keras_spark3_rossmann.py.patch
+++ b/examples/keras_spark3_rossmann.py.patch
@@ -4,33 +4,78 @@
 < TRAINING_CLUSTER = None  # or 'spark://hostname:7077'
 ---
 > TRAINING_CLUSTER = 'local-cluster[2,1,1024]'  # or 'spark://hostname:7077'
-391a393
+57a59,64
+> # Whether to infer on GPU.
+> GPU_INFERENCE_ENABLED = False
+> 
+> # Cluster for GPU inference.
+> GPU_INFERENCE_CLUSTER = 'local-cluster[2,1,1024]'  # or 'spark://hostname:7077'
+> 
+391a399
 >     from horovod.spark.task import get_available_devices
-406c408
+406c414
 <     config.gpu_options.visible_device_list = str(hvd.local_rank())
 ---
 >     config.gpu_options.visible_device_list = get_available_devices()[0]
-492a495,517
+488a497,521
+> def set_gpu_conf(conf):
+>     # This config will change depending on your cluster setup.
+>     #
+>     # 1. Standalone Cluster
+>     # - Must configure spark.worker.* configs as below.
+>     #
+>     # 2. YARN
+>     # - Requires YARN 3.1 or higher to support GPUs
+>     # - Cluster should be configured to have isolation on so that
+>     #   multiple executors don’t see the same GPU on the same host.
+>     # - If you don’t have isolation then you would require a different discovery script
+>     #   or other way to make sure that 2 executors don’t try to use same GPU.
+>     #
+>     # 3. Kubernetes
+>     # - Requires GPU support and isolation.
+>     # - Add conf.set(“spark.executor.resource.gpu.discoveryScript”, DISCOVERY_SCRIPT)
+>     # - Add conf.set(“spark.executor.resource.gpu.vendor”, “nvidia.com”)
+>     conf = conf.set("spark.test.home", os.environ.get('SPARK_HOME'))
+>     conf = conf.set("spark.worker.resource.gpu.discoveryScript", DISCOVERY_SCRIPT)
+>     conf = conf.set("spark.worker.resource.gpu.amount", 1)
+>     conf = conf.set("spark.task.resource.gpu.amount", "1")
+>     conf = conf.set("spark.executor.resource.gpu.amount", "1")
+>     return conf
 > 
-> # This config will change depending on your cluster setup.
-> #
-> # 1. Standalone Cluster
-> # - Must configure spark.worker.* configs as below.
-> #
-> # 2. YARN
-> # - Requires YARN 3.1 or higher to support GPUs
-> # - Cluster should be configured to have isolation on so that
-> #   multiple executors don’t see the same GPU on the same host.
-> # - If you don’t have isolation then you would require a different discovery script
-> #   or other way to make sure that 2 executors don’t try to use same GPU.
-> #
-> # 3. Kubernetes
-> # - Requires GPU support and isolation.
-> # - Add conf.set(“spark.executor.resource.gpu.discoveryScript”, DISCOVERY_SCRIPT)
-> # - Add conf.set(“spark.executor.resource.gpu.vendor”, “nvidia”)
-> conf = conf.set("spark.test.home", os.environ.get('SPARK_HOME'))
-> conf = conf.set("spark.worker.resource.gpu.discoveryScript", DISCOVERY_SCRIPT)
-> conf = conf.set("spark.worker.resource.gpu.amount", 1)
-> conf = conf.set("spark.task.resource.gpu.amount", "1")
-> conf = conf.set("spark.executor.resource.gpu.amount", "1")
 > 
+492a526
+> conf = set_gpu_conf(conf)
+521,522c555,563
+< if LIGHT_PROCESSING_CLUSTER:
+<     conf.setMaster(LIGHT_PROCESSING_CLUSTER)
+---
+> 
+> if GPU_INFERENCE_ENABLED:
+>     if GPU_INFERENCE_CLUSTER:
+>         conf.setMaster(GPU_INFERENCE_CLUSTER)
+>     conf = set_gpu_conf(conf)
+> else:
+>     if LIGHT_PROCESSING_CLUSTER:
+>         conf.setMaster(LIGHT_PROCESSING_CLUSTER)
+> 
+532,536c573,584
+<         # Do not use GPUs for prediction, use single CPU core per task.
+<         config = tf.ConfigProto(device_count={'GPU': 0})
+<         config.inter_op_parallelism_threads = 1
+<         config.intra_op_parallelism_threads = 1
+<         K.set_session(tf.Session(config=config))
+---
+>         if GPU_INFERENCE_ENABLED:
+>             from pyspark import TaskContext
+>             config = tf.ConfigProto()
+>             config.gpu_options.allow_growth = True
+>             config.gpu_options.visible_device_list = TaskContext.get().resources()['gpu'].addresses[0]
+>             K.set_session(tf.Session(config=config))
+>         else:
+>             # Do not use GPUs for prediction, use single CPU core per task.
+>             config = tf.ConfigProto(device_count={'GPU': 0})
+>             config.inter_op_parallelism_threads = 1
+>             config.intra_op_parallelism_threads = 1
+>             K.set_session(tf.Session(config=config))
+552a601
+> # Submit a Spark job to do inference. Horovod framework is not involved here.


### PR DESCRIPTION
Currently only CPU inference is available for end-to-end example keras_spark3_rossmann.py

This PR enables GPU inference for that example:
- There is a flag indicating whether to infer on GPU. It's disabled by default.
- GPU inference runs on a configurable Spark 3.0 cluster.
- This PR also demonstrates Spark 3.0 GPU scheduling.

Besides, there's another pending git commit to enable batch inference on GPU: https://github.com/chuanlihao/horovod/commit/7d5a5690f988a500fbd80dbdeb1609a7a8f90dc6