### PR TITLE
Renaming few functions to hide complexity

### DIFF
--- a/horovod/run/elastic/driver.py
+++ b/horovod/run/elastic/driver.py
@@ -344,7 +344,7 @@ class ElasticDriver(object):
             host_assignments[slot_info.hostname].append(slot_info)
         self._host_assignments = host_assignments
         self._world_size = len(host_assignments_list)
-        self._rendezvous.httpd.reset(host_assignments_list)
+        self._rendezvous.httpd.init(host_assignments_list)
 
     def _count_available_slots(self):
         return sum([self._get_slots(host) for host in self._available_hosts])

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -86,11 +86,11 @@ def _create_exec_command(settings, env, local_host_names, run_command):
     # Create a event for communication between threads
     event = threading.Event()
 
-    def set_event_on_sigterm(signum, frame):
+    def set_event_on_signal(signum, frame):
         event.set()
 
-    signal.signal(signal.SIGINT, set_event_on_sigterm)
-    signal.signal(signal.SIGTERM, set_event_on_sigterm)
+    signal.signal(signal.SIGINT, set_event_on_signal)
+    signal.signal(signal.SIGTERM, set_event_on_signal)
 
     def get_command(slot_info):
         # generate env for rendezvous
@@ -235,7 +235,7 @@ def gloo_run(settings, local_host_names, common_intfs, env, command):
 
     # start global rendezvous server and get port that it is listening on
     global_rendezv_port = rendezvous.start_server()
-    rendezvous.httpd.extract_scope_size(host_alloc_plan)
+    rendezvous.httpd.init(host_alloc_plan)
     run_command = get_run_command(command, common_intfs, global_rendezv_port)
     exec_command = _create_exec_command(settings, env, local_host_names, run_command)
 

--- a/horovod/run/http/http_server.py
+++ b/horovod/run/http/http_server.py
@@ -148,7 +148,7 @@ class RendezvousHTTPServer(socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServe
         # Total size for scopes
         self.scope_size = {}
 
-    def reset(self, host_alloc_plan):
+    def init(self, host_alloc_plan):
         with self.cache_lock:
             self.cache.clear()
 
@@ -156,9 +156,9 @@ class RendezvousHTTPServer(socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServe
             self.finished_list.clear()
 
         self.scope_size.clear()
-        self.extract_scope_size(host_alloc_plan)
+        self._extract_scope_size(host_alloc_plan)
 
-    def extract_scope_size(self, host_alloc_plan):
+    def _extract_scope_size(self, host_alloc_plan):
         for slot_info in host_alloc_plan:
             self.scope_size['global_'] = slot_info.size
             cross_rank = slot_info.cross_rank
@@ -178,6 +178,7 @@ class RendezvousServer:
 
     # Rendezvous function finds a available port, create http socket,
     # and start listening loop to handle request
+    # self.httpd.init needs to be called after server start
     def start_server(self, handler_cls=RendezvousHandler):
         self.httpd, port = find_port(
             lambda addr: RendezvousHTTPServer(


### PR DESCRIPTION
some methods expose too much complexity, this simplifies the name for the caller