### PR TITLE
Fix keras spark example in docs

### DIFF
--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -234,7 +234,7 @@ shows how you can use the low level ``horovod.spark.run`` API to train a model e
     $ wget https://raw.githubusercontent.com/horovod/horovod/master/examples/keras_spark_rossmann_run.py
     $ wget http://files.fast.ai/part2/lesson14/rossmann.tgz
     $ tar zxvf rossmann.tgz
-    $ python keras_spark_rossmann_advanced.py
+    $ python keras_spark_rossmann_run.py
 
 
 Spark cluster setup


### PR DESCRIPTION
Example file keras_spark_rossmann_advanced.py got renamed to keras_spark_rossmann_run.py during code review but we missed this spot in the docs.