### PR TITLE
Fixed issue with ThreadPool not joining on reinitialization

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -362,6 +362,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
       gloo_context.Initialize(ParseGlooIface());
     }
 #endif
+
   // Initialize controller
   state.controller->Initialize();
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -362,7 +362,6 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
       gloo_context.Initialize(ParseGlooIface());
     }
 #endif
-
   // Initialize controller
   state.controller->Initialize();
 
@@ -520,6 +519,10 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
     cb(SHUT_DOWN_ERROR);
   }
 
+#if HAVE_CUDA
+  cuda_context.Finalize();
+#endif
+
 #if HAVE_MPI
   mpi_context.Finalize(mpi_ctx_manager);
 #endif
@@ -660,6 +663,7 @@ void horovod_shutdown() {
   if (horovod_global.background_thread.joinable()) {
     horovod_global.shut_down = true;
     horovod_global.background_thread.join();
+
     // Reset the initialization flag to allow restarting with horovod_init(...)
     horovod_global.initialize_flag.clear();
     horovod_global.shut_down = false;

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -21,6 +21,10 @@
 namespace horovod {
 namespace common {
 
+void CUDAContext::Finalize() {
+  finalizer_thread_pool.reset();
+}
+
 cudaError_t CUDAContext::GetCudaEvent(cudaEvent_t* event) {
   int device;
   auto status = cudaGetDevice(&device);

--- a/horovod/common/ops/cuda_operations.h
+++ b/horovod/common/ops/cuda_operations.h
@@ -30,6 +30,8 @@ namespace horovod {
 namespace common {
 
 struct CUDAContext {
+  void Finalize();
+
   cudaError_t GetCudaEvent(cudaEvent_t* event);
 
   cudaError_t ReleaseCudaEvent(cudaEvent_t event);

--- a/horovod/common/thread_pool.cc
+++ b/horovod/common/thread_pool.cc
@@ -26,14 +26,7 @@ void ThreadPool::create(int num_threads) {
 }
 
 ThreadPool::~ThreadPool() {
-  std::unique_lock<std::mutex> lock(mutex_);
-  running_ = false;
-  cond_.notify_all();
-  lock.unlock();
-
-  for (auto& thread: threads_) {
-    thread.join();
-  }
+  reset();
 }
 
 void ThreadPool::execute(std::function<void(void)> f) {
@@ -42,6 +35,18 @@ void ThreadPool::execute(std::function<void(void)> f) {
     work_queue_.push(f);
   }
   cond_.notify_one();
+}
+
+void ThreadPool::reset() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  running_ = false;
+  cond_.notify_all();
+  lock.unlock();
+
+  for (auto& thread: threads_) {
+    thread.join();
+  }
+  threads_.clear();
 }
 
 void ThreadPool::loop() {

--- a/horovod/common/thread_pool.h
+++ b/horovod/common/thread_pool.h
@@ -27,6 +27,7 @@ class ThreadPool {
   public:
     ~ThreadPool();
     void create(int num_threads);
+    void reset();
     void execute(std::function<void(void)> f);
 
   private:

--- a/setup.py
+++ b/setup.py
@@ -524,6 +524,17 @@ def get_ddl_dirs(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
     return ddl_include_dirs, ddl_lib_dirs
 
 
+def set_cuda_options(COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, BUILD_MPI, LIBRARY_DIRS, LIBRARIES, **kwargs):
+    cuda_include_dirs, cuda_lib_dirs = get_cuda_dirs(build_ext, COMPILE_FLAGS)
+    MACROS += [('HAVE_CUDA', '1')]
+    INCLUDES += cuda_include_dirs
+    SOURCES += ['horovod/common/ops/cuda_operations.cc']
+    if BUILD_MPI:
+        SOURCES += ['horovod/common/ops/mpi_cuda_operations.cc']
+    LIBRARY_DIRS += cuda_lib_dirs
+    LIBRARIES += ['cudart']
+
+
 def get_common_options(build_ext):
     cpp_flags = get_cpp_flags(build_ext)
     link_flags = get_link_flags(build_ext)
@@ -672,6 +683,17 @@ def get_common_options(build_ext):
     LIBRARY_DIRS = []
     LIBRARIES = []
 
+    options = dict(MACROS=MACROS,
+                   INCLUDES=INCLUDES,
+                   SOURCES=SOURCES,
+                   COMPILE_FLAGS=COMPILE_FLAGS,
+                   LINK_FLAGS=LINK_FLAGS,
+                   LIBRARY_DIRS=LIBRARY_DIRS,
+                   LIBRARIES=LIBRARIES,
+                   BUILD_GLOO=have_gloo,
+                   BUILD_MPI=have_mpi,
+                   )
+
     cpu_operation = os.environ.get('HOROVOD_CPU_OPERATIONS')
     if cpu_operation:
         print('INFO: Set default CPU operation to ' + cpu_operation)
@@ -722,14 +744,8 @@ def get_common_options(build_ext):
         LINK_FLAGS += ['-lccl']
 
     if have_cuda:
-        MACROS += [('HAVE_CUDA', '1')]
-        INCLUDES += cuda_include_dirs
-        SOURCES += ['horovod/common/ops/cuda_operations.cc']
-        if have_mpi:
-            SOURCES += ['horovod/common/ops/mpi_cuda_operations.cc']
+        set_cuda_options(COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, have_mpi, LIBRARY_DIRS, LIBRARIES)
         INCLUDES += ['horovod/common/ops/cuda']
-        LIBRARY_DIRS += cuda_lib_dirs
-        LIBRARIES += ['cudart']
 
     if have_nccl:
         MACROS += [('HAVE_NCCL', '1')]
@@ -1028,15 +1044,7 @@ def build_mx_extension(build_ext, global_options):
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
     if mx_have_cuda and not macro_have_cuda:
-        cuda_include_dirs, cuda_lib_dirs = get_cuda_dirs(build_ext, options[
-            'COMPILE_FLAGS'])
-        options['MACROS'] += [('HAVE_CUDA', '1')]
-        options['INCLUDES'] += cuda_include_dirs
-        options['SOURCES'] += ['horovod/common/ops/cuda_operations.cc']
-        if options['BUILD_MPI']:
-            options['SOURCES'] += ['horovod/common/ops/mpi_cuda_operations.cc']
-        options['LIBRARY_DIRS'] += cuda_lib_dirs
-        options['LIBRARIES'] += ['cudart']
+        set_cuda_options(**options)
 
     mxnet_mpi_lib.define_macros = options['MACROS']
     if check_macro(options['MACROS'], 'HAVE_CUDA'):
@@ -1164,7 +1172,8 @@ def build_torch_extension(build_ext, global_options, torch_version):
     options = deepcopy(global_options)
 
     have_cuda = is_torch_cuda()
-    if not have_cuda and check_macro(options['MACROS'], 'HAVE_CUDA'):
+    have_cuda_macro = check_macro(options['MACROS'], 'HAVE_CUDA')
+    if not have_cuda and have_cuda_macro:
         raise DistutilsPlatformError(
             'Horovod build with GPU support was requested, but this PyTorch '
             'installation does not support CUDA.')
@@ -1176,13 +1185,13 @@ def build_torch_extension(build_ext, global_options, torch_version):
     # Update HAVE_CUDA to mean that PyTorch supports CUDA. Internally, we will be checking
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
-    updated_macros = set_macro(
-        options['MACROS'], 'HAVE_CUDA', str(int(have_cuda)))
+    if have_cuda and not have_cuda_macro:
+        set_cuda_options(**options)
 
     # Export TORCH_VERSION equal to our representation of torch.__version__. Internally it's
     # used for backwards compatibility checks.
     updated_macros = set_macro(
-        updated_macros, 'TORCH_VERSION', str(torch_version))
+        options['MACROS'], 'TORCH_VERSION', str(torch_version))
 
     # Create_extension overwrites these files which are customized, we need to protect them.
     with protect_files('horovod/torch/mpi_lib/__init__.py',
@@ -1241,7 +1250,8 @@ def build_torch_extension_v2(build_ext, global_options, torch_version):
 
     have_cuda = is_torch_cuda_v2(build_ext, include_dirs=options['INCLUDES'],
                                  extra_compile_args=compile_flags)
-    if not have_cuda and check_macro(options['MACROS'], 'HAVE_CUDA'):
+    have_cuda_macro = check_macro(options['MACROS'], 'HAVE_CUDA')
+    if not have_cuda and have_cuda_macro:
         raise DistutilsPlatformError(
             'Horovod build with GPU support was requested, but this PyTorch '
             'installation does not support CUDA.')
@@ -1249,13 +1259,13 @@ def build_torch_extension_v2(build_ext, global_options, torch_version):
     # Update HAVE_CUDA to mean that PyTorch supports CUDA. Internally, we will be checking
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
-    updated_macros = set_macro(
-        options['MACROS'], 'HAVE_CUDA', str(int(have_cuda)))
+    if have_cuda and not have_cuda_macro:
+        set_cuda_options(**options)
 
     # Export TORCH_VERSION equal to our representation of torch.__version__. Internally it's
     # used for backwards compatibility checks.
     updated_macros = set_macro(
-        updated_macros, 'TORCH_VERSION', str(torch_version))
+        options['MACROS'], 'TORCH_VERSION', str(torch_version))
 
     # Always set _GLIBCXX_USE_CXX11_ABI, since PyTorch can only detect whether it was set to 1.
     updated_macros = set_macro(updated_macros, '_GLIBCXX_USE_CXX11_ABI',
@@ -1274,18 +1284,18 @@ def build_torch_extension_v2(build_ext, global_options, torch_version):
         from torch.utils.cpp_extension import CppExtension as TorchExtension
 
     ext = TorchExtension(torch_mpi_lib_v2.name,
-                        define_macros=updated_macros,
-                        include_dirs=options['INCLUDES'],
-                        sources=options['SOURCES'] + [
+                         define_macros=updated_macros,
+                         include_dirs=options['INCLUDES'],
+                         sources=options['SOURCES'] + [
                             'horovod/torch/mpi_ops_v2.cc',
                             'horovod/torch/handle_manager.cc',
                             'horovod/torch/ready_event.cc',
                             'horovod/torch/cuda_util.cc',
                             'horovod/torch/adapter_v2.cc'],
-                        extra_compile_args=compile_flags,
-                        extra_link_args=options['LINK_FLAGS'],
-                        library_dirs=options['LIBRARY_DIRS'],
-                        libraries=options['LIBRARIES'])
+                         extra_compile_args=compile_flags,
+                         extra_link_args=options['LINK_FLAGS'],
+                         library_dirs=options['LIBRARY_DIRS'],
+                         libraries=options['LIBRARIES'])
 
     # Patch an existing torch_mpi_lib_v2 extension object.
     for k, v in ext.__dict__.items():

--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,7 @@ def get_ddl_dirs(build_ext, cuda_include_dirs, cuda_lib_dirs, cpp_flags):
     return ddl_include_dirs, ddl_lib_dirs
 
 
-def set_cuda_options(COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, BUILD_MPI, LIBRARY_DIRS, LIBRARIES, **kwargs):
+def set_cuda_options(build_ext, COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, BUILD_MPI, LIBRARY_DIRS, LIBRARIES, **kwargs):
     cuda_include_dirs, cuda_lib_dirs = get_cuda_dirs(build_ext, COMPILE_FLAGS)
     MACROS += [('HAVE_CUDA', '1')]
     INCLUDES += cuda_include_dirs
@@ -683,17 +683,6 @@ def get_common_options(build_ext):
     LIBRARY_DIRS = []
     LIBRARIES = []
 
-    options = dict(MACROS=MACROS,
-                   INCLUDES=INCLUDES,
-                   SOURCES=SOURCES,
-                   COMPILE_FLAGS=COMPILE_FLAGS,
-                   LINK_FLAGS=LINK_FLAGS,
-                   LIBRARY_DIRS=LIBRARY_DIRS,
-                   LIBRARIES=LIBRARIES,
-                   BUILD_GLOO=have_gloo,
-                   BUILD_MPI=have_mpi,
-                   )
-
     cpu_operation = os.environ.get('HOROVOD_CPU_OPERATIONS')
     if cpu_operation:
         print('INFO: Set default CPU operation to ' + cpu_operation)
@@ -744,7 +733,7 @@ def get_common_options(build_ext):
         LINK_FLAGS += ['-lccl']
 
     if have_cuda:
-        set_cuda_options(COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, have_mpi, LIBRARY_DIRS, LIBRARIES)
+        set_cuda_options(build_ext, COMPILE_FLAGS, MACROS, INCLUDES, SOURCES, have_mpi, LIBRARY_DIRS, LIBRARIES)
         INCLUDES += ['horovod/common/ops/cuda']
 
     if have_nccl:
@@ -1044,7 +1033,7 @@ def build_mx_extension(build_ext, global_options):
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
     if mx_have_cuda and not macro_have_cuda:
-        set_cuda_options(**options)
+        set_cuda_options(build_ext, **options)
 
     mxnet_mpi_lib.define_macros = options['MACROS']
     if check_macro(options['MACROS'], 'HAVE_CUDA'):
@@ -1186,7 +1175,7 @@ def build_torch_extension(build_ext, global_options, torch_version):
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
     if have_cuda and not have_cuda_macro:
-        set_cuda_options(**options)
+        set_cuda_options(build_ext, **options)
 
     # Export TORCH_VERSION equal to our representation of torch.__version__. Internally it's
     # used for backwards compatibility checks.
@@ -1260,7 +1249,7 @@ def build_torch_extension_v2(build_ext, global_options, torch_version):
     # HOROVOD_GPU_(ALLREDUCE|ALLGATHER|BROADCAST) to decide whether we should use GPU
     # version or transfer tensors to CPU memory for those operations.
     if have_cuda and not have_cuda_macro:
-        set_cuda_options(**options)
+        set_cuda_options(build_ext, **options)
 
     # Export TORCH_VERSION equal to our representation of torch.__version__. Internally it's
     # used for backwards compatibility checks.

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -76,6 +76,26 @@ class TorchTests(unittest.TestCase):
            types = [t for t in types if t in ccl_supported_types]
         return types
 
+    def test_horovod_reinit(self):
+        """Test that Horovod can init -> shutdown -> init successfully."""
+        mpi_rank, _ = mpi_env_rank_and_size()
+        gloo_rank = int(os.getenv('HOROVOD_RANK', -1))
+
+        is_mpi = gloo_rank == -1
+        if is_mpi:
+            # Only applies for Gloo
+            return
+
+        hvd.init()
+        rank, size = hvd.rank(), hvd.size()
+
+        hvd.shutdown()
+        hvd.init()
+        rank2, size2 = hvd.rank(), hvd.size()
+
+        assert rank == rank2
+        assert size == size2
+
     def test_horovod_rank(self):
         """Test that the rank returned by hvd.rank() is correct."""
         mpi_rank, _ = mpi_env_rank_and_size()


### PR DESCRIPTION
Recreating the ThreadPool without joining was resulting in errors of the form:

```
Thu Jan 16 16:21:02 2020[0]<stderr>:terminate called without an active exception
Thu Jan 16 16:21:02 2020[0]<stderr>:Aborted
```

This PR allows `ThreadPool::create` to be called during the second init by joining and clearing threads on shutdown.

Also fixes an issue with mixed install (using CUDA without any GPU Horovod ops) where Horovod CUDA headers would be included and the `HAVE_CUDA` macro would be set, but implementation files would not be included, causing symbol lookup errors at runtime.