### PR TITLE
Add dev to extras_require in setup.py

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -6,6 +6,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION=16.04
 ARG MPI_KIND=OpenMPI
 ARG PYTHON_VERSION=3.6
+# NOTE: keep versions in sync with setup.py extras_require{'dev'}:
 ARG TENSORFLOW_PACKAGE=tensorflow-cpu==1.15.0
 ARG KERAS_PACKAGE=keras==2.2.4
 ARG PYTORCH_PACKAGE=torch==1.2.0+cpu

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -25,17 +25,19 @@ Develop within a virtual environment to avoid dependency issues:
 
 We recommend installing package versions that match with those under test in
 `Buildkite <https://github.com/horovod/horovod/blob/master/.buildkite/gen-pipeline.sh>`__.
-
-For example:
+The following versions are recommended (see default versions defined through :code:`ARG` in
+`Dockerfile.test.cpu <https://github.com/horovod/horovod/blob/master/Dockerfile.test.cpu>`__ and
+`Dockerfile.test.gpu <https://github.com/horovod/horovod/blob/master/Dockerfile.test.gpu>`__ file.
+The versions with CPU support can be installed through the provided :code:`setup.py` file:
 
 .. code-block:: bash
 
-    $ pip install tensorflow==1.14.0
-    $ pip install keras==2.2.4
-    $ pip install torch==1.1.0 torchvision
-    $ pip install mock pytest pytest-forked parameterized
-    $ pip install h5py future scipy mpi4py pyspark mxnet
+    pip install -e .[dev]
 
+You can find all other non-Python packages that need to be installed on your system for Horovod to build
+in the `Dockerfile.test.cpu <https://github.com/horovod/horovod/blob/master/Dockerfile.test.cpu>`__ and
+`Dockerfile.test.gpu <https://github.com/horovod/horovod/blob/master/Dockerfile.test.gpu>`__ files.
+Specifically, see all :code:`RUN apt-get install` lines.
 
 Build and Install
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,20 @@ class custom_build_ext(build_ext):
             raise RuntimeError('CMake failed: {}'.format(str(e)))
 
 
+# python packages required to use horovod in general
 require_list = ['cloudpickle', 'psutil', 'pyyaml', 'dataclasses;python_version<"3.7"']
+
+# python packages required / recommended to develop horovod
+# e.g., set of framework versions pinned for development, keep in sync with Dockerfile.test.cpu
+# NOTE: do not use versions with +cpu or +gpu here as users would need to add --find-links to pip
+dev_require_list = ['tensorflow-cpu==1.15.0',
+                    'keras==2.2.4',
+                    'torch==1.2.0',
+                    'torchvision==0.4.0',
+                    'mxnet==1.5.0',
+                    'pyspark==2.4.0']
+
+# python packages required only to run tests
 test_require_list = ['mock', 'pytest', 'pytest-forked', 'parameterized']
 
 # framework dependencies
@@ -158,7 +171,16 @@ setup(name='horovod',
           'mxnet': mxnet_require_list,
           'spark': spark_require_list,
           'ray': ray_require_list,
+          'dev': dev_require_list,
       },
+      # not used by pip since 19.0: https://github.com/pypa/pip/issues/4187#issuecomment-415067034
+      # here for completeness as pip install needs some of these via -f for versions with '+cpu'
+      # for examples, see Dockerfile.test.cpu and Dockerfile.test.gpu
+      dependency_links=[
+          'https://download.pytorch.org/whl/torch_stable.html',
+          'https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html',
+          'https://dist.mxnet.io/python/all'
+      ],
       python_requires='>=3.6',
       zip_safe=False,
       entry_points={


### PR DESCRIPTION
This simplifies initial setup of an development environment by invoking
```
pip install -e .[dev]
```
Rather than extracting the dependencies from documentation.

Note: this contains #1698, which is unrelated to this PR and should go into master first.