### PR TITLE
Add LSF and jsrun support to horovodrun

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,8 @@ See `Run Horovod <docs/running.rst>`_ for more details, including RoCE/InfiniBan
 
 7. To run in Singularity, see `Singularity <https://github.com/sylabs/examples/tree/master/machinelearning/horovod>`_.
 
+8. To run in a LSF HPC cluster (e.g. Summit), see `LSF <docs/lsf.rst>`_.
+
 Gloo
 ----
 `Gloo <https://github.com/facebookincubator/gloo>`_ is an open source collective communications library developed by Facebook.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,6 +119,8 @@ Guides
 
    spark_include
 
+   lsf_include
+
    tensor-fusion_include
 
    timeline_include

--- a/docs/lsf.rst
+++ b/docs/lsf.rst
@@ -1,0 +1,32 @@
+.. inclusion-marker-start-do-not-remove
+
+
+Horovod in LSF
+==============
+
+This page includes examples for running Horovod in a LSF cluster.
+``horovodrun`` will automatically detect the host names and GPUs of your LSF job.
+If the LSF cluster supports ``jsrun``, ``horovodrun`` will use it as launcher
+otherwise it will default to ``mpirun``.
+
+Inside a LSF batch file or in an interactive session, you just need to use:
+
+.. code-block:: bash
+
+    horovodrun python train.py
+
+Here, Horovod will start a process per GPU on all the hosts of the LSF job.
+
+You can also limit the run to a subset of the job resources. For example, using only 6 GPUs:
+
+.. code-block:: bash
+
+    horovodrun -np 6 python train.py
+
+You can still pass extra arguments to ``horovodrun``. For example, to trigger CUDA-Aware MPI:
+
+.. code-block:: bash
+
+    horovodrun --mpi-args="-gpu" python train.py
+
+.. inclusion-marker-end-do-not-remove

--- a/docs/lsf_include.rst
+++ b/docs/lsf_include.rst
@@ -1,0 +1,3 @@
+.. include:: ./lsf.rst
+   :start-after: inclusion-marker-start-do-not-remove
+   :end-before: inclusion-marker-end-do-not-remove

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -274,6 +274,8 @@ See `Run Horovod <running.rst>`_ for more details, including RoCE/InfiniBand twe
 
 7. To run in Singularity, see `Singularity <https://github.com/sylabs/examples/tree/master/machinelearning/horovod>`_.
 
+8. To run in a LSF HPC cluster (e.g. Summit), see `LSF <lsf.rst>`_.
+
 Gloo
 ----
 `Gloo <https://github.com/facebookincubator/gloo>`_ is an open source collective communications library developed by Facebook.

--- a/horovod/run/driver/driver_service.py
+++ b/horovod/run/driver/driver_service.py
@@ -13,8 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 
-from horovod.run.common.service import driver_service
+import os
+import six
+import sys
 
+from socket import AF_INET
+from psutil import net_if_addrs
+
+from horovod.run.util import cache, lsf, threads
+from horovod.run.common.service import driver_service
+from horovod.run.common.util import codec, safe_shell_exec
+from horovod.run.task import task_service
 
 class HorovodRunDriverService(driver_service.BasicDriverService):
     NAME = 'horovodrun driver service'
@@ -33,3 +42,212 @@ class HorovodRunDriverClient(driver_service.BasicDriverClient):
             key,
             verbose,
             match_intf=match_intf)
