### PR TITLE
remove uses of deprecated torch API (removed on commit #33376 on pyto…

### DIFF
--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -52,8 +52,8 @@ class MetricAverageCallbackImpl(object):
         self.device = device
 
     def _make_variable(self, metric, value):
-        with tf.name_scope('MetricAverageCallback'):
-            var = tf.Variable(value, name=metric)
+        with self.backend.name_scope('MetricAverageCallback'):
+            var = self.backend.variable(value, name=metric)
             self.backend.get_session().run(var.initializer)
             allreduce_op = hvd.allreduce(var, device_dense=self.device)
             return var, allreduce_op
@@ -66,7 +66,7 @@ class MetricAverageCallbackImpl(object):
         for metric, value in sorted(logs.items()):
             if hvd._executing_eagerly():
                 reduced_logs[metric] = \
-                    hvd.allreduce(tf.constant(value, name=metric)).numpy()
+                    hvd.allreduce(self.backend.constant(value, name=metric)).numpy()
             else:
                 if metric not in self.variables:
                     self.variables[metric], self.allreduce_ops[metric] = \

--- a/horovod/torch/ready_event.cc
+++ b/horovod/torch/ready_event.cc
@@ -14,7 +14,12 @@
 // =============================================================================
 
 #if HAVE_CUDA
+#if TORCH_VERSION >= 1005000000
+#include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDAException.h>
+#else
 #include <THC/THC.h>
+#endif
 #include <cassert>
 #include <mutex>
 #include <queue>
@@ -24,8 +29,10 @@
 #include "ready_event.h"
 #include "cuda_util.h"
 
+#if TORCH_VERSION < 1005000000
 #if HAVE_CUDA
 extern THCState* state;
+#endif
 #endif
 
 namespace horovod {
@@ -50,12 +57,22 @@ TorchReadyEvent::TorchReadyEvent(int device) : device_(device) {
       cuda_event_ = queue.front();
       queue.pop();
     } else {
+      #if TORCH_VERSION >= 1005000000
+      C10_CUDA_CHECK(cudaEventCreateWithFlags(
+          &cuda_event_, cudaEventBlockingSync | cudaEventDisableTiming));
+      #else
       THCudaCheck(cudaEventCreateWithFlags(
           &cuda_event_, cudaEventBlockingSync | cudaEventDisableTiming));
+      #endif
     }
   }
-  auto stream = THCState_getCurrentStreamOnDevice(state, device_);
+  #if TORCH_VERSION >= 1005000000
+  auto stream = c10::cuda::getCurrentCUDAStream(device_);
+  C10_CUDA_CHECK(cudaEventRecord(cuda_event_, stream));
+  #else
+  auto stream = THCudaCheck(cudaEventRecord(cuda_event_, stream));
   THCudaCheck(cudaEventRecord(cuda_event_, stream));
+  #endif
 }
 
 TorchReadyEvent::~TorchReadyEvent() {
@@ -71,7 +88,11 @@ bool TorchReadyEvent::Ready() const {
   if (status == cudaErrorNotReady) {
     return false;
   }
+  #if TORCH_VERSION >= 1005000000
+  C10_CUDA_CHECK(status);
+  #else
   THCudaCheck(status);
+  #endif
   return true;
 }
 #endif


### PR DESCRIPTION
The commit https://github.com/pytorch/pytorch/pull/33376 removed the functions of the family `THCState_getCurrentStream`. The functionality of these functions are now provided by functions of the pytorch's C10 library.

These changes causes problems on the file `read_events.cc` that use some of these functions. I have replaced these functions with the C10 correspondents. However for backward compatibility the previously used functions still on the code guarded by a TORCH_VERSION check.