### PR TITLE
Add extra build flag 'HOROVOD_BUILD_ARCH_FLAGS'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,17 +118,17 @@ def get_supported_instruction_set_flags(flags_to_check):
 def get_cpp_flags(build_ext):
     last_err = None
     default_flags = ['-std=c++11', '-fPIC', '-O2', '-Wall', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
-    avx_env_vars = os.environ.get('HOROVOD_BUILD_ARCH_FLAGS')
-    avx_fma_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma']) if avx_env_vars is None else avx_env_vars.split()
+    build_arch_flags_env = os.environ.get('HOROVOD_BUILD_ARCH_FLAGS')
+    build_arch_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma']) if build_arch_flags_env is None else build_arch_flags_env.split()
     if sys.platform == 'darwin':
         # Darwin most likely will have Clang, which has libc++.
-        flags_to_try = [default_flags + ['-stdlib=libc++'] + avx_fma_flags,
-                        default_flags + avx_fma_flags,
+        flags_to_try = [default_flags + ['-stdlib=libc++'] + build_arch_flags,
+                        default_flags + build_arch_flags,
                         default_flags + ['-stdlib=libc++'],
                         default_flags]
     else:
-        flags_to_try = [default_flags + avx_fma_flags,
-                        default_flags + ['-stdlib=libc++'] + avx_fma_flags,
+        flags_to_try = [default_flags + build_arch_flags,
+                        default_flags + ['-stdlib=libc++'] + build_arch_flags,
                         default_flags,
                         default_flags + ['-stdlib=libc++']]
     for cpp_flags in flags_to_try:

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,8 @@ def get_supported_instruction_set_flags(flags_to_check):
 def get_cpp_flags(build_ext):
     last_err = None
     default_flags = ['-std=c++11', '-fPIC', '-O2', '-Wall', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
-    avx_fma_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma'])
+    avx_env_vars = os.environ.get('HOROVOD_BUILD_ARCH_FLAGS')
+    avx_fma_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma']) if avx_env_vars is None else avx_env_vars.split()
     if sys.platform == 'darwin':
         # Darwin most likely will have Clang, which has libc++.
         flags_to_try = [default_flags + ['-stdlib=libc++'] + avx_fma_flags,


### PR DESCRIPTION
Add env variable to specify architecture-specific compiler flags.
For example, to be compatible with the older CPU architecture 'Sandy Bridge' and tune for 'Broadwell':
HOROVOD_BUILD_ARCH_FLAGS="-march=sandybridge -mtune=broadwell" ... pip install horovod

Signed-off-by: Nicolas V Castet <nvcastet@us.ibm.com>