### PR TITLE
Clear response cache during controller initialization process

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -52,6 +52,13 @@ Controller::Controller(ResponseCache& response_cache, TensorQueue& tensor_queue,
       timeline_(timeline), response_cache_(response_cache),
       parameter_manager_(parameter_manager) {}
 
+void Controller::Initialize() {
+  response_cache_.clear();
+
+  // Initialize concrete implementations.
+  DoInitialization();
+}
+
 ResponseList Controller::ComputeResponseList(std::atomic_bool& shut_down,
                                              HorovodGlobalState& state) {
   // Update cache capacity if autotuning is active.

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -38,8 +38,8 @@ public:
              Timeline& timeline, ParameterManager& parameter_manager);
 
   Controller(const Controller&) = delete;
-  // Functions must be overridden by concrete controller
-  virtual void Initialize() = 0;
+
+  void Initialize();
 
   virtual int GetTypeSize(DataType dtype) = 0;
 
@@ -126,6 +126,9 @@ public:
   StallInspector& GetStallInspector() { return stall_inspector_; };
 
 protected:
+  // Functions must be overridden by concrete controller
+  virtual void DoInitialization() = 0;
+
   // For rank 0 to receive other ranks' ready tensors.
   virtual void RecvReadyTensors(std::vector<std::string>& ready_to_reduce,
                                 std::vector<RequestList>& ready_list) = 0;

--- a/horovod/common/gloo/gloo_controller.cc
+++ b/horovod/common/gloo/gloo_controller.cc
@@ -31,7 +31,7 @@
 namespace horovod {
 namespace common {
 
-void GlooController::Initialize() {
+void GlooController::DoInitialization() {
   rank_ = gloo_context_.ctx->rank;
   size_ = gloo_context_.ctx->size;
   is_coordinator_ = rank_ == 0;

--- a/horovod/common/gloo/gloo_controller.h
+++ b/horovod/common/gloo/gloo_controller.h
@@ -31,8 +31,6 @@ public:
       : Controller(response_cache, tensor_queue, timeline, parameter_manager),
         gloo_context_(gloo_context) {};
 
-  void Initialize() override;
-
   int GetTypeSize(DataType dtype) override;
 
   void CrossRankBitwiseAnd(std::vector<long long>& bitvector,
@@ -55,6 +53,8 @@ public:
   void Barrier(Communicator communicator) override;
 
 protected:
+  void DoInitialization() override;
+
   GlooContext& gloo_context_;
 };
 

--- a/horovod/common/mpi/mpi_controller.cc
+++ b/horovod/common/mpi/mpi_controller.cc
@@ -22,7 +22,7 @@ namespace horovod {
 namespace common {
 
 // MPIController
-void MPIController::Initialize() {
+void MPIController::DoInitialization() {
   // Check if multi-thread is supported.
   int provided;
   MPI_Query_thread(&provided);

--- a/horovod/common/mpi/mpi_controller.h
+++ b/horovod/common/mpi/mpi_controller.h
@@ -34,8 +34,6 @@ public:
 
   virtual ~MPIController()=default;
 
-  void Initialize() override;
-
   int GetTypeSize(DataType dtype) override;
 
   void CrossRankBitwiseAnd(std::vector<long long>& bitvector,
@@ -60,6 +58,8 @@ public:
   bool IsMpiThreadsSupported() const { return mpi_threads_supported_; }
 
 protected:
+  void DoInitialization() override;
+
   MPIContext& mpi_ctx_;
 
   // flag indicating whether MPI multi-threading is supported


### PR DESCRIPTION
In elastic mode, new workers will start with an empty cache.  If existing workers retain their cache, it can lead to segmentation faults due to inaccurate assumptions about the presence or absence of certain keys in the cache.

In the future, it may be worth exploring ways to allow for caches to be out of sync, or to synchronize them during the initial startup process of the new workers.

Signed-off-by: Travis Addair <taddair@uber.com>