### PR TITLE
Update tests to petastorm==0.8.2 to fix pandas==1.0.0 compatibility

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -97,7 +97,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.24.2
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -77,7 +77,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas==0.24.2
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \

--- a/setup.py
+++ b/setup.py
@@ -1541,7 +1541,7 @@ setup(name='horovod',
           'spark':  [
               'h5py>=2.9',
               'numpy',
-              'petastorm==0.8.2rc0',
+              'petastorm==0.8.2',
               'pyarrow>=0.15.0',  # Petastorm 0.7.7 is not compatible with < 0.15.0
               'pyspark>=2.3.2'
           ],

--- a/setup.py
+++ b/setup.py
@@ -1541,7 +1541,7 @@ setup(name='horovod',
           'spark':  [
               'h5py>=2.9',
               'numpy',
-              'petastorm==0.8.1rc1',
+              'petastorm==0.8.2rc0',
               'pyarrow>=0.15.0',  # Petastorm 0.7.7 is not compatible with < 0.15.0
               'pyspark>=2.3.2'
           ],

--- a/setup.py
+++ b/setup.py
@@ -1541,7 +1541,7 @@ setup(name='horovod',
           'spark':  [
               'h5py>=2.9',
               'numpy',
-              'petastorm>=0.7.7',
+              'petastorm==0.8.1rc1',
               'pyarrow>=0.15.0',  # Petastorm 0.7.7 is not compatible with < 0.15.0
               'pyspark>=2.3.2'
           ],


### PR DESCRIPTION
After fix is confirmed and new petastorm version is released, we will update the petastorm version and merge.