### PR TITLE
Adasum Full GPU Ring-based Allreduce

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include * *.h *.hpp *.cc *.md
+recursive-include * *.h *.hpp *.cc *.md *.ipp
 
 include LICENSE horovod.lds horovod.exp
 prune .eggs
@@ -19,3 +19,6 @@ exclude third_party/eigen/Eigen/src/SparseCholesky/*
 graft third_party/gloo/cmake
 recursive-include third_party/gloo CMakeLists.txt
 recursive-include third_party/gloo *.in
+
+# include cmake related files for cuda kernels
+graft horovod/common/ops/cuda/

--- a/horovod/common/ops/adasum/adasum_cuda_ring.cc
+++ b/horovod/common/ops/adasum/adasum_cuda_ring.cc
@@ -1,0 +1,329 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "adasum_cuda_ring.h"
+
+namespace horovod {
+namespace common {
+
+void Ring::InitRing(int tmp[], bool _isFat, int rank, int size, cudaStream_t _adasum_stream) {
+  load = 0;
+  isFat = _isFat;
+  for (int i = 0; i < 8; i++)
+    loop[i] = tmp[i];
+
+  for (int j = 0; j < size; j++) { // go through allranks
+    if (rank == loop[j]) {
+      prevGPU = loop[(j-1+size) % size];
+      nextGPU = loop[(j+1+size) % size];
+    }
+  }
+  adasum_stream = _adasum_stream;
+}
+
+int Ring::GetAfterLoad(int message_len) {
+  if (!isFat)
+    return 2*(load+message_len);
+  else
+    return (load+message_len);
+}
+
+void Ring::AddLoad(int message_len) {
+  load += message_len;
+}
+
+void Ring::ReduceLoad(int message_len) {
+  load -= message_len;
+}
+
+Message::Message(MPIContext* mpi_context)
+  : mpi_context(mpi_context) {
+}
+
+void Message::InitMessage(Ring* _ring, int _rank, int _ring_starter_rank, int _count, void* _grad_buf, void* _recv_buf, DataType _datatype, MPI_Comm _comm, int _tag) {
+  comm = _comm;
+  count = _count;
+  tag = _tag;
+  ring = _ring;
+  rank = _rank;
+  ring_starter_rank = _ring_starter_rank;
+  leg = 0;
+  grad_buf = _grad_buf;
+  recv_buf = _recv_buf;
+  datatype = _datatype;
+  cuda_stream_sync = false;
+  Start();
+}
+
+ReduceMessage::ReduceMessage(MPIContext* mpi_context)
+  : Message(mpi_context) {
+}
+
+void ReduceMessage::Start() {
+
+  auto mpi_datatype = mpi_context->GetMPIDataType(datatype);
+  if (rank == ring_starter_rank) {
+    MPI_Isend(grad_buf, count, mpi_datatype, ring->nextGPU, tag, comm, &req);
+  } else {
+    MPI_Irecv(recv_buf, count, mpi_datatype, ring->prevGPU, tag, comm, &req);
+  }
+}
+
+bool ReduceMessage::Test() {
+  auto mpi_datatype = mpi_context->GetMPIDataType(datatype);
+
+  int flag = 0;
+  if (leg == 2)
+    return true;
+  if (!cuda_stream_sync) {
+    MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+  }
+  if (flag == 1 || cuda_stream_sync) {
+    leg++;
+    if (leg == 2) {
+      ring->ReduceLoad(count);
+      return true;
+    }
+    if (leg == 1) {
+      if (rank == ring_starter_rank) {
+        MPI_Irecv(grad_buf, count, mpi_datatype, ring->prevGPU, tag, comm, &req);
+      } else if (!cuda_stream_sync) {
+        // call the cuda kernel
+        switch(datatype) {
+          case HOROVOD_FLOAT16:
+            AdasumCudaReduce(count, (uint16_t*)grad_buf, (uint16_t*)recv_buf, ring->adasum_stream);
+            break;
+          case HOROVOD_FLOAT32:
+            AdasumCudaReduce(count, (float*)grad_buf, (float*)recv_buf, ring->adasum_stream);
+            break;
+          case HOROVOD_FLOAT64:
+            AdasumCudaReduce(count, (double*)grad_buf, (double*)recv_buf, ring->adasum_stream);
+            break;
+          default:
+            throw std::logic_error("Message::Test: Unsupported data type.");
+        }
+        cuda_stream_sync = true;
+        leg--;
+      } else {
+        cudaStreamSynchronize(ring->adasum_stream);
+        MPI_Isend(grad_buf, count, mpi_datatype, ring->nextGPU, tag, comm, &req);
+        cuda_stream_sync = false;
+      }
+    }
+  }
+  return false;
+}
+
+BroadcastMessage::BroadcastMessage(MPIContext* mpi_context)
+  : Message(mpi_context) {
+}
+
+void BroadcastMessage::Start() {
+  auto mpi_datatype = mpi_context->GetMPIDataType(datatype);
+  if (rank == ring_starter_rank) {
+    MPI_Isend(grad_buf, count, mpi_datatype, ring->nextGPU, tag, comm, &req);
+    leg = 1;
+  } else {
+    MPI_Irecv(grad_buf, count, mpi_datatype, ring->prevGPU, tag, comm, &req);
+    if (ring->nextGPU == ring_starter_rank)
+      leg = 1;
+  }
+}
+
+bool BroadcastMessage::Test() {
+  auto mpi_datatype = mpi_context->GetMPIDataType(datatype);
+
+  int flag;
+  if (leg == 2)
+    return true;
+  MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+  if (flag == 1) {
+    leg++;
+    if (leg == 2) {
+      ring->ReduceLoad(count);
+      return true;
+    }
+    if (leg == 1) {
+      if (rank != ring_starter_rank) {
+        MPI_Isend(grad_buf, count, mpi_datatype, ring->nextGPU, tag, comm, &req);
+      }
+    }
+  }
+  return false;
+}
+
+std::vector<std::vector<int>> AllRings::GetTopologyMatrix(int size) {
+  std::vector<std::vector<int>> topology_matrix(size, std::vector<int>(size));
+  for (int i = 0; i < size; i++) {
+    for (int j = 0; j < size; j++) {
+      if (i == j) {
+        topology_matrix[i][j] = -1;
+        continue;
+      }
+      int accessSupported = 0;
+      cudaDeviceGetP2PAttribute(&accessSupported, cudaDevP2PAttrAccessSupported,
+                                i, j);
+      if (!accessSupported) {
+        topology_matrix[i][j] = -1;
+        continue;
+      }
+      int perfRank = 0;
+      cudaDeviceGetP2PAttribute(&perfRank, cudaDevP2PAttrPerformanceRank, i, j);
+      topology_matrix[i][j] = perfRank;
+    }
+  }
+  return topology_matrix;
+}
+
+std::vector<int>
+AllRings::GetRingFromTopologyMatrix(int size,
+                                    const std::vector<std::vector<int>>& topology_matrix,
+                                    int performance_rank) {
+  // Every node in topology matrix
+  // must have 2 connections for each performance rank.
+  //
+  // Typical topology matrix example:
+  //
+  // {{-1, 1, 1, 0, 0, -1, -1, -1},
+  //  {1, -1, 0, 1, -1, 0, -1, -1},
+  //  {1, 0, -1, 0, -1, -1, 1, -1},
+  //  {0, 1, 0, -1, -1, -1, -1, 1},
+  //  {0, -1, -1, -1, -1, 1, 1, 0},
+  //  {-1, 0, -1, -1, 1, -1, 0, 1},
+  //  {-1, -1, 1, -1, 1, 0, -1, 0},
+  //  {-1, -1, -1, 1, 0, 1, 0, -1}}
+
+  assert(topology_matrix.size() == size);
+  assert(topology_matrix[0].size() == size);
+
+  // Start point doesn't matter, let's start with 0.
+  std::vector<int> ring;
+  int curr = 0;
+  int prev = -1;
+  do {
+    for (int i = 0; i < size; i++) {
+      if (i != prev && topology_matrix[curr][i] == performance_rank) {
+        ring.push_back(curr);
+        prev = curr;
+        curr = i;
+        break;
+      }
+    }
+  } while (curr != 0);
+  return ring;
+}
+
+AllRings::~AllRings() {
+  for (int i = 0; i < messages.size(); i++)
+    delete messages[i];
+  delete[] rings;
+}
+
+AllRings::AllRings(int rank, int size) {
+  rings = new Ring[num_rings];
+  auto topology_matrix = GetTopologyMatrix(size);
+
+  int greatest_priority;
+  cudaDeviceGetStreamPriorityRange(NULL, &greatest_priority);
+  cudaStreamCreateWithPriority(&adasum_stream, cudaStreamNonBlocking, greatest_priority);
+
+  auto fat_ring = GetRingFromTopologyMatrix(size, topology_matrix, 0);
+  if (fat_ring.empty()) {
+    LOG(INFO) << "No rings created from topology matrix, use defaults.";
+    {
+      // fat ring 1
+      int tmp[8] = {0, 3, 2, 1, 5, 6, 7, 4};
+      rings[0].InitRing(tmp, true, rank, size, adasum_stream);
+    }
+    {
+      // fat ring 2
+      int tmp[8] = {0, 4, 7, 6, 5, 1, 2, 3};
+      rings[1].InitRing(tmp, true, rank, size, adasum_stream);
+    }
+    {
+      // skinny ring 1
+      int tmp[8] = {0, 2, 6, 4, 5, 7, 3, 1};
+      rings[2].InitRing(tmp, false, rank, size, adasum_stream);
+    }
+    {
+      // skinny ring 2
+      int tmp[8] = {0, 1, 3, 7, 5, 4, 6, 2};
+      rings[3].InitRing(tmp, false, rank, size, adasum_stream);
+    }
+  } else {
+    rings[0].InitRing(fat_ring.data(), true, rank, size, adasum_stream);
+    std::reverse(fat_ring.begin(), fat_ring.end());
+    rings[1].InitRing(fat_ring.data(), true, rank, size, adasum_stream);
+
+    auto skinny_ring = GetRingFromTopologyMatrix(size, topology_matrix, 1);
+    assert(!skinny_ring.empty());
+    rings[2].InitRing(skinny_ring.data(), false, rank, size, adasum_stream);
+    std::reverse(skinny_ring.begin(), skinny_ring.end());
+    rings[3].InitRing(skinny_ring.data(), false, rank, size, adasum_stream);
+  }
+};
+
+Ring* AllRings::PickRing(int count) {
+  int min_load = (1<<30); // INF
+  Ring* ret_ring = NULL;
+  for (int i = 0; i < num_rings; i++) {
+    Ring* ring = &rings[i];
+    int cur_ring_after_load = ring->GetAfterLoad(count);
+    if (cur_ring_after_load < min_load) {
+      ret_ring = ring;
+      min_load = cur_ring_after_load;
+    }
+  }
+  ret_ring->AddLoad(count);
+  assert(ret_ring != NULL);
+  return ret_ring;
+}
+
+void AllRings::InitMessageInRing(Message* message, void* grad_buf, void* recv_buf, int size, DataType datatype, MPI_Comm comm, int grad_tag, int rank) {
+  int count = -1;
+  switch(datatype) {
+    case HOROVOD_FLOAT16:
+      count = size / sizeof(uint16_t);
+      break;
+    case HOROVOD_FLOAT32:
+      count = size / sizeof(float);
+      break;
+    case HOROVOD_FLOAT64:
+      count = size / sizeof(double);
+      break;
+    default:
+      throw std::logic_error("AllRings::InitMessageInRing: Unsupported data type.");
+  }
+  messages.push_back(message);
+	Ring*	ring = PickRing(count);
+  message->InitMessage(ring, rank, grad_tag % 8, count, grad_buf, recv_buf, datatype, comm, grad_tag);
+}
+
+void AllRings::WaitAllMessages() {
+  
+  bool all_done = false;
+  while (!all_done) {
+    all_done = true;
+    for (int i = 0; i < messages.size(); i++) {
+      if (!messages.at(i)->Test())
+        all_done = false;
+    }
+  }
+  for (int i = 0; i < messages.size(); i++)
+    delete messages[i];
+  messages.clear();
+}
+} // common
+} // horovod

--- a/horovod/common/ops/adasum/adasum_cuda_ring.h
+++ b/horovod/common/ops/adasum/adasum_cuda_ring.h
@@ -1,0 +1,114 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#ifndef HOROVOD_ADASUM_CUDA_RING_H
+#define HOROVOD_ADASUM_CUDA_RING_H
+
+#include "mpi.h"
+
+#include "../../common.h"
+#include "../../global_state.h"
+#include "../../mpi/mpi_context.h"
+#include "../gpu_operations.h"
+#include "../cuda/adasum_cuda_kernels.h"
+
+namespace horovod {
+namespace common {
+
+struct Ring {
+  int loop[8];
+  int nextGPU;
+  int prevGPU;
+  int load;
+  bool isFat;
+  cudaStream_t adasum_stream;
+
+  void InitRing(int tmp[], bool _isFat, int rank, int size, cudaStream_t _adasum_stream);
+  int GetAfterLoad(int message_len);
+  void AddLoad(int message_len);
+  void ReduceLoad(int message_len);
+};
+
+struct Message {
+  MPIContext* mpi_context;
+  MPI_Comm comm;
+  MPI_Request req;
+  Ring* ring;
+  int rank;
+  int ring_starter_rank;
+  int leg; // number of legs in the ring has been done
+  void* grad_buf;
+  void* recv_buf;
+  DataType datatype;
+  int tag;
+  int count;
+  bool cuda_stream_sync; // used to determine whether previous leg ended with mpi op or cuda async op
+
+  Message(MPIContext* mpi_context);
+  void InitMessage(Ring* _ring, int rank, int _ring_starter_rank, int _count, void* _grad_buf, void* _recv_buf, DataType _datatype, MPI_Comm _comm, int _tag);
+  virtual bool Test() = 0;
+protected:
+  virtual void Start() = 0;
+};
+
+struct ReduceMessage : public Message {
+  ReduceMessage(MPIContext* mpi_context);
+  virtual bool Test();
+protected:
+  virtual void Start();
+};
+
+struct BroadcastMessage : public Message {
+  BroadcastMessage(MPIContext* mpi_context);
+  virtual bool Test();
+protected:
+  virtual void Start();
+};
+
+struct AllRings {
+  int num_rings = 4;
+  Ring* rings;
+  std::vector<Message*> messages;
+  cudaStream_t adasum_stream;
+
+  ~AllRings();
+  AllRings(int rank, int size);
+  Ring* PickRing(int count);
+  void InitMessageInRing(Message* message, void* grad_buf, void* recv_buf, int size, DataType datatype, MPI_Comm comm, int grad_tag, int rank);
+  void WaitAllMessages();
+
+  // private:
+  static std::vector<std::vector<int>> GetTopologyMatrix(int size);
+  static std::vector<int> GetRingFromTopologyMatrix(
+      int size, const std::vector<std::vector<int>>& topology_matrix,
+      int performance_rank);
+};
+
+template<typename T>
+void AdasumCudaReduce(int count, T* device_a, T* device_b, cudaStream_t stream){
+
+  static double* device_vals;
+  static bool device_vals_init = false;
+  if (!device_vals_init) {
+    cudaMalloc(&device_vals, 3*sizeof(double));
+    device_vals_init = true;
+  }
+
+  CudaSingleAdasumImpl(count, device_a, device_b, device_vals, stream);
+}
+
+} // common
+} // horovod
+#endif // HOROVOD_ADASUM_CUDA_RING_H

--- a/horovod/common/ops/adasum_cuda_ring_operations.cc
+++ b/horovod/common/ops/adasum_cuda_ring_operations.cc
@@ -1,0 +1,206 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "adasum_cuda_ring_operations.h"
+
+namespace horovod {
+namespace common {
+
+AdasumCudaRingAllreduceOp::AdasumCudaRingAllreduceOp(MPIContext* mpi_context, GPUContext* gpu_context, HorovodGlobalState* global_state)
+    : AdasumMPI(mpi_context, global_state), GPUAllreduce(gpu_context, global_state){
+}
+
+AdasumCudaRingAllreduceOp::~AdasumCudaRingAllreduceOp() {
+}
+
+Status AdasumCudaRingAllreduceOp::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
+  if(entries.empty()) {
+    return Status::OK();
+  }
+  gpu_op_context_.InitGPU(entries);
+  if (!reduction_comms_initialized) {
+    InitializeVHDDReductionComms();
+  }
+  return RingHierarchical(entries, response);
+}
+
+Status AdasumCudaRingAllreduceOp::RingHierarchical(std::vector<TensorTableEntry>& entries,
+                        const Response& response) {
+
+  int num_reductions = entries.size();
+  auto& first_entry = entries[0];
+
+  // If needed, allocate a temporary GPU buffer that's needed for Adasum computation.
+  // Currently, the max combined size of entries that can be passed in at once is equal to the tensor fusion buffer size.
+  size_t new_gpu_size = (global_state_->parameter_manager.TensorFusionThresholdBytes() > first_entry.output->size()) ? 
+                        global_state_->parameter_manager.TensorFusionThresholdBytes() : first_entry.output->size();
+  if (new_gpu_size > gpu_buffer_size) {
+    if (gpu_buffer_size > 0) {
+      cudaFree(gpu_temp_recv_buffer);
+    }
+    cudaMalloc(&gpu_temp_recv_buffer, new_gpu_size);
+    gpu_buffer_size = new_gpu_size;
+  }
+  int64_t offset = 0;
+  size_t total_buffer_size = 0;
+
+  AllRings all_rings(global_state_->controller->GetLocalRank(), global_state_->controller->GetLocalSize());
+
+  int local_rank = 0;
+  int local_size = global_state_->controller->GetLocalSize();
+
+  bool cross_node = global_state_->controller->GetSize() > global_state_->controller->GetLocalSize();
+
+  MPI_Comm_rank(mpi_context_->local_comm, &local_rank);
+
+  size_t layerid = 0;
+  //enqueue messages
+  for (; layerid < num_reductions; ++layerid) {
+    auto& entry = entries.at(layerid);
+    void* buffer_data;
+    int buffer_len;
+    void* recv_buffer;
+    buffer_data = (void*) entry.tensor->data();
+    buffer_len = entry.output->size();
+    if (layerid % 8 == local_rank) {
+      total_buffer_size += buffer_len;
+    }
+    if (entry.tensor->data() == entry.output->data()) {
+      // Get the temp buffer to be used for the Op
+      recv_buffer = (uint8_t*)gpu_temp_recv_buffer + offset;
+      offset += buffer_len;
+    }
+    else {
+      recv_buffer = (void*) entry.output->data();
+    }
+    gpu_context_->ErrorCheck("cudaSetDevice", cudaSetDevice(entry.device));
+
+    all_rings.InitMessageInRing(new ReduceMessage(mpi_context_),
+                      buffer_data,
+                      recv_buffer,
+                      buffer_len,
+                      entry.tensor->dtype(),
+                      mpi_context_->local_comm,
+                      layerid,
+                      global_state_->controller->GetLocalRank());
+  }
+  // wait for messages to finish
+  all_rings.WaitAllMessages();
+
+  if (cross_node) {
+      if (global_state_->parameter_manager.TensorFusionThresholdBytes() > total_buffer_size) {
+        total_buffer_size = global_state_->parameter_manager.TensorFusionThresholdBytes();
+      }
+      if (total_buffer_size > cpu_buffer_size) {
+        if (cpu_buffer_size > 0) {
+          free(cpu_cross_node_buffer);
+        }
+        cpu_cross_node_buffer = malloc(total_buffer_size);
+        cpu_buffer_size = total_buffer_size;
+      }
+      offset = 0;
+      std::vector<int> tensor_counts(num_reductions);
+      // start device to host copies
+      for (layerid = 0; layerid < num_reductions; ++layerid) {
+        if (layerid % 8 == local_rank) {
+          auto& entry = entries.at(layerid);
+          tensor_counts[layerid] = entry.tensor->shape().num_elements();
+          int buffer_len = entry.output->size();
+          void* buffer_data = (uint8_t*)cpu_cross_node_buffer + offset;
+          offset += buffer_len;
+          
+          auto cuda_result = cudaMemcpyAsync(
+            buffer_data, (void*) entry.tensor->data(),
+            buffer_len, 
+            cudaMemcpyDeviceToHost,
+            gpu_context_->streams[global_state_->current_nccl_stream][layerid]);
+          gpu_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
+        } else {
+          tensor_counts[layerid] = 0;
+        }
+      }
+      auto recv_buffer = GetRecvBuffer(total_buffer_size);
+      // wait for this layer to finish copying to host
+      DispatchFusedAllreduce(entries, cpu_cross_node_buffer, recv_buffer, tensor_counts, local_size, 
+                              mpi_context_->GetMPICommunicator(Communicator::GLOBAL), 0, reduction_comms_,
+                              first_entry.tensor->dtype(), global_state_);
+      offset = 0;
+      for (layerid = 0; layerid < num_reductions; ++layerid) {
+        if (layerid % 8 == local_rank) {
+          auto& entry = entries.at(layerid);
+          int buffer_len = entry.output->size();
+          void* buffer_data = (uint8_t*)cpu_cross_node_buffer + offset;
+          offset += buffer_len;
+          // start the copy back to device
+          auto cuda_result = cudaMemcpyAsync(
+            (void*) entry.tensor->data(), buffer_data,
+            buffer_len, 
+            cudaMemcpyHostToDevice,
+            gpu_context_->streams[global_state_->current_nccl_stream][layerid]);
+          gpu_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
+        }
+      }
+  }
+
+  //ring broadcast
+  for (layerid = 0; layerid < entries.size(); ++layerid) {
+    auto& entry = entries.at(layerid);
+    void* buffer_data;
+    int buffer_len;
+    buffer_data = (void*) entry.tensor->data();
+    buffer_len = entry.output->size();
+
+    // This will create a stream per layer.
+    all_rings.InitMessageInRing(new BroadcastMessage(mpi_context_),
+                      buffer_data,
+                      nullptr,
+                      buffer_len,
+                      entry.output->dtype(),
+                      mpi_context_->local_comm,
+                      layerid,
+                      global_state_->controller->GetLocalRank());
+  }
+
+  all_rings.WaitAllMessages();
+
+  for (layerid = 0; layerid < entries.size(); ++layerid) {
+    auto& entry = entries.at(layerid);
+    if(entry.tensor->data() != entry.output->data()) {
+      MemcpyUtil(entry, (void *) entry.output->data(), (void *) entry.tensor->data(), (size_t) entry.tensor->size(), layerid);
+    }
+  }
+  return Status::OK();
+}
+
+void AdasumCudaRingAllreduceOp::MemcpyUtil(TensorTableEntry entry, void* dest, void* src, size_t buffer_len, int layerid) {
+    assert(dest != nullptr);
+    assert(src != nullptr);
+    auto cuda_result = cudaMemcpyAsync(dest, src,
+                                    buffer_len, 
+                                    cudaMemcpyDeviceToDevice,
+                                    gpu_context_->streams[global_state_->current_nccl_stream][entry.device]);
+    gpu_context_->ErrorCheck("cudaMemcpyAsync", cuda_result);
+    auto cuda_sync_result = cudaStreamSynchronize(gpu_context_->streams[global_state_->current_nccl_stream][entry.device]);
+    gpu_context_->ErrorCheck("cudaStreamSynchronize", cuda_sync_result);
+}
+
+bool AdasumCudaRingAllreduceOp::Enabled(const ParameterManager& param_manager,
+                            const std::vector<TensorTableEntry>& entries,
+                            const Response& response) const {
+  return (entries[0].device != CPU_DEVICE_ID) && (global_state_->controller->GetLocalSize() == 8);
+
+}
+}
+}

--- a/horovod/common/ops/adasum_cuda_ring_operations.h
+++ b/horovod/common/ops/adasum_cuda_ring_operations.h
@@ -1,0 +1,55 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#ifndef HOROVOD_ADASUM_CUDA_RING_OPERATIONS_H
+#define HOROVOD_ADASUM_CUDA_RING_OPERATIONS_H
+
+#include "adasum/adasum_mpi.h"
+#include "adasum/adasum_cuda_ring.h"
+#include "gpu_operations.h"
+
+
+namespace horovod {
+namespace common {
+
+class AdasumCudaRingAllreduceOp : public AdasumMPI, public GPUAllreduce{
+  public:
+  AdasumCudaRingAllreduceOp(MPIContext* mpi_context,
+                        GPUContext* gpu_context,
+                        HorovodGlobalState* global_state);
+
+  ~AdasumCudaRingAllreduceOp();
+  bool Enabled(const ParameterManager& param_manager,
+               const std::vector<TensorTableEntry>& entries,
+               const Response& response) const override;
+
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
+
+  protected:
+  Status RingHierarchical(std::vector<TensorTableEntry>& entries,
+                          const Response& response);
+
+  void MemcpyUtil(TensorTableEntry entry, void* dest, void* src, size_t buffer_len, int layerid);
+
+  private:
+  void* gpu_temp_recv_buffer;
+  size_t gpu_buffer_size = 0;
+  void* cpu_cross_node_buffer;
+  size_t cpu_buffer_size = 0;
+};
+} // namespace common
+} // namespace horovod
+#endif // HOROVOD_ADASUM_CUDA_RING_OPERATIONS_H

--- a/horovod/common/ops/adasum_nccl_operations.h
+++ b/horovod/common/ops/adasum_nccl_operations.h
@@ -13,8 +13,8 @@
 // limitations under the License.
 // =============================================================================
 
-#ifndef HOROVOD_ADASUM_GPU_OPERATIONS_H
-#define HOROVOD_ADASUM_GPU_OPERATIONS_H
+#ifndef HOROVOD_ADASUM_NCCL_OPERATIONS_H
+#define HOROVOD_ADASUM_NCCL_OPERATIONS_H
 
 #include "adasum/adasum_mpi.h"
 #include "nccl_operations.h"
@@ -23,13 +23,13 @@
 namespace horovod {
 namespace common {
 
-class AdasumGpuAllreduceOp : public AdasumMPI, public NCCLAllreduce {
+class AdasumNCCLHierarchicalAllreduceOp : public AdasumMPI, public NCCLAllreduce {
 public:
-  AdasumGpuAllreduceOp(MPIContext* mpi_context, NCCLContext* nccl_context,
-                       GPUContext* gpu_context,
-                       HorovodGlobalState* global_state);
+  AdasumNCCLHierarchicalAllreduceOp(MPIContext* mpi_context, NCCLContext* nccl_context,
+                        GPUContext* gpu_context,
+                        HorovodGlobalState* global_state);
 
-  ~AdasumGpuAllreduceOp();
+  ~AdasumNCCLHierarchicalAllreduceOp();
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -50,4 +50,4 @@ private:
 };
 } // namespace common
 } // namespace horovod
-#endif // HOROVOD_ADASUM_GPU_OPERATIONS_H
+#endif // HOROVOD_ADASUM_NCCL_OPERATIONS_H

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
+project(adasum_cuda_kernels)
+
+find_package(CUDA)
+
+list(APPEND CUDA_NVCC_FLAGS "--compiler-options -fPIC -D_FORCE_INLINES -arch=sm_60")
+
+cuda_add_library(adasum_cuda_kernels
+    adasum_cuda_kernels.cu
+)

--- a/horovod/common/ops/cuda/adasum_cuda_kernels.cu
+++ b/horovod/common/ops/cuda/adasum_cuda_kernels.cu
@@ -1,0 +1,202 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include <iostream>
+#include <stdio.h>
+#include <cuda_fp16.h>
+#include <time.h>
+#include <stdint.h>
+#include <float.h>
+
+#define THREADS_PER_BLOCK 64
+
+__device__ __constant__ double min_guard = DBL_MIN;
+
+template<typename T, typename TACC>
+__global__
+void CudaSingleAdasumKernel(int count, T* a, const T* b, TACC* out) {
+	__shared__ TACC a_coeff;
+	__shared__ TACC b_coeff;
+	int index = threadIdx.x + blockIdx.x * blockDim.x;
+	if (0 == threadIdx.x) {
+		if ((TACC) out[0] >= min_guard) {
+			a_coeff = 1.0 - out[2] / out[0] * 0.5;
+		} else {
+			a_coeff = 1;
+		}
+		if ((TACC) out[1] >= min_guard) {
+			b_coeff = 1.0 - out[2] / out[1] * 0.5;
+		} else {
+			b_coeff = 1;
+		}
+	}
+	__syncthreads();
+	if (count > index){
+		a[index] = (T) ((TACC) a[index] * a_coeff + (TACC) b[index] * b_coeff);
+	}
+}
+
+template<typename T, typename TACC>
+__global__
+void CudaDotProductKernel(int count, const T* a, const T* b, TACC* out) {
+	__shared__ TACC normsq_a[THREADS_PER_BLOCK];
+	__shared__ TACC normsq_b[THREADS_PER_BLOCK];
+	__shared__ TACC dot[THREADS_PER_BLOCK];
+	int index = threadIdx.x + blockIdx.x * blockDim.x;
+	if (index < count){
+		normsq_a[threadIdx.x] = (TACC) a[index] * (TACC) a[index];
+		normsq_b[threadIdx.x] = (TACC) b[index] * (TACC) b[index];
+		dot[threadIdx.x]      = (TACC) a[index] * (TACC) b[index];
+	}
+	__syncthreads();
+	if (0 == threadIdx.x) {
+		TACC normsq_a_sum = 0;
+		TACC normsq_b_sum = 0;
+		TACC dot_sum = 0;
+		for(int i = 0; i < THREADS_PER_BLOCK; i++){
+			if (i + blockIdx.x * blockDim.x < count){
+				normsq_a_sum += normsq_a[i];
+				normsq_b_sum += normsq_b[i];
+				dot_sum += dot[i];
+			}
+		}
+		atomicAdd(out, normsq_a_sum);
+		atomicAdd(out+1, normsq_b_sum);
+		atomicAdd(out+2, dot_sum);
+	}
+}
+
+template<typename T, typename TACC>
+__global__
+void CudaScaleAddKernel(int count, T* a, const T* b, TACC a_coeff, TACC b_coeff) {
+	int index = threadIdx.x + blockIdx.x * blockDim.x;
+	if (count > index){
+		a[index] = (T) ((TACC) a[index] * a_coeff + (TACC) b[index] * b_coeff);
+	}
+}
+
+template<typename T>
+__global__
+void ConvertToFloat(int count, T* a, float* b) {
+	int index = threadIdx.x + blockIdx.x * blockDim.x;
+	if (count > index){
+		b[index] = (float) a[index];
+	}
+}
+
+void ErrorCheck(std::string op_name, cudaError_t cuda_result) {
+	if (cuda_result != cudaSuccess) {
+		throw std::logic_error(std::string(op_name) + " failed: " + cudaGetErrorString(cuda_result));
+	}
+}
+
+void CudaSingleAdasumImpl(int count, double* device_a, const double* device_b, 
+	double* device_vals, cudaStream_t stream) {
+	
+	ErrorCheck("cudaMemsetAsync", cudaMemsetAsync(device_vals, 0, 3*sizeof(double), stream));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK, 0, stream>>>(count, device_a, device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(double)", cudaGetLastError());
+	CudaSingleAdasumKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK, 0, stream>>>(count, device_a, device_b,
+		device_vals);
+}
+
+void CudaSingleAdasumImpl(int count, float* device_a, const float* device_b, 
+	double* device_vals, cudaStream_t stream) {
+	
+	ErrorCheck("cudaMemsetAsync", cudaMemsetAsync(device_vals, 0, 3*sizeof(double), stream));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK, 0, stream>>>(count, device_a, device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(float)", cudaGetLastError());
+	CudaSingleAdasumKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK, 0, stream>>>(count, device_a, device_b,
+		device_vals);
+}
+
+void CudaSingleAdasumImpl(int count, uint16_t* device_a, const uint16_t* device_b, 
+	double* device_vals, cudaStream_t stream) {
+	
+	ErrorCheck("cudaMemsetAsync", cudaMemsetAsync(device_vals, 0, 3*sizeof(double), stream));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK, 0, stream>>>(count, (__half*) device_a, (__half*) device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(fp16)", cudaGetLastError());
+	CudaSingleAdasumKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK, 0, stream>>>(count, (__half*)device_a, (__half*)device_b,
+		device_vals);
+}
+
+void CudaDotProductImpl(int count, const double* device_a, const double* device_b, 
+	double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot) {
+	
+	ErrorCheck("cudaMemset", cudaMemset(device_vals, 0, 3*sizeof(double)));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK>>>(count, device_a, device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(double)", cudaGetLastError());
+
+	double host_vals[3];
+	ErrorCheck("cudaMemcpy", cudaMemcpy(host_vals, device_vals, 3*sizeof(double), cudaMemcpyDeviceToHost));
+	host_normsq_a = host_vals[0];
+	host_normsq_b = host_vals[1];
+	host_dot = host_vals[2];
+}
+
+void CudaDotProductImpl(int count, const float* device_a, const float* device_b, 
+	double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot) {
+	
+	ErrorCheck("cudaMemset", cudaMemset(device_vals, 0, 3*sizeof(double)));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK>>>(count, device_a, device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(float)", cudaGetLastError());
+
+	double host_vals[3];
+	ErrorCheck("cudaMemcpy", cudaMemcpy(host_vals, device_vals, 3*sizeof(double), cudaMemcpyDeviceToHost));
+	host_normsq_a = host_vals[0];
+	host_normsq_b = host_vals[1];
+	host_dot = host_vals[2];
+}
+
+void CudaDotProductImpl(int count, const uint16_t* device_a, const uint16_t* device_b, 
+	double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot) {
+	
+	ErrorCheck("cudaMemset", cudaMemset(device_vals, 0, 3*sizeof(double)));
+
+	CudaDotProductKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK,
+		THREADS_PER_BLOCK>>>(count, (__half*) device_a, (__half*) device_b, device_vals);
+	ErrorCheck("CudaDotProductKernel(fp16)", cudaGetLastError());
+
+	double host_vals[3];
+	ErrorCheck("cudaMemcpy", cudaMemcpy(host_vals, device_vals, 3*sizeof(double), cudaMemcpyDeviceToHost));
+	host_normsq_a = host_vals[0];
+	host_normsq_b = host_vals[1];
+	host_dot = host_vals[2];
+}
+
+void CudaScaleAddImpl(int count, double* a_device, const double* b_device, double host_a_coeff, double host_b_coeff) {
+	CudaScaleAddKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK>>>(count, a_device, b_device,
+		host_a_coeff, host_b_coeff);
+}
+
+void CudaScaleAddImpl(int count, float* a_device, const float* b_device, double host_a_coeff, double host_b_coeff) {
+	CudaScaleAddKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK>>>(count, a_device, b_device,
+		host_a_coeff, host_b_coeff);
+}
+
+void CudaScaleAddImpl(int count, uint16_t* a_device, const uint16_t* b_device, double host_a_coeff, double host_b_coeff) {
+	CudaScaleAddKernel<<<(count+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK, THREADS_PER_BLOCK>>>(count, (__half*)a_device, (__half*)b_device,
+		host_a_coeff, host_b_coeff);
+}

--- a/horovod/common/ops/cuda/adasum_cuda_kernels.cu
+++ b/horovod/common/ops/cuda/adasum_cuda_kernels.cu
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <float.h>
 
-#define THREADS_PER_BLOCK 64
+#define THREADS_PER_BLOCK 128
 
 __device__ __constant__ double min_guard = DBL_MIN;
 
@@ -84,15 +84,6 @@ void CudaScaleAddKernel(int count, T* a, const T* b, TACC a_coeff, TACC b_coeff)
 	int index = threadIdx.x + blockIdx.x * blockDim.x;
 	if (count > index){
 		a[index] = (T) ((TACC) a[index] * a_coeff + (TACC) b[index] * b_coeff);
-	}
-}
-
-template<typename T>
-__global__
-void ConvertToFloat(int count, T* a, float* b) {
-	int index = threadIdx.x + blockIdx.x * blockDim.x;
-	if (count > index){
-		b[index] = (float) a[index];
 	}
 }
 

--- a/horovod/common/ops/cuda/adasum_cuda_kernels.h
+++ b/horovod/common/ops/cuda/adasum_cuda_kernels.h
@@ -1,0 +1,40 @@
+// Copyright 2019 Microsoft. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include <stdint.h>
+#include <cuda_runtime.h>
+void CudaSingleAdasumImpl(int count, double* device_a, const double* device_b, 
+						double* device_vals, cudaStream_t stream);
+
+void CudaSingleAdasumImpl(int count, float* device_a, const float* device_b, 
+						double* device_vals, cudaStream_t stream);
+
+void CudaSingleAdasumImpl(int count, uint16_t* device_a, const uint16_t* device_b, 
+						double* device_vals, cudaStream_t stream);
+
+void CudaDotProductImpl(int count, const double* device_a, const double* device_b, 
+						double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot);
+
+void CudaDotProductImpl(int count, const float* device_a, const float* device_b, 
+						double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot);
+
+void CudaDotProductImpl(int count, const uint16_t* device_a, const uint16_t* device_b, 
+						double* device_vals, double& host_normsq_a, double& host_normsq_b, double& host_dot);
+
+void CudaScaleAddImpl(int count, double* a_device, const double* b_device, double host_a_coeff, double host_b_coeff);
+
+void CudaScaleAddImpl(int count, float* a_device, const float* b_device, double host_a_coeff, double host_b_coeff);
+
+void CudaScaleAddImpl(int count, uint16_t* a_device, const uint16_t* b_device, double host_a_coeff, double host_b_coeff);

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -105,9 +105,13 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
                         horovod_local_size = tf.cast(local_size(), dtype=tensor.dtype)
                         new_tensor = summed_tensor / horovod_local_size
                     else:
-                        warnings.warn('Adasum reduction does not currently support GPU reduction using MPI. Tensors '
-                                      'are copied to CPU memory instead. To use Adasum for GPU reduction, please '
-                                      'compile Horovod with HOROVOD_GPU_ALLREDUCE=NCCL.')
+                        if horovod_local_size != 8:
+                            warnings.warn("Adasum reduction does not currently support "
+                                "GPU reduction using MPI for machines without 8 GPUs. Tensors are copied to CPU memory instead."
+                                "To use Adasum for GPU reduction, please compile Horovod with HOROVOD_GPU_ALLREDUCE=NCCL.")
+                        else:
+                            warnings.warn("Adasum GPU reduction using MPI is intended only for DGX-1 like machines with 8 GPUs that "
+                            "are connected with nvlinks.")
                         new_tensor = summed_tensor
                 else:
                     if not check_num_rank_power_of_2(size()):

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -109,9 +109,13 @@ def _allreduce_async(tensor, output, name, op):
                     raise NotImplementedError('Running GPU Adasum with non-power of 2 nodes is not supported yet.')
                 divisor = local_size()
             else:
-                warnings.warn('Adasum reduction does not currently support GPU reduction using MPI. Tensors are '
-                              'copied to CPU memory instead. To use Adasum for GPU reduction, please compile Horovod '
-                              'with HOROVOD_GPU_ALLREDUCE=NCCL.')
+                if local_size() != 8:
+                    warnings.warn("Adasum reduction does not currently support "
+                        "GPU reduction using MPI for machines without 8 GPUs. Tensors are copied to CPU memory instead."
+                        "To use Adasum for GPU reduction, please compile Horovod with HOROVOD_GPU_ALLREDUCE=NCCL.")
+                else:
+                    warnings.warn("Adasum GPU reduction using MPI is intended only for DGX-1 like machines with 8 GPUs that "
+                            "are connected with nvlinks.")
                 divisor = 1
         else:
             if not num_rank_is_power_2(size()):


### PR DESCRIPTION
This PR adds a new Adasum Op that is capable of being performed completely on the GPU intranode. It works by mimicking the NCCL ring Allreduce using a custom algorithm that is based on CUDA-aware MPI send/receive primitives. On machines that are able to support it, it allows for much higher throughput than other Adasum operations.

Note that this current version only works on DGX1-like machines that have 8 GPUs. It could be extended to more in the future, but this was the main use case where the other two currently existing Adasum modes (CPU and Hierarchical) both have large drawbacks.

In order to use it, Horovod should be compiled with HOROVOD_GPU_ALLREDUCE=MPI and op=hvd.Adasum should be passed in to the optimizer/allreduce calls. The user needs to have a CUDA-aware MPI implementation installed (we used OpenMPI with UCX). 