+
+
+def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
+                         settings):
+    """
+    Executes the task server and service client task for registration on the
+    hosts.
+    :param all_host_names: list of addresses. for example,
+        ['worker-0','worker-1']
+        ['10.11.11.11', '10.11.11.12']
+    :type all_host_names: list(string)
+    :param local_host_names: names that are resolved to one of the addresses
+    of local hosts interfaces. For example,
+        set(['localhost', '127.0.0.1'])
+    :type local_host_names: set
+    :param driver_addresses: map of interfaces and their address and port for
+    the service. For example:
+        {
+            'lo': [('127.0.0.1', 34588)],
+            'docker0': [('172.122.10.1', 34588)],
+            'eth0': [('11.111.33.73', 34588)]
+        }
+    :type driver_addresses: map
+    :param settings: the object that contains the setting for running horovod
+    :type settings: Horovod.run.common.util.settings.Settings
+    :return:
+    :rtype:
+    """
+
+    def _exec_command(command):
+        host_output = six.StringIO()
+        try:
+            exit_code = safe_shell_exec.execute(command,
+                                                stdout=host_output,
+                                                stderr=host_output)
+            if exit_code != 0:
+                print(
+                    'Launching horovodrun task function was not '
+                    'successful:\n{host_output}'
+                    .format(host_output=host_output.getvalue()))
+                os._exit(exit_code)
+        finally:
+            host_output.close()
+        return exit_code
+
+    if settings.ssh_port:
+        ssh_port_arg = '-p {ssh_port}'.format(ssh_port=settings.ssh_port)
+    else:
+        ssh_port_arg = ''
+    args_list = []
+    for index in range(len(all_host_names)):
+        host_name = all_host_names[index]
+        if host_name in local_host_names:
+            command = \
+                '{python} -m horovod.run.task_fn {index} ' \
+                '{driver_addresses} {settings}'\
+                .format(python=sys.executable,
+                        index=codec.dumps_base64(index),
+                        driver_addresses=codec.dumps_base64(driver_addresses),
+                        settings=codec.dumps_base64(settings))
+        else:
+            command = \
+                'ssh -o StrictHostKeyChecking=no {host} {ssh_port_arg} ' \
+                '\'{python} -m horovod.run.task_fn {index} {driver_addresses}' \
+                ' {settings}\''\
+                .format(host=host_name,
+                        ssh_port_arg=ssh_port_arg,
+                        python=sys.executable,
+                        index=codec.dumps_base64(index),
+                        driver_addresses=codec.dumps_base64(driver_addresses),
+                        settings=codec.dumps_base64(settings))
+        args_list.append([command])
+    # Each thread will use ssh command to launch the server on one task. If an
+    # error occurs in one thread, entire process will be terminated. Otherwise,
+    # threads will keep running and ssh session -- and the the task server --
+    # will be bound to the thread. In case, the horovodrun process dies, all
+    # the ssh sessions and all the task servers will die as well.
+    threads.execute_function_multithreaded(_exec_command,
+                                           args_list,
+                                           block_until_all_done=False)
+
+
+@cache.use_cache()
+def _driver_fn(all_host_names, local_host_names, settings):
+    """
+    launches the service service, launches the task service on each worker and
+    have them register with the service service. Each worker probes all the
+    interfaces of the worker index + 1 (in a ring manner) and only keeps the
+    routed interfaces. Function returns the intersection of the set of all the
+    routed interfaces on all the workers.
+    :param all_host_names: list of addresses. for example,
+        ['worker-0','worker-1']
+        ['10.11.11.11', '10.11.11.12']
+    :type all_host_names: list(string)
+    :param local_host_names: host names that resolve into a local addresses.
+    :type local_host_names: set
+    :param settings: the object that contains the setting for running horovod
+    :type settings: Horovod.run.common.util.settings.Settings
+    :return: example: ['eth0', 'eth1']
+    :rtype: list[string]
+    """
+    # Launch a TCP server called service service on the host running
+    # horovodrun.
+    driver = HorovodRunDriverService(
+        settings.num_hosts, settings.key, settings.nic)
+    if settings.verbose >= 2:
+        print('Launched horovodrun server.')
+    # Have all the workers register themselves with the service service.
+    _launch_task_servers(all_host_names, local_host_names,
+                         driver.addresses(), settings)
+    if settings.verbose >= 2:
+        print('Attempted to launch horovod task servers.')
+    try:
+        # wait for all the hosts to register with the service service.
+        if settings.verbose >= 2:
+            print('Waiting for the hosts to acknowledge.')
+        driver.wait_for_initial_registration(settings.timeout)
+        tasks = [
+            task_service.HorovodRunTaskClient(
+                index,
+                driver.task_addresses_for_driver(index),
+                settings.key,
+                settings.verbose) for index in range(
+                settings.num_hosts)]
+        # Notify all the drivers that the initial registration is complete.
+        for task in tasks:
+            task.notify_initial_registration_complete()
+        if settings.verbose >= 2:
+            print('Notified all the hosts that the registration is complete.')
+        # Each worker should probe the interfaces of the next worker in a ring
+        # manner and filter only the routed ones -- it should filter out
+        # interfaces that are not really connected to any external networks
+        # such as lo0 with address 127.0.0.1.
+        if settings.verbose >= 2:
+            print('Waiting for hosts to perform host-to-host '
+                  'interface checking.')
+        driver.wait_for_task_to_task_address_updates(settings.timeout)
+        if settings.verbose >= 2:
+            print('Host-to-host interface checking successful.')
+        # Determine a set of common interfaces for task-to-task communication.
+        common_intfs = set(driver.task_addresses_for_tasks(0).keys())
+        for index in range(1, settings.num_hosts):
+            common_intfs.intersection_update(
+                driver.task_addresses_for_tasks(index).keys())
+        if not common_intfs:
+            raise Exception(
+                'Unable to find a set of common task-to-task communication '
+                'interfaces: %s'
+                % [(index, driver.task_addresses_for_tasks(index))
+                   for index in range(settings.num_hosts)])
+        return common_intfs
+    finally:
+        driver.shutdown()
+
+
+def _get_common_interfaces(settings, all_host_names, remote_host_names, fn_cache):
+    '''
+    Find the set of common and routed interfaces on all the hosts.
+    :param settings: the object that contains the setting for running horovod
+    :type settings: Horovod.run.common.util.settings.Settings
+    :param all_host_names: list of the host names
+    :type all_host_names: list(string)
+    :param remote_host_names: list of the remote host names.
+    :type remote_host_names: list(string)
+    :param fn_cache: Cache storing the results of checks performed by horovodrun
+    :type fn_cache: Horovod.run.util.cache.Cache
+    :return: List of common interfaces
+    '''
+    # Skipping interface discovery for LSF cluster as it slows down considerably the job start
+    if lsf.LSFUtils.using_lsf():
+        return None
+
+    if len(remote_host_names) > 0:
+        if settings.verbose >= 2:
+            print('Testing interfaces on all the hosts.')
+
+        local_host_names = set(all_host_names) - set(remote_host_names)
+        # Find the set of common, routed interfaces on all the hosts (remote
+        # and local) and specify it in the args to be used by NCCL. It is
+        # expected that the following function will find at least one interface
+        # otherwise, it will raise an exception.
+        common_intfs = _driver_fn(all_host_names, local_host_names,
+                                  settings, fn_cache=fn_cache)
+
+        if settings.verbose >= 2:
+            print('Interfaces on all the hosts were successfully checked.')
+            print('Common interface found: ' + ' '.join(common_intfs))
+
+    else:
+        if settings.verbose >= 2:
+            print('All hosts are local, finding the interfaces '
+                  'with address 127.0.0.1')
+        # If all the given hosts are local, find the interfaces with address
+        # 127.0.0.1
+        common_intfs = set()
+        for iface, addrs in net_if_addrs().items():
+            if settings.nic and iface != settings.nic:
+                continue
+            for addr in addrs:
+                if addr.family == AF_INET and addr.address == '127.0.0.1':
+                    common_intfs.add(iface)
+                    break
+
+        if len(common_intfs) == 0:
+            raise ValueError('No interface is found for address 127.0.0.1.')
+
+        if settings.verbose >= 2:
+            print('Local interface found ' + ' '.join(common_intfs))
+    return common_intfs

