### PR TITLE
Do not run mxnet nightly with py2.7

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -114,7 +114,7 @@ RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; then \
-        pip install --pre mxnet -f https://dist.mxnet.io/python/all; \
+        pip install --pre mxnet-mkl -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \
     fi

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -113,7 +113,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
+RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; then \
         pip install --pre mxnet -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -96,7 +96,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
+RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; then \
         pip install --pre mxnet-cu101 -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -165,7 +165,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
-        MXNET_PACKAGE: mxnet-nightly
+        MXNET_PACKAGE: mxnet==1.5.1
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-cpu-base
@@ -282,7 +282,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
-        MXNET_PACKAGE: mxnet-cu101==1.6.0b20190808
+        MXNET_PACKAGE: mxnet-nightly
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-gpu-base

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -165,7 +165,7 @@ services:
         KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
-        MXNET_PACKAGE: mxnet==1.5.1
+        MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-cpu-base


### PR DESCRIPTION
MXNet nightly stopped supporting python 2.7. This PR will test horovod with mxnet 1.5 when Python version is 2.7