### PR TITLE
Reenabled GPU tests on g4dn.12xlarge spot instances

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -8,27 +8,27 @@ repository=823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
 
 # list of all the tests
 tests=( \
-       test-cpu-openmpi-py2_7-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-openmpi-py3_6-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+#       test-cpu-openmpi-py2_7-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
+#       test-cpu-openmpi-py3_6-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
+#       test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
+#       test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
+#       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+#       test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+#       test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
+#       test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
+#       test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+#       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+#       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+#       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
 )
 
 build_test() {

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -314,10 +314,10 @@ for test in ${tests[@]}; do
     # if mpi is specified, run mpi cpu_test
     if [[ ${test} == *mpi* ]]; then
       run_mpi ${test} "cpu"
-    fi
 
-    # spark tests use MPI
-    run_spark ${test} "cpu"
+      # spark tests use MPI
+      run_spark ${test} "cpu"
+    fi
 
     # no runner application, world size = 1
     run_single ${test} "cpu"

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -23,13 +23,12 @@ tests=( \
        test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       # TODO(travis): reenable once billing issues resolved
-#       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-#       test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-#       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
+       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
 )
 
 build_test() {
@@ -92,10 +91,9 @@ run_test() {
   echo "    queue: ${queue}"
 }
 
-run_all() {
+run_mpi_pytest() {
   local test=$1
   local queue=$2
-  local pytest_queue=$3
 
   local exclude_keras_if_needed=""
   if [[ ${test} == *"tf2_"* ]] || [[ ${test} == *"tfhead"* ]]; then
@@ -108,9 +106,14 @@ run_all() {
   local exclude_interactiverun="| sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g'"
 
   # pytests have 4x GPU use cases and require a separate queue
-  run_test "${test}" "${pytest_queue}" \
+  run_test "${test}" "${queue}" \
     ":pytest: Run PyTests (${test})" \
     "bash -c \"cd /horovod/test && (echo test_*.py ${exclude_keras_if_needed} ${exclude_interactiverun} | xargs -n 1 \\\$(cat /mpirun_command) pytest -v --capture=no)\""
+}
+
+run_mpi_integration() {
+  local test=$1
+  local queue=$2
 
   # Run test_interactiverun.py
   if [[ ${test} != *"mpich"* ]]; then
@@ -173,6 +176,62 @@ run_all() {
       ":tensorflow: Test TensorFlow 2.0 Keras MNIST (${test})" \
       "bash -c \"\\\$(cat /mpirun_command) python /horovod/examples/tensorflow2_keras_mnist.py\""
   fi
+}
+
+run_mpi() {
+  local test=$1
+  local queue=$2
+
+  run_mpi_pytest ${test} ${queue}
+  run_mpi_integration ${test} ${queue}
+}
+
+run_gloo_pytest() {
+  local test=$1
+  local queue=$2
+
+  # Seems that spark tests depend on MPI, do not test those when mpi is not available
+  local exclude_spark_if_needed=""
+  if [[ ${test} != *"mpi"* ]]; then
+    exclude_spark_if_needed="| sed 's/[a-z_]*spark[a-z_.]*//g'"
+  fi
+
+  # These tests are covered in MPI, and testing them in Gloo does not cover any new code paths
+  local excluded_tests="| sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'"
+
+  run_test "${test}" "${queue}" \
+    ":pytest: Run PyTests (${test})" \
+    "bash -c \"cd /horovod/test && (echo test_*.py ${exclude_spark_if_needed} ${excluded_tests} | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no)\""
+}
+
+run_gloo_integration() {
+  local test=$1
+  local queue=$2
+
+  run_test "${test}" "${queue}" \
+    ":tensorflow: Test Keras MNIST (${test})" \
+    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras_mnist_advanced.py"
+
+  run_test "${test}" "${queue}" \
+    ":python: Test PyTorch MNIST (${test})" \
+    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch_mnist.py"
+
+  run_test "${test}" "${queue}" \
+    ":muscle: Test MXNet MNIST (${test})" \
+    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet_mnist.py"
+}
+
+run_gloo() {
+  local test=$1
+  local queue=$2
+
+  run_gloo_pytest ${test} ${queue}
+  run_gloo_integration ${test} ${queue}
+}
+
+run_spark() {
+  local test=$1
+  local queue=$2
 
   # Horovod Spark Estimator tests
   if [[ ${test} != *"tf1_1_0"* && ${test} != *"tf1_6_0"* && ${test} != *"torch0_"* && ${test} != *"mpich"* ]]; then
@@ -190,41 +249,9 @@ run_all() {
   fi
 }
 
-run_gloo() {
-  local test=$1
-  local queue=$2
-  local pytest_queue=$3
-
-  # Seems that spark tests depend on MPI, do not test those when mpi is not available
-  local exclude_spark_if_needed=""
-  if [[ ${test} != *"mpi"* ]]; then
-    exclude_spark_if_needed="| sed 's/[a-z_]*spark[a-z_.]*//g'"
-  fi
-
-  # These tests are covered in MPI, and testing them in Gloo does not cover any new code paths
-  local excluded_tests="| sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'"
-
-  run_test "${test}" "${pytest_queue}" \
-    ":pytest: Run PyTests (${test})" \
-    "bash -c \"cd /horovod/test && (echo test_*.py ${exclude_spark_if_needed} ${excluded_tests} | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no)\""
-
-  run_test "${test}" "${queue}" \
-    ":tensorflow: Test Keras MNIST (${test})" \
-    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras_mnist_advanced.py"
-
-  run_test "${test}" "${queue}" \
-    ":python: Test PyTorch MNIST (${test})" \
-    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch_mnist.py"
-
-  run_test "${test}" "${queue}" \
-    ":muscle: Test MXNet MNIST (${test})" \
-    "horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet_mnist.py"
-}
-
 run_single() {
   local test=$1
   local queue=$2
-  local pytest_queue=$3
 
   # Only in TensorFlow 1.X
   if [[ ${test} != *"tf2_"* ]] && [[ ${test} != *"tfhead"* ]]; then
@@ -281,30 +308,54 @@ for test in ${tests[@]}; do
   if [[ ${test} == *-cpu-* ]]; then
     # if gloo is specified, run gloo_test
     if [[ ${test} == *-gloo* ]]; then
-      run_gloo ${test} "cpu" "cpu"
+      run_gloo ${test} "cpu"
     fi
+
     # if mpi is specified, run mpi cpu_test
     if [[ ${test} == *mpi* ]]; then
-      run_all ${test} "cpu" "cpu"
+      run_mpi ${test} "cpu"
     fi
+
+    # spark tests use MPI
+    run_spark "cpu"
+
     # no runner application, world size = 1
-    run_single ${test} "cpu" "cpu"
+    run_single ${test} "cpu"
   fi
 done
 
 # wait for all builds to finish
 echo "- wait"
 
-# run all the gpu tests
+# run 4x gpu tests
 for test in ${tests[@]}; do
   if [[ ${test} == *-gpu-* ]] || [[ ${test} == *-mixed-* ]]; then
     # if gloo is specified, run gloo_test
     if [[ ${test} == *-gloo* ]]; then
-      run_gloo ${test} "gpu" "4x-gpu"
+      run_gloo_pytest ${test} "4x-gpu-g4"
     fi
+
     # if mpi is specified, run mpi gpu_test
     if [[ ${test} == *mpi* ]]; then
-      run_all ${test} "gpu" "4x-gpu"
+      run_mpi_pytest ${test} "4x-gpu-g4"
+    fi
+  fi
+done
+
+# wait for all builds to finish
+echo "- wait"
+
+# run 2x gpu tests
+for test in ${tests[@]}; do
+  if [[ ${test} == *-gpu-* ]] || [[ ${test} == *-mixed-* ]]; then
+    # if gloo is specified, run gloo_test
+    if [[ ${test} == *-gloo* ]]; then
+      run_gloo_integration ${test} "2x-gpu-g4"
+    fi
+
+    # if mpi is specified, run mpi gpu_test
+    if [[ ${test} == *mpi* ]]; then
+      run_mpi_integration ${test} "2x-gpu-g4"
     fi
   fi
 done

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -317,7 +317,7 @@ for test in ${tests[@]}; do
     fi
 
     # spark tests use MPI
-    run_spark "cpu"
+    run_spark ${test} "cpu"
 
     # no runner application, world size = 1
     run_single ${test} "cpu"

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -8,27 +8,27 @@ repository=823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
 
 # list of all the tests
 tests=( \
-#       test-cpu-openmpi-py2_7-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
-#       test-cpu-openmpi-py3_6-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
-#       test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-#       test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-#       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-#       test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-#       test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-#       test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-#       test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-#       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
-#       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py2_7-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
+       test-cpu-openmpi-py3_6-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2 \
+       test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
+       test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
+       test-cpu-openmpi-py2_7-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py2_7-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
+       test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
+       test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
+       test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
-#       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
+       test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
 )
 
 build_test() {

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -17,7 +17,6 @@ ARG PYSPARK_PACKAGE=pyspark==2.4.0
 SHELL ["/bin/bash", "-cu"]
 
 # Install essential packages.
-RUN echo "hello"
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         wget \
         ca-certificates \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -99,6 +99,10 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
 RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas enum34
+RUN pip --version
+RUN pip list
+RUN python -m pip --version
+RUN python -m pip list
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -98,7 +98,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas enum34
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -17,6 +17,7 @@ ARG PYSPARK_PACKAGE=pyspark==2.4.0
 SHELL ["/bin/bash", "-cu"]
 
 # Install essential packages.
+RUN echo "hello"
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         wget \
         ca-certificates \
@@ -98,11 +99,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas enum34
-RUN pip --version
-RUN pip list
-RUN python -m pip --version
-RUN python -m pip list
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.4.0 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.5.0.dev20200131 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -78,7 +78,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas enum34
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.4.0.dev20200116 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.4.0 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.5.0.dev20200214 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.5.0.dev20200131 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.4.0.dev20200116 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.5.0.dev20200214 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.5.0.dev20200213 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -78,7 +78,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas enum34
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -88,7 +88,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-        pip install --pre torch==1.5.0.dev20200213 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch==1.5.0.dev20200131 ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -275,7 +275,7 @@ services:
       args:
         CUDA_DOCKER_VERSION: 10.1-devel-ubuntu18.04
         CUDNN_VERSION: 7.6.5.32-1+cuda10.1
-        NCCL_VERSION_OVERRIDE: 2.5.6-1+cuda10.1
+        NCCL_VERSION_OVERRIDE: 2.4.8-1+cuda10.1
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -280,8 +280,8 @@ services:
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
-        PYTORCH_PACKAGE: torch==1.3.0
-        TORCHVISION_PACKAGE: torchvision==0.4.1
+        PYTORCH_PACKAGE: torch-nightly
+        TORCHVISION_PACKAGE: torchvision
         MXNET_PACKAGE: mxnet-cu101==1.6.0b20190808
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -280,8 +280,8 @@ services:
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
-        PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
+        PYTORCH_PACKAGE: torch==1.3.0
+        TORCHVISION_PACKAGE: torchvision==0.4.1
         MXNET_PACKAGE: mxnet-cu101==1.6.0b20190808
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -161,7 +161,7 @@ services:
       args:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203
+        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -174,7 +174,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203
+        TENSORFLOW_PACKAGE: tf-nightly==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -278,7 +278,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.5.6-1+cuda10.1
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.1.0.dev20191203 tf-estimator-nightly==2.1.0.dev2020012309
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision


### PR DESCRIPTION
This PR includes the following changes:

1. Enable all previously disabled GPU tests using G4 spot instances in AWS, now that budgeting has been sorted out.
2. Pin PyTorch to a specific working nightly until #1731 fixes v1.5.0 API incompatibilities.
3. Revert NCCL used in testing to 2.4.8, as 2.5.6 caused segfaults in pytests.

Signed-off-by: Travis Addair <taddair@uber.com>