--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -1,0 +1,150 @@
+# Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import print_function
+import os
+import tempfile
+from horovod.run.common.util import safe_shell_exec
+from horovod.run.util import lsf
+from distutils.spawn import find_executable
+from horovod.run.mpi_run import _get_mpi_implementation_flags, _MPI_NOT_FOUND_ERROR_MSG
+
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
+
+
+def is_jsrun_installed():
+    """Returns True if jsrun is installed."""
+    return find_executable('jsrun') is not None
+
+
+def js_run(settings, common_intfs, env, command, stdout=None, stderr=None, run_func=safe_shell_exec.execute):
+    """
+    Runs Horovod with jsrun.
+
+    Args:
+        settings: Settings for running jsrun.
+                  Note: settings.num_proc and settings.hosts must not be None.
+        common_intfs: Interfaces to include by jsrun.
+        env: Environment dictionary to use for running jsrun.
+        command: Command and arguments to run as a list of string.
+        stdout: Stdout of the mpi process.
+                Only used when settings.run_func_mode is True.
+        stderr: Stderr of the mpi process.
+                Only used when settings.run_func_mode is True.
+        run_func: Run function to use. Must have arguments 'command' and 'env'.
+                  Only used when settings.run_func_mode is True.
+                  Defaults to safe_shell_exec.execute.
+    """
+    mpi_impl_flags, _ = _get_mpi_implementation_flags(settings.tcp_flag)
+    if mpi_impl_flags is None:
+        raise Exception(_MPI_NOT_FOUND_ERROR_MSG)
+
+    if not is_jsrun_installed():
+        raise Exception(
+            'horovodrun convenience script does not find the jsrun command.\n\n'
+            'Please, make sure you are running on a cluster with jsrun installed or '
+            'use one of the other launchers.')
+
+    if common_intfs and 'NCCL_SOCKET_IFNAME' not in env:
+        env['NCCL_SOCKET_IFNAME'] = ','.join(common_intfs)
+
+    smpiargs = ' '.join(mpi_impl_flags)
+    if settings.extra_mpi_args:
+        smpiargs += ' ' + settings.extra_mpi_args
+
+    if settings.binding_args:
+        binding_args = settings.binding_args
+    else:
+        rf = generate_jsrun_rankfile(settings)
+        if settings.verbose >= 2:
+            safe_shell_exec.execute('cat {rf}'.format(rf=rf))
+        binding_args = '--erf_input {rf}'.format(rf=rf)
+
+    jsrun_command = (
+        'jsrun {binding_args} '
+        '{output_filename_arg} '
+        '{smpiargs} '
+        '{command}'
+        .format(binding_args = binding_args,
+                output_filename_arg='--stdio_stderr {file} --stdio_stdout {file}'.format(file=settings.output_filename)
+                                    if settings.output_filename else '',
+                smpiargs= '--smpiargs {args}'.format(args=quote(smpiargs)) if smpiargs else '',
+                command=' '.join(quote(par) for par in command))
+    )
+
+    if settings.verbose >= 2:
+        print(jsrun_command)
+
+    # Execute the jsrun command.
+    if settings.run_func_mode:
+        exit_code = run_func(command=jsrun_command, env=env, stdout=stdout, stderr=stderr)
+        if exit_code != 0:
+            raise RuntimeError("jsrun failed with exit code {exit_code}".format(exit_code=exit_code))
+    else:
+        os.execve('/bin/sh', ['/bin/sh', '-c', jsrun_command], env)
+
+
+def generate_jsrun_rankfile(settings):
+    """
+    Generates rankfile to use with jsrun.
+    It splits the cores among the processes, which leads to best performance according to experiments.
+
+    Args:
+        settings: Settings for running jsrun.
+                  Note: settings.num_proc and settings.hosts must not be None.
+    """
+    cpu_per_gpu = (lsf.LSFUtils.get_num_cores() * lsf.LSFUtils.get_num_threads()) // lsf.LSFUtils.get_num_gpus()
+    host_list = (x.split(':') for x in settings.hosts.split(','))
+
+    # Verify and truncate host list if necessary
+    validated_list = []
+    remaining_slots = settings.num_proc
+    for host, slots in host_list:
+        slots = int(slots)
+        if slots > lsf.LSFUtils.get_num_gpus():
+            raise ValueError('Invalid host input, slot count for host \'{host}:{slots}\' is greater '
+                             'than number of GPUs per host \'{gpus}\'.'.format(
+                host=host, slots=slots, gpus=lsf.LSFUtils.get_num_gpus()))
+        needed_slots = min(slots, remaining_slots)
+        validated_list.append((host, needed_slots))
+        remaining_slots -= needed_slots
+        if remaining_slots == 0:
+            break
+    if remaining_slots != 0:
+        raise ValueError('Not enough slots on the hosts to fulfill the {slots} requested.'.format(
+            slots=settings.num_proc))
+
+    # Generate rankfile
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, 'w') as tmp:
+        tmp.write('overlapping_rs: allow\n')
+        tmp.write('cpu_index_using: logical\n')
+        rank = 0
+        for host, slots in validated_list:
+            cpu_val = 0
+            tmp.write('\n')
+            for s in range(slots):
+                tmp.write('rank: {rank}: {{ hostname: {host}; cpu: {{{scpu}-{ecpu}}} ; gpu: * ; mem: * }}\n'.format(
+                    rank=rank,
+                    host=host,
+                    scpu=cpu_val,
+                    ecpu=cpu_val + cpu_per_gpu - 1
+                ))
+                rank += 1
+                cpu_val += cpu_per_gpu
+    return path

