### PR TITLE
Prevent launching Horovod ops in MXNet DistributedOptimizer/DistributedTrainer if running on a single rank.

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -51,6 +51,8 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
         return self._optimizer.create_state_multi_precision(index, weight)
 
     def _do_allreduce(self, index, grad):
+        if size() == 1: return
+
         if isinstance(index, (tuple, list)):
             for i in range(len(index)):
                 allreduce_(grad[i], average=False,
@@ -98,6 +100,8 @@ class DistributedTrainer(mx.gluon.Trainer):
         self._scale /= size()
 
     def _allreduce_grads(self):
+        if size() == 1: return
+
         # sort needed for Python < 3.6 is not guaranteed
         for i, param in enumerate(sorted(self._params, key=lambda p: p.name)):
             if param.grad_req != 'null':
@@ -128,6 +132,8 @@ def broadcast_parameters(params, root_rank=0):
         root_rank: The rank of the process from which parameters will be
                    broadcasted to all other processes.
     """
+    if size() == 1: return
+
     tensors = []
     if isinstance(params, dict):
         tensors = [p for _, p in sorted(params.items())]


### PR DESCRIPTION
The current MXNet `DistributedOptimizer`/`DistributedTrainer` implementations will unnecessarily launch Horovod ops in the case where a script is run on a single rank. This PR adds checks to prevent this from occurring.