### PR TITLE
Fix root rank output handling bug in MXNet out-of-place broadcast.

### DIFF
--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -96,11 +96,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
       });
       break;
     case OperationType::BROADCAST:
-      if (horovod_rank() == ops_param->root_rank) {
-        if (tensor != output) {
-          TensorUtil::Copy(output, tensor);
-        }
-      } else {
+      if (horovod_rank() != ops_param->root_rank) {
         hvd_output = std::make_shared<MXTensor>(output);
       }
 

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -190,8 +190,11 @@ def broadcast(tensor, root_rank, name=None, priority=0):
         A tensor of the same shape and type as `tensor`, with the value
         broadcasted from root rank.
     """
-    output = mx.nd.zeros(shape=tensor.shape, ctx=tensor.context,
-                         dtype=tensor.dtype)
+    if rank == root_rank:
+        output = tensor.copy()
+    else:
+        output = mx.nd.zeros(shape=tensor.shape, ctx=tensor.context,
+                             dtype=tensor.dtype)
     c_in = tensor.handle
     c_out = output.handle
     if isinstance(name, string_types):

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -190,7 +190,7 @@ def broadcast(tensor, root_rank, name=None, priority=0):
         A tensor of the same shape and type as `tensor`, with the value
         broadcasted from root rank.
     """
-    if rank == root_rank:
+    if rank() == root_rank:
         output = tensor.copy()
     else:
         output = mx.nd.zeros(shape=tensor.shape, ctx=tensor.context,


### PR DESCRIPTION
Recent testing has shown that there is an issue with the existing MXNet out-of-place broadcast implementation in setting the output result on the root rank. The existing implementation has a race condition that can return zero tensor instead of the expected output if it is queried quickly after the `hvd.broadcast` call. For instance, in this example here:
```
    tensor = nd.full((1), 42, dtype=np.int32)
    output = hvd.broadcast(tensor=tensor, root_rank=0)
    result = output[0].asscalar()
```
we see that `result` on the root rank can sometimes be `0` instead of the expected value `42`.

The issue is due to this special handling for root rank and the call to `TensorUtil::Copy` here: https://github.com/horovod/horovod/blob/master/horovod/mxnet/mpi_ops.cc#L101

The problem arises because `TensorUtil::Copy` launches an MXNet op (`CopyFromTo`) within the Horovod op to copy the root rank input to output. This creates a race condition because if `output.asscalar()` is scheduled on the Python main thread before `CopyFromTo` is scheduled by the engine worker thread, it will return the output tensor before the copy is carried out, yielding an incorrect zero tensor.  

This is fixed by moving the input to output tensor copy on the root rank to the `hvd.broadcast` function in Python. 

cc @ptrendx