--- a/horovod/run/run.py
+++ b/horovod/run/run.py
@@ -22,8 +22,6 @@ import sys
 import re
 import textwrap
 
-from socket import AF_INET
-from psutil import net_if_addrs
 try:
     from shlex import quote
 except ImportError:
@@ -38,10 +36,9 @@ import horovod
 from horovod.common.util import (extension_available,
                                  gloo_built, mpi_built,
                                  nccl_built, ddl_built, ccl_built)
-from horovod.run.common.util import codec, config_parser, safe_shell_exec, timeout, secret
+from horovod.run.common.util import config_parser, safe_shell_exec, timeout, secret
 from horovod.run.common.util import settings as hvd_settings
 from horovod.run.driver import driver_service
-from horovod.run.task import task_service
 from horovod.run.util import cache, threads, network, lsf
 from horovod.run.gloo_run import gloo_run
 from horovod.run.mpi_run import mpi_run
@@ -114,177 +111,6 @@ def _check_all_hosts_ssh_successful(host_addresses, ssh_port=None):
     if not ssh_successful_to_all_hosts:
         exit(1)
     return True
-
-
-def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
-                         settings):
-    """
-    Executes the task server and service client task for registration on the
-    hosts.
-    :param all_host_names: list of addresses. for example,
-        ['worker-0','worker-1']
-        ['10.11.11.11', '10.11.11.12']
-    :type all_host_names: list(string)
-    :param local_host_names: names that are resolved to one of the addresses
-    of local hosts interfaces. For example,
-        set(['localhost', '127.0.0.1'])
-    :type local_host_names: set
-    :param driver_addresses: map of interfaces and their address and port for
-    the service. For example:
-        {
-            'lo': [('127.0.0.1', 34588)],
-            'docker0': [('172.122.10.1', 34588)],
-            'eth0': [('11.111.33.73', 34588)]
-        }
-    :type driver_addresses: map
-    :param settings: the object that contains the setting for running horovod
-    :type settings: Horovod.run.common.util.settings.Settings
-    :return:
-    :rtype:
-    """
-
-    def _exec_command(command):
-        host_output = six.StringIO()
-        try:
-            exit_code = safe_shell_exec.execute(command,
-                                                stdout=host_output,
-                                                stderr=host_output)
-            if exit_code != 0:
-                print(
-                    'Launching horovodrun task function was not '
-                    'successful:\n{host_output}'
-                    .format(host_output=host_output.getvalue()))
-                os._exit(exit_code)
-        finally:
-            host_output.close()
-        return exit_code
-
-    if settings.ssh_port:
-        ssh_port_arg = '-p {ssh_port}'.format(ssh_port=settings.ssh_port)
-    else:
-        ssh_port_arg = ''
-    args_list = []
-    for index in range(len(all_host_names)):
-        host_name = all_host_names[index]
-        if host_name in local_host_names:
-            command = \
-                '{python} -m horovod.run.task_fn {index} ' \
-                '{driver_addresses} {settings}'\
-                .format(python=sys.executable,
-                        index=codec.dumps_base64(index),
-                        driver_addresses=codec.dumps_base64(driver_addresses),
-                        settings=codec.dumps_base64(settings))
-        else:
-            command = \
-                'ssh -o StrictHostKeyChecking=no {host} {ssh_port_arg} ' \
-                '\'{python} -m horovod.run.task_fn {index} {driver_addresses}' \
-                ' {settings}\''\
-                .format(host=host_name,
-                        ssh_port_arg=ssh_port_arg,
-                        python=sys.executable,
-                        index=codec.dumps_base64(index),
-                        driver_addresses=codec.dumps_base64(driver_addresses),
-                        settings=codec.dumps_base64(settings))
-        args_list.append([command])
-    # Each thread will use ssh command to launch the server on one task. If an
-    # error occurs in one thread, entire process will be terminated. Otherwise,
-    # threads will keep running and ssh session -- and the the task server --
-    # will be bound to the thread. In case, the horovodrun process dies, all
-    # the ssh sessions and all the task servers will die as well.
-    threads.execute_function_multithreaded(_exec_command,
-                                           args_list,
-                                           block_until_all_done=False)
-
-
-@cache.use_cache()
-def _driver_fn(all_host_names, local_host_names, settings):
-    """
-    launches the service service, launches the task service on each worker and
-    have them register with the service service. Each worker probes all the
-    interfaces of the worker index + 1 (in a ring manner) and only keeps the
-    routed interfaces. Function returns the intersection of the set of all the
-    routed interfaces on all the workers.
-    :param all_host_names: list of addresses. for example,
-        ['worker-0','worker-1']
-        ['10.11.11.11', '10.11.11.12']
-    :type all_host_names: list(string)
-    :param local_host_names: host names that resolve into a local addresses.
-    :type local_host_names: set
-    :param settings: the object that contains the setting for running horovod
-    :type settings: Horovod.run.common.util.settings.Settings
-    :return: example: ['eth0', 'eth1']
-    :rtype: list[string]
-    """
-    # Launch a TCP server called service service on the host running
-    # horovodrun.
-    driver = driver_service.HorovodRunDriverService(
-        settings.num_hosts, settings.key, settings.nic)
-    if settings.verbose >= 2:
-        print('Launched horovodrun server.')
-    # Have all the workers register themselves with the service service.
-    _launch_task_servers(all_host_names, local_host_names,
-                         driver.addresses(), settings)
-    if settings.verbose >= 2:
-        print('Attempted to launch horovod task servers.')
-    try:
-        # wait for all the hosts to register with the service service.
-        if settings.verbose >= 2:
-            print('Waiting for the hosts to acknowledge.')
-        driver.wait_for_initial_registration(settings.timeout)
-        tasks = [
-            task_service.HorovodRunTaskClient(
-                index,
-                driver.task_addresses_for_driver(index),
-                settings.key,
-                settings.verbose) for index in range(
-                settings.num_hosts)]
-        # Notify all the drivers that the initial registration is complete.
-        for task in tasks:
-            task.notify_initial_registration_complete()
-        if settings.verbose >= 2:
-            print('Notified all the hosts that the registration is complete.')
-        # Each worker should probe the interfaces of the next worker in a ring
-        # manner and filter only the routed ones -- it should filter out
-        # interfaces that are not really connected to any external networks
-        # such as lo0 with address 127.0.0.1.
-        if settings.verbose >= 2:
-            print('Waiting for hosts to perform host-to-host '
-                  'interface checking.')
-        driver.wait_for_task_to_task_address_updates(settings.timeout)
-        if settings.verbose >= 2:
-            print('Host-to-host interface checking successful.')
-        # Determine a set of common interfaces for task-to-task communication.
-        common_intfs = set(driver.task_addresses_for_tasks(0).keys())
-        for index in range(1, settings.num_hosts):
-            common_intfs.intersection_update(
-                driver.task_addresses_for_tasks(index).keys())
-        if not common_intfs:
-            raise Exception(
-                'Unable to find a set of common task-to-task communication '
-                'interfaces: %s'
-                % [(index, driver.task_addresses_for_tasks(index))
-                   for index in range(settings.num_hosts)])
-        return common_intfs
-    finally:
-        driver.shutdown()
-
-
-def _get_driver_ip(common_intfs):
-    """
-    :param common_intfs: object return by `_driver_fn`
-    :return: driver ip. We make sure all workers can connect to this ip.
-    """
-    iface = list(common_intfs)[0]
-    driver_ip = None
-    for addr in net_if_addrs()[iface]:
-        if addr.family == AF_INET:
-            driver_ip = addr.address
-
-    if not driver_ip:
-        raise RuntimeError(
-            'Cannot find an IPv4 address of the common interface.')
-
-    return driver_ip
 
 
 def check_build(verbose):
