### PR TITLE
Pin pyarrow<0.16.0

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -43,6 +43,7 @@ RUN pip install -U --force pip setuptools requests pytest mock pytest-forked
 # Install PySpark.
 RUN apt-get update -qq && apt install -y openjdk-8-jdk-headless
 RUN pip install ${PYSPARK_PACKAGE}
+RUN pip install 'pyarrow<0.16.0'
 
 # Install MPI.
 RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -50,6 +50,7 @@ RUN pip install -U --force pip setuptools requests pytest mock pytest-forked
 # Install PySpark.
 RUN apt-get update -qq && apt install -y openjdk-8-jdk-headless
 RUN pip install ${PYSPARK_PACKAGE}
+RUN pip install 'pyarrow<0.16.0'
 
 # Install MPI.
 RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \


### PR DESCRIPTION
The 0.16 release of PyArrow requires numpy > 0.15, but older versions of MXNet are incompatible with more recent versions of numpy.  As such, we need to test against an older version of PyArrow.

In a followup PR, we will have per-test versions of PyArrow so we can test old MXNet + old PyArrow as well as new MXNet + new PyArrow.

Signed-off-by: Travis Addair <taddair@uber.com>