### PR TITLE
Revert "Add mpi_args to horovod.run.run (#1770)"

### DIFF
--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -890,7 +890,6 @@ def run(
         verbose=None,
         use_gloo=None,
         use_mpi=None,
-        mpi_args=None,
         network_interface=None):
     """
     Launch a Horovod job to run the specified process function and get the return value.
@@ -929,7 +928,6 @@ def run(
                      be the default if Horovod was not built with MPI support.
     :param use_mpi: Run Horovod using the MPI controller. This will
                     be the default if Horovod was built with MPI support.
-    :param mpi_args: Extra arguments for the MPI controller. This is only used when use_mpi is True.
     :param network_interface: Specify the network interface for communication.
 
     :return: Return a list which contains values return by all Horovod processes.
@@ -955,7 +953,6 @@ def run(
     hargs.hostfile = hostfile
     hargs.start_timeout = start_timeout
     hargs.ssh_port = ssh_port
-    hargs.mpi_args = mpi_args
     hargs.disable_cache = disable_cache
     hargs.output_filename = output_filename
     hargs.verbose = verbose


### PR DESCRIPTION
This reverts commit 5e822b50fab2aae0abde1533c346ee2cff47cbde.

Fix history following: https://github.community/t5/How-to-use-Git-and-GitHub/Authorship-of-merge-commits-made-by-Github-Apps-changed/td-p/48797