@@ -793,49 +619,11 @@ def _run(args):
         if settings.verbose >= 2:
             print('SSH was successful into all the remote hosts.')
 
-    common_intfs = None
-    # Skipping interface discovery for LSF cluster as it slows down considerably the job start
-    if not lsf.LSFUtils.using_lsf():
-        if len(remote_host_names) > 0:
-            if settings.verbose >= 2:
-                print('Testing interfaces on all the hosts.')
-
-            local_host_names = set(all_host_names) - set(remote_host_names)
-            # Find the set of common, routed interfaces on all the hosts (remote
-            # and local) and specify it in the args to be used by NCCL. It is
-            # expected that the following function will find at least one interface
-            # otherwise, it will raise an exception.
-            common_intfs = _driver_fn(all_host_names, local_host_names,
-                                      settings, fn_cache=fn_cache)
-
-            if settings.verbose >= 2:
-                print('Interfaces on all the hosts were successfully checked.')
-                print('Common interface found: ' + ' '.join(common_intfs))
-
-        else:
-            if settings.verbose >= 2:
-                print('All hosts are local, finding the interfaces '
-                      'with address 127.0.0.1')
-            # If all the given hosts are local, find the interfaces with address
-            # 127.0.0.1
-            common_intfs = set()
-            for iface, addrs in net_if_addrs().items():
-                if settings.nic and iface != settings.nic:
-                    continue
-                for addr in addrs:
-                    if addr.family == AF_INET and addr.address == '127.0.0.1':
-                        common_intfs.add(iface)
-                        break
-
-            if len(common_intfs) == 0:
-                raise ValueError('No interface is found for address 127.0.0.1.')
-
-            if settings.verbose >= 2:
-                print('Local interface found ' + ' '.join(common_intfs))
-
+    common_intfs = driver_service._get_common_interfaces(settings, all_host_names,
+                                                         remote_host_names, fn_cache)
     if args.run_func:
         # get the driver IPv4 address
