### PR TITLE
Add process binding arguments to horovodrun

### DIFF
--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -17,8 +17,8 @@
 class Settings(object):
 
     def __init__(self, verbose=0, ssh_port=None, extra_mpi_args=None, tcp_flag=None,
-                 key=None, timeout=None, num_hosts=None, num_proc=None, hosts=None,
-                 output_filename=None, run_func_mode=None, nic=None):
+                 binding_args=None, key=None, timeout=None, num_hosts=None, num_proc=None,
+                 hosts=None, output_filename=None, run_func_mode=None, nic=None):
         """
         :param verbose: level of verbosity
         :type verbose: int
@@ -28,6 +28,8 @@ class Settings(object):
         :type extra_mpi_args: string
         :param tcp_flag: TCP only communication flag
         :type tcp_flag: boolean
+        :param binding_args: Process binding arguments
+        :type binding_args: string
         :param key: used for encryption of parameters passed across the hosts
         :type key: str
         :param timeout: has to finish all the checks before this timeout runs
@@ -50,6 +52,7 @@ class Settings(object):
         self.ssh_port = ssh_port
         self.extra_mpi_args = extra_mpi_args
         self.tcp_flag = tcp_flag
+        self.binding_args = binding_args
         self.key = key
         self.timeout = timeout
         self.num_hosts = num_hosts

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -561,6 +561,9 @@ def parse_args():
                                        'e.g. --mpi-args="--map-by ppr:6:node"')
     group_library_options.add_argument('--tcp', action='store_true', dest='tcp_flag',
                                        help='If this flag is set, only TCP is used for communication.')
+    group_library_options.add_argument('--binding-args', action='store', dest='binding_args',
+                                       help='Process binding arguments. Default is socket for Spectrum MPI '
+                                       'and no binding for other cases. e.g. --binding-args="--rankfile myrankfile"')
     group_library_options.add_argument('--num-nccl-streams', action=make_override_action(override_args),
                                        type=int, default=1,
                                        help='Number of NCCL streams. Only applies when running with NCCL support. '
@@ -662,6 +665,7 @@ class HorovodArgs(object):
         self.mpi_threads_disable = None
         self.mpi_args = None
         self.tcp_flag = None
+        self.binding_args = None
         self.num_nccl_streams = None
         self.ccl_bgt_affinity = None
         self.gloo_timeout_seconds = None
@@ -734,6 +738,7 @@ def _run(args):
                                      ssh_port=args.ssh_port,
                                      extra_mpi_args=args.mpi_args,
                                      tcp_flag=args.tcp_flag,
+                                     binding_args=args.binding_args,
                                      key=secret.make_secret_key(),
                                      timeout=tmout,
                                      num_hosts=len(all_host_names),

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -178,12 +178,12 @@ class SparkTests(unittest.TestCase):
                          'Spark timed out before mpi_run was called, test setup is broken.')
         self.assertEqual(str(e.value), 'Spark job has failed, see the error above.')
 
-        mpi_flags = _get_mpi_implementation_flags(False)
+        mpi_flags, binding_args = _get_mpi_implementation_flags(False)
         self.assertIsNotNone(mpi_flags)
         expected_command = ('mpirun '
                             '--allow-run-as-root --tag-output '
                             '-np {expected_np} -H [^ ]+ '
-                            '-bind-to none -map-by slot '
+                            '{binding_args} '
                             '{mpi_flags}  '
                             '-mca btl_tcp_if_include [^ ]+ -x NCCL_SOCKET_IFNAME=[^ ]+  '
                             '-x _HOROVOD_SECRET_KEY {expected_env}'
@@ -192,6 +192,7 @@ class SparkTests(unittest.TestCase):
                             r'-mca plm_rsh_agent "[^"]+python[\d]* -m horovod.spark.driver.mpirun_rsh [^ ]+ [^ ]+" '
                             r'[^"]+python[\d]* -m horovod.spark.task.mpirun_exec_fn [^ ]+ [^ ]+'.format(
                                 expected_np=expected_np,
+                                binding_args=' '.join(binding_args),
                                 expected_env=expected_env + ' ' if expected_env else '',
                                 mpi_flags=' '.join(mpi_flags),
                                 extra_mpi_args=extra_mpi_args if extra_mpi_args else ''))


### PR DESCRIPTION
To maintain compute/memory locality, it is often good practise to
bind processes to NUMA nodes.
In ppc64le architecture with large models, I see a 20% performance gain
because tensor swapping happens between GPU memory and system memory and
CPU/GPU link (NVLINK) is faster than inter-socket link.
The PR also makes socket binding the default for SMPI (ppc64le). Even
with those flags, you may end up in a situation when a process with a GPU is bound to a
non-local CPU socket. That happens usually when GPUs are not split evenly across sockets or
you don't use all the GPUs of a node. In those cases, it
is recommended to use a rankfile to get more control: --binding-args="--rankfile myrankfile"

Signed-off-by: Nicolas V Castet <nvcastet@us.ibm.com>