### PR TITLE
Use parameter names when scheduling allreduces in DistributedTrainer. 

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -102,11 +102,10 @@ class DistributedTrainer(mx.gluon.Trainer):
     def _allreduce_grads(self):
         if size() == 1: return
 
-        # sort needed for Python < 3.6 is not guaranteed
-        for i, param in enumerate(sorted(self._params, key=lambda p: p.name)):
+        for i, param in enumerate(self._params):
             if param.grad_req != 'null':
                 allreduce_(param.list_grad()[0], average=False,
-                           name=str(i), priority=-i)
+                           name=param.name, priority=-i)
 
 
 # Wrapper to inject Horovod broadcast after parameter initialization


### PR DESCRIPTION
#1186 introduced a sort of the parameter list to ensure the parameters were submitted to Horovod in a consistent order across workers when using `DistributedTrainer` so that requests to Horovod are given globally consistent names. This sort should not be applied in the case that the parameter list originates from a `ParameterDict` in MXNet as that data structure is already ordered (based on the graph construction). 

A particular reason this sort should only be applied when absolutely necessary is that the sort by name produces `priority` values based on a name-based ordering, which is unrelated to the underlying computation. Preserving the order of the parameter list from a `ParameterDict` results in assigned priorities consistent with those applied in the native MXNet `Trainer`. 

Update: Instead of conditionally applying the sort, new solution is to just use the parameter names when scheduling the allreduces so that the order of submission no longer matters.