### PR TITLE
Cleanup tests to improve debugging and deprecate Python 2 for new framework releases

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -20,7 +20,6 @@ tests=( \
        test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \
        test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
-       test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-mpich-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0 \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -131,9 +131,9 @@ RUN if [[ ${MPI_KIND} == "ONECCL" ]]; then \
       export I_MPI_ROOT=/usr/local/oneccl; \
       export PIP_HOROVOD_MPICXX_SHOW=/usr/local/oneccl/bin/mpicxx; \
       echo "horovod python setup.py sdist, mpicxx is $(which mpicxx)"; \
-      cd /horovod && python setup.py sdist; \
+      cd /horovod && HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 python setup.py sdist; \
     else \
-      cd /horovod && python setup.py sdist; \
+      cd /horovod && HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 python setup.py sdist; \
     fi
 
 RUN if [[ ${MPI_KIND} == "ONECCL" ]]; then \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -105,7 +105,7 @@ RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; 
 # Install Horovod.
 RUN cd /horovod && python setup.py sdist
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
-    bash -c "${HOROVOD_BUILD_FLAGS} pip install -v $(ls /horovod/dist/horovod-*.tar.gz)[spark]" && \
+    bash -c "${HOROVOD_BUILD_FLAGS} HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install -v $(ls /horovod/dist/horovod-*.tar.gz)[spark]" && \
     ldconfig
 
 # Hack for compatibility of MNIST example with TensorFlow 1.1.0.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -155,18 +155,6 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py2_7-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
-    extends: test-cpu-base
-    build:
-      args:
-        MPI_KIND: OpenMPI
-        PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==2.1.0 tensorflow-estimator==2.1.0
-        KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
-        PYTORCH_PACKAGE: torch-nightly
-        TORCHVISION_PACKAGE: torchvision
-        MXNET_PACKAGE: mxnet==1.5.0
-        PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0:
     extends: test-cpu-base
     build:

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -687,12 +687,12 @@ def parse_host_files(filename):
     :return: Comma separated string of <IP address> or <host name>:<Number of GPUs>
     """
     hosts = []
-    for line in open(filename):
-        line = line.rstrip()
-        hostname = line.split()[0]
-        slots = line.split('=')[1]
-        hosts.append('{name}:{slots}'.format(name=hostname, slots=slots))
-
+    with open(filename, 'r') as f:
+        for line in f.readlines():
+            line = line.rstrip()
+            hostname = line.split()[0]
+            slots = line.split('=')[1]
+            hosts.append('{name}:{slots}'.format(name=hostname, slots=slots))
     return ','.join(hosts)
 
 


### PR DESCRIPTION
- Removed Python 2 tests for upcoming framework releases
- Requiring frameworks to build successfully  with Horovod in Docker image
- Using context manager when parsing the host file to prevent file handle leak