### PR TITLE
support data transformation  before train and validation in torch estimators

### DIFF
--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -80,6 +80,11 @@ class EstimatorParams(Params):
                    'then training will resume from last checkpoint in the store',
                    typeConverter=TypeConverters.toString)
 
+    transformation_fn = Param(Params._dummy(), 'transformation_fn',
+                              'functions that construct the transformation '
+                              'function that applies custom transformations to '
+                              'every batch before train and validation steps')
+
     def __init__(self):
         super(EstimatorParams, self).__init__()
 
@@ -106,7 +111,8 @@ class EstimatorParams(Params):
             partitions_per_process=10,
             run_id=None,
             train_steps_per_epoch=None,
-            validation_steps_per_epoch=None)
+            validation_steps_per_epoch=None,
+            transformation_fn=None)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -268,6 +274,12 @@ class EstimatorParams(Params):
 
     def getRunId(self):
         return self.getOrDefault(self.run_id)
+
+    def setTransformationFn(self, value):
+        return self._set(transformation_fn=value)
+
+    def getTransformationFn(self):
+        return self.getOrDefault(self.transformation_fn)
 
 
 class ModelParams(HasOutputCols):

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -140,6 +140,9 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         train_steps_per_epoch: Number of steps to train each epoch. Useful for testing that model trains successfully.
                                Defaults to training the entire dataset each epoch.
         validation_steps_per_epoch: Number of validation steps to perform each epoch.
+        transformation_fn: Optional custom function to execute before passing the loaded data into the train and validation steps.
+                This is useful for tasks such as cropping and rescaling of image samples before train starts.
+
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -169,7 +172,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  partitions_per_process=None,
                  run_id=None,
                  train_steps_per_epoch=None,
-                 validation_steps_per_epoch=None):
+                 validation_steps_per_epoch=None,
+                 transformation_fn=None):
 
         super(KerasEstimator, self).__init__()
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -140,9 +140,13 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         train_steps_per_epoch: Number of steps to train each epoch. Useful for testing that model trains successfully.
                                Defaults to training the entire dataset each epoch.
         validation_steps_per_epoch: Number of validation steps to perform each epoch.
-        transformation_fn: Optional custom function to execute before passing the loaded data into the train and validation steps.
-                This is useful for tasks such as cropping and rescaling of image samples before train starts.
-
+        transformation_fn: Optional function that takes a row as its parameter
+                           and returns a modified row that is then fed into the
+                           train or validation step. This transformation is
+                           applied after batching. See Petastorm [TransformSpec](https://github.com/uber/petastorm/blob/master/petastorm/transform.py)
+                           for more details. Note that this fucntion constructs
+                           another function which should perform the
+                           transformation.
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -133,7 +133,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                                'function that applies custom transformations to '
                                'every batch before train and validation steps')
 
-@keyword_only
+    @keyword_only
     def __init__(self,
                  num_proc=None,
                  model=None,

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -164,7 +164,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,
                          input_shapes=None,
-                         train_minibatch_fn=None)
+                         train_minibatch_fn=None,
+                         transformation_fn=None)
 
         kwargs = self._input_kwargs
 

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -119,8 +119,13 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         train_steps_per_epoch: Number of steps to train each epoch. Useful for testing that model trains successfully.
                                Defaults to training the entire dataset each epoch.
         validation_steps_per_epoch: Number of validation steps to perform each epoch.
-        transformation_fn: Optional custom function to execute before passing the loaded data into the train and validation steps.
-                        This is useful for tasks such as cropping and rescaling of image samples before train starts.
+        transformation_fn: Optional function that takes a row as its parameter
+                           and returns a modified row that is then fed into the
+                           train or validation step. This transformation is
+                           applied after batching. See Petastorm [TransformSpec](https://github.com/uber/petastorm/blob/master/petastorm/transform.py)
+                           for more details. Note that this fucntion constructs
+                           another function which should perform the
+                           transformation.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -128,10 +128,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                               'functions that construct the loss')
     train_minibatch_fn = Param(Params._dummy(), 'train_minibatch_fn',
                                'functions that construct the minibatch train function for torch')
-    transformation_fn = Param(Params._dummy(), 'transformation_fn',
-                               'functions that construct the transformation '
-                               'function that applies custom transformations to '
-                               'every batch before train and validation steps')
 
     @keyword_only
     def __init__(self,
@@ -191,12 +187,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getLossConstructors(self):
         return self.getOrDefault(self.loss_constructors)
-
-    def setTransformationFn(self, value):
-        return self._set(transformation_fn=value)
-
-    def getTransformationFn(self):
-        return self.getOrDefault(self.transformation_fn)
 
     def _get_optimizer(self):
         return self.getOrDefault(self.optimizer)


### PR DESCRIPTION
Some traninig jobs require to apply custom transformations to each batch before passing it to train or validation step. For instance, for training resnet model, each batch is cropped and scaled. this diff enables such transformations: 

an example transformation is:
 
```
def _transform_row(row):
    transform = transforms.Compose([
        transforms.RandomResizedCrop(224),
        transforms.RandomHorizontalFlip(),
        transforms.ToTensor(),
        transforms.Normalize(mean=[0.485, 0.456, 0.406],
                             std=[0.229, 0.224, 0.225])
    ])
    codec = CompressedImageCodec('png')
    class_to_index = {val[0]: int(key) for key, val in index_to_class.items()}

    row['image'] = row['image'].apply(lambda row: transform(Image.fromarray(codec.decode("image", row))).flatten().tolist())
    row['noun_id'] = row['noun_id'].apply(lambda val: class_to_index[val])
    return row
```
with 
```
index_to_class = {"0": ["n01440764", "tench"], "1": ["n01443537", "goldfish"],
                  "2": ["n01484850", "great_white_shark"],
                  "3": ["n01491361", "tiger_shark"],
					...
                  "999": ["n15075141", "toilet_tissue"]}
```