-        driver_ip = _get_driver_ip(common_intfs)
+        driver_ip = network._get_driver_ip(common_intfs)
         run_func_server = KVStoreServer(verbose=settings.verbose)
         run_func_server_port = run_func_server.start_server()
         pickled_exec_func = cloudpickle.dumps(args.run_func)
@@ -869,7 +657,7 @@ def _launch_job(args, remote_host_names, settings, common_intfs, command):
         if not gloo_built(verbose=(settings.verbose >= 2)):
             raise ValueError('Gloo support has not been built.  If this is not expected, ensure CMake is installed '
                              'and reinstall Horovod with HOROVOD_WITH_GLOO=1 to debug the build error.')
-        gloo_run(settings, remote_host_names, common_intfs, env, _get_driver_ip(common_intfs), command)
+        gloo_run(settings, remote_host_names, common_intfs, env, network._get_driver_ip(common_intfs), command)
     elif args.use_mpi:
         if not mpi_built(verbose=(settings.verbose >= 2)):
             raise ValueError('MPI support has not been built.  If this is not expected, ensure MPI is installed '
@@ -887,7 +675,7 @@ def _launch_job(args, remote_host_names, settings, common_intfs, command):
             else:
                 mpi_run(settings, common_intfs, env, command)
         elif gloo_built(verbose=(settings.verbose >= 2)):
-            gloo_run(settings, remote_host_names, common_intfs, env, _get_driver_ip(common_intfs), command)
+            gloo_run(settings, remote_host_names, common_intfs, env, network._get_driver_ip(common_intfs), command)
         else:
             raise ValueError('Neither MPI nor Gloo support has been built. Try reinstalling Horovod ensuring that '
                              'either MPI is installed (MPI) or CMake is installed (Gloo).')

--- a/horovod/run/util/lsf.py
+++ b/horovod/run/util/lsf.py
@@ -1,0 +1,102 @@
+# Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import six
+import yaml
+from horovod.common.util import _cache
+from horovod.run.common.util import safe_shell_exec
+
+class LSFUtils:
+    """LSF Utilities"""
+    _CSM_ALLOCATION_QUERY = "/opt/ibm/csm/bin/csm_allocation_query"
+    _CSM_NODE_QUERY = "/opt/ibm/csm/bin/csm_node_attributes_query"
+    _LSCPU_CMD = "LANG=en_US.utf8 lscpu"
+    _THREAD_KEY= "Thread(s) per core"
+    _csm_allocation_info = {}
+
+    @staticmethod
+    def using_lsf():
+        """Returns True if LSF was used to start the current process."""
+        return "LSB_JOBID" in os.environ
+
+    @staticmethod
+    def get_allocation_info():
+        """Returns and sets the static CSM allocation info."""
+        if not LSFUtils._csm_allocation_info:
+            lsf_job_id = os.environ["LSB_JOBID"].strip()
+            output = six.StringIO()
+            exit_code = safe_shell_exec.execute("{cmd} -j {job}".format(
+                cmd=LSFUtils._CSM_ALLOCATION_QUERY, job=lsf_job_id),
+                stdout=output, stderr=output)
+            if exit_code != 0:
+                raise RuntimeError(
+                    "{cmd} failed with exit code {exit_code}".format(
+                        cmd=LSFUtils._CSM_ALLOCATION_QUERY, exit_code=exit_code))
+            LSFUtils._csm_allocation_info = yaml.safe_load(output.getvalue())
+            # Fetch the total number of cores and gpus for the first host
+            output = six.StringIO()
+            exit_code = safe_shell_exec.execute("{cmd} -n {node}".format(
+                cmd=LSFUtils._CSM_NODE_QUERY,
+                node=LSFUtils._csm_allocation_info["compute_nodes"][0]),
+                stdout=output, stderr=output)
+            if exit_code != 0:
+                raise RuntimeError(
+                    "{cmd} failed with exit code {exit_code}".format(
+                        cmd=LSFUtils._CSM_NODE_QUERY, exit_code=exit_code))
+            node_output = yaml.safe_load(output.getvalue())
+            total_core_count = (int(node_output["Record_1"]["discovered_cores"]) -
+                               int(node_output["Record_1"]["discovered_sockets"]) * LSFUtils._csm_allocation_info["isolated_cores"])
+            LSFUtils._csm_allocation_info["compute_node_cores"]= total_core_count
+            LSFUtils._csm_allocation_info["compute_node_gpus"] = int(node_output["Record_1"]["discovered_gpus"])
+            # Sorting LSF hostnames
+            LSFUtils._csm_allocation_info["compute_nodes"].sort()
+        return LSFUtils._csm_allocation_info
+
+    @staticmethod
+    def get_compute_hosts():
+        """Returns the list of LSF compute hosts."""
+        return LSFUtils.get_allocation_info()["compute_nodes"]
+
+    @staticmethod
+    def get_num_cores():
+        """Returns the number of cores per node."""
+        return LSFUtils.get_allocation_info()["compute_node_cores"]
+
+    @staticmethod
+    def get_num_gpus():
+        """Returns the number of gpus per node."""
+        return LSFUtils.get_allocation_info()["compute_node_gpus"]
+
+    @staticmethod
+    @_cache
+    def get_num_processes():
+        """Returns the total number of processes."""
+        return len(LSFUtils.get_compute_hosts()) * LSFUtils.get_num_gpus()
+
+    @staticmethod
+    @_cache
+    def get_num_threads():
+        """Returns the number of hardware threads."""
+        lscpu_cmd = 'ssh -o StrictHostKeyChecking=no {host} {cmd}'.format(
+            host=LSFUtils.get_compute_hosts()[0],
+            cmd = LSFUtils._LSCPU_CMD
+        )
+        output = six.StringIO()
+        exit_code = safe_shell_exec.execute(lscpu_cmd, stdout=output, stderr=output)
+        if exit_code != 0:
+            raise RuntimeError("{cmd} failed with exit code {exit_code}".format(
+                cmd=lscpu_cmd, exit_code=exit_code))
+        return int(yaml.safe_load(output.getvalue())[LSFUtils._THREAD_KEY])

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -404,8 +404,8 @@ class RunTests(unittest.TestCase):
                             '--erf_input /tmp/rankfile '
                             '--stdio_stderr >output filename goes here< '
                             '--stdio_stdout >output filename goes here< '
-                            '--smpiargs \' >mpi-extra args go here<\' '
-                            'cmd arg1 arg2')
+                            '--smpiargs \'{mpi_args} >mpi-extra args go here<\' '
+                            'cmd arg1 arg2').format(mpi_args=' '.join(mpi_flags))
         expected_env = {'env1': 'val1', 'env2': 'val2'}
         run_func.assert_called_once_with(command=expected_command, env=expected_env, stdout=stdout, stderr=stderr)
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -25,13 +25,13 @@ import unittest
 import warnings
 
 import pytest
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from horovod.run.common.util import config_parser, secret, settings as hvd_settings, timeout
 from horovod.run.common.util.host_hash import _hash, host_hash
 from horovod.run.mpi_run import _get_mpi_implementation_flags, _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_run
 from horovod.run.run import parse_args, parse_host_files
