### PR TITLE
Pinned Pandas version to 0.24.2

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -97,7 +97,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.25.3
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -97,7 +97,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.25.3
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.24.2
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -77,7 +77,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.25.3
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.24.2
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -77,7 +77,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.25.3
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \


### PR DESCRIPTION
Petastorm is not compatible with the newly released Pandas==1.0.0 and causes the tests to fail. We will remove this pinned version after petastorm is fixed.