### PR TITLE
Properly set set_shutdown flag in response_list when using cached communication path

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -190,6 +190,7 @@ ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
 
     // Fuse responses as normal.
     response_list = FuseResponses(responses);
+    response_list.set_shutdown(cache_coordinator.should_shut_down());
   } else {
     // There are uncached messages coming in, need communication to figure out
     // whether those are ready to be reduced.


### PR DESCRIPTION
When using the cached communication path, the shutdown flag in the generated `response_list` is left unset (defaults to `false`). I added the missing call to `response_list.set_shutdown`.  