-
+from horovod.run.js_run import js_run, generate_jsrun_rankfile
 
 @contextlib.contextmanager
 def override_args(tool=None, *args):
@@ -294,7 +294,7 @@ class RunTests(unittest.TestCase):
         mpi_flags, binding_args = _get_mpi_implementation_flags(False)
         self.assertIsNotNone(mpi_flags)
         mpi_flags.append('-mca plm_rsh_no_tree_spawn true')
-        mpi_flags.append('-mca plm_rsh_num_concurrent 2')
+        mpi_flags.append('-mca plm_rsh_num_concurrent {}'.format(settings.num_hosts))
         expected_cmd = ('mpirun '
                         '--allow-run-as-root --tag-output '
                         '-np 2 -H host '
@@ -369,3 +369,73 @@ class RunTests(unittest.TestCase):
 
         hosts = parse_host_files(host_filename)
         self.assertEqual(hosts, '172.31.32.7:8,172.31.33.9:8')
+
+    """
+    Tests js_run.
+    """
+    @patch('horovod.run.js_run.is_jsrun_installed', MagicMock(return_value=True))
+    @patch('horovod.run.js_run.generate_jsrun_rankfile', MagicMock(return_value='/tmp/rankfile'))
+    @patch('horovod.run.util.lsf.LSFUtils.get_num_gpus', MagicMock(return_value=2))
+    @patch('horovod.run.util.lsf.LSFUtils.get_num_cores', MagicMock(return_value=2))
+    def test_js_run(self):
+        if _get_mpi_implementation_flags(False)[0] is None:
+            self.skipTest("MPI is not available")
+
+        cmd = ['cmd', 'arg1', 'arg2']
+        env = {'env1': 'val1', 'env2': 'val2'}
+        stdout = '<stdout>'
+        stderr = '<stderr>'
+        settings = hvd_settings.Settings(
+            verbose=0,
+            extra_mpi_args='>mpi-extra args go here<',
+            num_hosts=2,
+            num_proc=4,
+            hosts='>host names go here<',
+            output_filename='>output filename goes here<',
+            run_func_mode=True
+        )
+        run_func = MagicMock(return_value=0)
+
+        js_run(settings, None, env, cmd, stdout=stdout, stderr=stderr, run_func=run_func)
+
+        mpi_flags, _ = _get_mpi_implementation_flags(False)
+        self.assertIsNotNone(mpi_flags)
+        expected_command = ('jsrun '
+                            '--erf_input /tmp/rankfile '
+                            '--stdio_stderr >output filename goes here< '
+                            '--stdio_stdout >output filename goes here< '
+                            '--smpiargs \' >mpi-extra args go here<\' '
+                            'cmd arg1 arg2')
+        expected_env = {'env1': 'val1', 'env2': 'val2'}
+        run_func.assert_called_once_with(command=expected_command, env=expected_env, stdout=stdout, stderr=stderr)
+
+    """
+    Tests generate_jsrun_rankfile.
+    """
+    @patch('horovod.run.util.lsf.LSFUtils.get_num_gpus', MagicMock(return_value=4))
+    @patch('horovod.run.util.lsf.LSFUtils.get_num_cores', MagicMock(return_value=4))
+    @patch('horovod.run.util.lsf.LSFUtils.get_num_threads', MagicMock(return_value=4))
+    def test_generate_jsrun_rankfile(self):
+        settings = hvd_settings.Settings(
+            num_proc=5,
+            hosts='host1:4,host2:4,host3:4',
+        )
+
+        rankfile_path = generate_jsrun_rankfile(settings)
+
+        with open(rankfile_path, 'r') as file:
+            gen_rankfile = file.read()
+
+        expected_rankfile = (
+"""overlapping_rs: allow
+cpu_index_using: logical
+
+rank: 0: { hostname: host1; cpu: {0-3} ; gpu: * ; mem: * }
+rank: 1: { hostname: host1; cpu: {4-7} ; gpu: * ; mem: * }
+rank: 2: { hostname: host1; cpu: {8-11} ; gpu: * ; mem: * }
+rank: 3: { hostname: host1; cpu: {12-15} ; gpu: * ; mem: * }
+
+rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
+""")
+
+        self.assertMultiLineEqual(gen_rankfile, expected_rankfile)


### PR DESCRIPTION
Example to run on a LSF cluster (e.g. Summit):
horovodrun python train.py

Also, perform cpu/mem process binding to get the best performance.

Contributors:
@bethune-bryant
@nvcastet

Signed-off-by: Nicolas V Castet <nvcastet@us.ibm.com>