### PR TITLE
Added extras_require to ensure Horovod is installed after frameworks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1546,6 +1546,19 @@ setup(name='horovod',
               'pyarrow>=0.15.0',  # Petastorm 0.7.7 is not compatible with < 0.15.0
               'pyspark>=2.3.2'
           ],
+          'tensorflow':  [
+              'tensorflow'
+          ],
+          'tensorflow-gpu':  [
+              'tensorflow-gpu'
+          ],
+          'pytorch':  [
+              'torch',
+              'torchvision'
+          ],
+          'mxnet':  [
+              'mxnet'
+          ]
       },
       zip_safe=False,
       scripts=['bin/horovodrun'])

--- a/setup.py
+++ b/setup.py
@@ -1555,7 +1555,7 @@ setup(name='horovod',
           'keras': [
               'keras>=2.0.8,!=2.0.9,!=2.1.0,!=2.1.1'
           ],
-          'torch':  [
+          'pytorch':  [
               'torch',
               'torchvision'
           ],

--- a/setup.py
+++ b/setup.py
@@ -1552,12 +1552,15 @@ setup(name='horovod',
           'tensorflow-gpu':  [
               'tensorflow-gpu'
           ],
-          'pytorch':  [
+          'keras': [
+              'keras>=2.0.8,!=2.0.9,!=2.1.0,!=2.1.1'
+          ],
+          'torch':  [
               'torch',
               'torchvision'
           ],
           'mxnet':  [
-              'mxnet'
+              'mxnet>=1.4.1'
           ]
       },
       zip_safe=False,


### PR DESCRIPTION
In some setups, Horovod will be installed along with other dependencies at once, and the pip compiler will use the dependency graph to determine the package install order.  This can create problems if TensorFlow, PyTorch or MXNet are listed as dependencies in the same file:

```
...
tensorflow==1.15
horovod
```

In this case, pip may decide to install Horovod before TensorFlow, because Horovod does not explicitly depend on any framework.  Now, users can optionally declare that TensorFlow must be installed before Horovod, or it will be installed as part of installing Horovod:

```
...
tensorflow==1.15
horovod[tensorflow]
```

Note that because this information is not passed to `setup.py`, it cannot be used to enforce that Horovod must build successfully with any particular framework.  As such, we still need env variables like `HOROVOD_WITH_TENSORFLOW=1` to enforce this.