### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -34,6 +34,11 @@ except:
     check_extension('horovod.torch', 'HOROVOD_WITH_PYTORCH',
                     __file__, 'mpi_lib', '_mpi_lib')
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 
 from horovod.torch.compression import Compression
 from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allreduce_async_
@@ -523,7 +528,7 @@ def broadcast_optimizer_state(optimizer, root_rank):
 
     # Returns the full type structure of the possibly nested objects for recursive casting back
     def _get_types(x):
-        if isinstance(x, collections.Iterable):
+        if isinstance(x, Iterable):
             return type(x), [_get_types(xi) for xi in x]
         else:
             return type(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 from distutils.version import LooseVersion
 
-import collections
 import inspect
 import itertools
 import os
@@ -37,6 +36,11 @@ import torch.nn.functional as F
 import horovod.torch as hvd
 
 from common import mpi_env_rank_and_size
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 _v2_api = LooseVersion(torch.__version__) >= LooseVersion('1.0.0')
 _fp16_supported = _v2_api
@@ -1111,7 +1115,7 @@ class TorchTests(unittest.TestCase):
             }
             for k, p in p0.items():
                 p_actual = optimizer.param_groups[0][k]
-                if not isinstance(p, collections.Iterable):
+                if not isinstance(p, Iterable):
                     p_actual = [p_actual]
                     p = [p]
                 for i in range(len(p)):


### PR DESCRIPTION
Fixes #1752 