### PR TITLE
remove uses of deprecated torch API (removed on commit #33376 on pyto…

### DIFF
--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.5.0.dev20200131 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+	pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -161,7 +161,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
+        TENSORFLOW_PACKAGE: tensorflow==2.1.0 tensorflow-estimator==2.1.0
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -174,7 +174,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
+        TENSORFLOW_PACKAGE: tensorflow==2.1.0 tensorflow-estimator==2.1.0
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -278,7 +278,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.4.8-1+cuda10.1
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.1.0 tensorflow-gpu-estimator==2.1.0
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision

--- a/horovod/torch/ready_event.cc
+++ b/horovod/torch/ready_event.cc
@@ -70,7 +70,7 @@ TorchReadyEvent::TorchReadyEvent(int device) : device_(device) {
   auto stream = c10::cuda::getCurrentCUDAStream(device_);
   C10_CUDA_CHECK(cudaEventRecord(cuda_event_, stream));
   #else
-  auto stream = THCudaCheck(cudaEventRecord(cuda_event_, stream));
+  auto stream = THCState_getCurrentStreamOnDevice(state, device_);
   THCudaCheck(cudaEventRecord(cuda_event_, stream));
   #endif
 }

--- a/horovod/torch/ready_event.cc
+++ b/horovod/torch/ready_event.cc
@@ -14,7 +14,12 @@
 // =============================================================================
 
 #if HAVE_CUDA
+#if TORCH_VERSION >= 1005000000
+#include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDAException.h>
+#else
 #include <THC/THC.h>
+#endif
 #include <cassert>
 #include <mutex>
 #include <queue>
@@ -24,8 +29,10 @@
 #include "ready_event.h"
 #include "cuda_util.h"
 
+#if TORCH_VERSION < 1005000000
 #if HAVE_CUDA
 extern THCState* state;
+#endif
 #endif
 
 namespace horovod {
@@ -50,12 +57,22 @@ TorchReadyEvent::TorchReadyEvent(int device) : device_(device) {
       cuda_event_ = queue.front();
       queue.pop();
     } else {
+      #if TORCH_VERSION >= 1005000000
+      C10_CUDA_CHECK(cudaEventCreateWithFlags(
+          &cuda_event_, cudaEventBlockingSync | cudaEventDisableTiming));
+      #else
       THCudaCheck(cudaEventCreateWithFlags(
           &cuda_event_, cudaEventBlockingSync | cudaEventDisableTiming));
+      #endif
     }
   }
-  auto stream = THCState_getCurrentStreamOnDevice(state, device_);
+  #if TORCH_VERSION >= 1005000000
+  auto stream = c10::cuda::getCurrentCUDAStream(device_);
+  C10_CUDA_CHECK(cudaEventRecord(cuda_event_, stream));
+  #else
+  auto stream = THCudaCheck(cudaEventRecord(cuda_event_, stream));
   THCudaCheck(cudaEventRecord(cuda_event_, stream));
+  #endif
 }
 
 TorchReadyEvent::~TorchReadyEvent() {
@@ -71,7 +88,11 @@ bool TorchReadyEvent::Ready() const {
   if (status == cudaErrorNotReady) {
     return false;
   }
+  #if TORCH_VERSION >= 1005000000
+  C10_CUDA_CHECK(status);
+  #else
   THCudaCheck(status);
+  #endif
   return true;
 }
 #endif


### PR DESCRIPTION
The commit https://github.com/pytorch/pytorch/pull/33376 removed the functions of the family THCState_getCurrentStream. The functionality of these functions are now provided by functions of the pytorch's C10 library.

These changes causes problems on the file `read_events.cc` that use some of these functions. I have replaced these functions with the C10 correspondents. However for backward compatibility the previously used functions still on the code guarded by a TORCH_VERSION check.

I have closed this same issue and I am now reopening it. Because accidentally I have messed up the signoff procedure when I first opened it. Sorry for the inconvenience

Signed-off-by: aavbsouza <aavbsouza@gmail.com>