### PR TITLE
Use backend api instead of tensorflow api in keras callbacks.

### DIFF
--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -52,8 +52,8 @@ class MetricAverageCallbackImpl(object):
         self.device = device
 
     def _make_variable(self, metric, value):
-        with tf.name_scope('MetricAverageCallback'):
-            var = tf.Variable(value, name=metric)
+        with self.backend.name_scope('MetricAverageCallback'):
+            var = self.backend.variable(value, name=metric)
             self.backend.get_session().run(var.initializer)
             allreduce_op = hvd.allreduce(var, device_dense=self.device)
             return var, allreduce_op
@@ -66,7 +66,7 @@ class MetricAverageCallbackImpl(object):
         for metric, value in sorted(logs.items()):
             if hvd._executing_eagerly():
                 reduced_logs[metric] = \
-                    hvd.allreduce(tf.constant(value, name=metric)).numpy()
+                    hvd.allreduce(self.backend.constant(value, name=metric)).numpy()
             else:
                 if metric not in self.variables:
                     self.variables[metric], self.allreduce_ops[metric] = \


### PR DESCRIPTION
I ran into a type error with `hvd.callbacks.MetricAverageCallback()`. It turns out it was because `tf.Variable` did not respect the type specified with keras `set_floatx`. Using the backend API fixed the issue, and it's probably good to do that every where that's possible.

@nvcastet @bnemanich