### PR TITLE
Harmonize unit tests

### DIFF
--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -99,7 +99,7 @@ def js_run(settings, common_intfs, env, command, stdout=None, stderr=None, run_f
         os.execve('/bin/sh', ['/bin/sh', '-c', jsrun_command], env)
 
 
-def generate_jsrun_rankfile(settings):
+def generate_jsrun_rankfile(settings, path=None):
     """
     Generates rankfile to use with jsrun.
     It splits the cores among the processes, which leads to best performance according to experiments.
@@ -107,6 +107,8 @@ def generate_jsrun_rankfile(settings):
     Args:
         settings: Settings for running jsrun.
                   Note: settings.num_proc and settings.hosts must not be None.
+        path: Optional path of the rankfile.
+              Note: this file will be overwritten.
     """
     cpu_per_gpu = (lsf.LSFUtils.get_num_cores() * lsf.LSFUtils.get_num_threads()) // lsf.LSFUtils.get_num_gpus()
     host_list = (x.split(':') for x in settings.hosts.split(','))
@@ -130,8 +132,8 @@ def generate_jsrun_rankfile(settings):
             slots=settings.num_proc))
 
     # Generate rankfile
-    fd, path = tempfile.mkstemp()
-    with os.fdopen(fd, 'w') as tmp:
+    path = tempfile.mktemp() if path is None else path
+    with open(path, 'w') as tmp:
         tmp.write('overlapping_rs: allow\n')
         tmp.write('cpu_index_using: logical\n')
         rank = 0

--- a/test/spark_common.py
+++ b/test/spark_common.py
@@ -19,7 +19,6 @@ import contextlib
 import os
 import platform
 import stat
-import tempfile
 
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import VectorAssembler

--- a/test/test_adasum_pytorch.py
+++ b/test/test_adasum_pytorch.py
@@ -50,7 +50,8 @@ class TorchAdasumTests(unittest.TestCase):
     # TODO support non-MPI Adasum operation
     # Only do this test if there are GPUs available.
     if not hvd.mpi_enabled() or not torch.cuda.is_available():
-      return
+      self.skipTest("No GPUs available")
+
     device = torch.device('cuda:{}'.format(hvd.local_rank()))
     np.random.seed(2)
     torch.manual_seed(2)
@@ -96,7 +97,7 @@ class TorchAdasumTests(unittest.TestCase):
     # TODO support non-MPI Adasum operation
     # Only do this test if there are GPUs available.
     if not hvd.mpi_enabled() or not torch.cuda.is_available():
-      return
+      self.skipTest("No GPUs available")
 
     device = torch.device('cuda:{}'.format(hvd.local_rank()))
     np.random.seed(2)
@@ -142,7 +143,8 @@ class TorchAdasumTests(unittest.TestCase):
     hvd.init()
     # TODO support non-MPI Adasum operation
     if not hvd.mpi_enabled():
-      return
+      self.skipTest("MPI not enabled")
+
     device = torch.device('cuda:{}'.format(hvd.local_rank())) if torch.cuda.is_available() else torch.device('cpu')
     np.random.seed(2)
     torch.manual_seed(2)
@@ -176,7 +178,8 @@ class TorchAdasumTests(unittest.TestCase):
     hvd.init()
     # TODO support non-MPI Adasum operation
     if not hvd.mpi_enabled():
-      return
+      self.skipTest("MPI not enabled")
+
     device = torch.device('cuda:{}'.format(hvd.local_rank())) if torch.cuda.is_available() else torch.device('cpu')
     np.random.seed(2)
     torch.manual_seed(2)

--- a/test/test_adasum_tensorflow.py
+++ b/test/test_adasum_tensorflow.py
@@ -106,12 +106,13 @@ class MPITests(tf.test.TestCase):
         hvd.init()
         # TODO support non-MPI Adasum operation
         if not hvd.mpi_enabled():
-            return
+            self.skipTest("MPI not enabled")
 
         size = hvd.size()
         # TODO support testing with non-power 2 ranks
         if not is_power2(size):
-            return
+            self.skipTest("MPI rank is not power of 2")
+
         rank = hvd.rank()
         rank_tensors = []
         for _ in range(size):
@@ -138,19 +139,21 @@ class MPITests(tf.test.TestCase):
         hvd.init()
         # TODO support non-MPI Adasum operation
         if not hvd.mpi_enabled() or not hvd.gpu_available('tensorflow') or not hvd.nccl_built():
-            return
+            self.skipTest("MPI, GPU or NCCL not available")
+
         rank = hvd.rank()
         rank_tensors = []
         size = hvd.size()
         # TODO support testing with non-power 2 ranks
         if not is_power2(size):
-            return
+            self.skipTest("MPI rank is not power of 2")
 
         local_size = hvd.local_size()
 
         # Only run on homogeneous cluster
-        if(not hvd.is_homogeneous()):
-            return
+        if not hvd.is_homogeneous():
+            self.skipTest("Horovod cluster is not homogeneous")
+
         num_nodes = int(size / local_size)
         for _ in range(size):
             rank_tensors.append([np.random.random_sample((2,2)), np.random.random_sample((2,2))])

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -177,7 +177,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         # Same rank, different dimension
         ctx = self._current_context()
@@ -213,7 +213,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         ctx = self._current_context()
         shape = (17, 3)
@@ -236,7 +236,7 @@ class MXTests(unittest.TestCase):
            perform reduction on CPU and GPU."""
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         rank = hvd.rank()
@@ -244,7 +244,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         shape = (17, 17, 17)
         if rank % 2 == 0:
@@ -287,7 +287,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         dtypes = ['int32',   'int64',
                   'float32', 'float64'] 
@@ -331,7 +331,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         dtypes = ['int32',   'int64',
                   'float32', 'float64'] 
@@ -377,7 +377,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         dtypes = ['int32',   'int64',
                   'float32', 'float64'] 
@@ -416,7 +416,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         ctx = self._current_context()
         shape = (17, rank+1)
@@ -438,7 +438,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         ctx = self._current_context()
         shape = (17, 3)
@@ -464,7 +464,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         ctx = self._current_context()
         shape = (17, 17, 17)
@@ -484,7 +484,7 @@ class MXTests(unittest.TestCase):
 
         # This test does not apply if there is only one worker.
         if hvd.size() == 1:
-            return
+            self.skipTest("Only one worker available")
 
         mx.random.seed(rank)
         layer = mx.gluon.nn.Conv2D(10, 2)

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -33,6 +33,9 @@ from horovod.run.mpi_run import _get_mpi_implementation_flags, _LARGE_CLUSTER_TH
 from horovod.run.run import parse_args, parse_host_files
 from horovod.run.js_run import js_run, generate_jsrun_rankfile
 
+from common import temppath
+
+
 @contextlib.contextmanager
 def override_args(tool=None, *args):
     old = sys.argv[:]
@@ -362,13 +365,13 @@ class RunTests(unittest.TestCase):
             mpi_run(settings, None, {}, cmd, run_func=run_func)
 
     def test_horovodrun_hostfile(self):
-        host_filename = '/tmp/hostfile'
-        with open(host_filename, 'w+') as fp:
-            fp.write('172.31.32.7 slots=8\n')
-            fp.write('172.31.33.9 slots=8\n')
+        with temppath() as host_filename:
+            with open(host_filename, 'w+') as fp:
+                fp.write('172.31.32.7 slots=8\n')
+                fp.write('172.31.33.9 slots=8\n')
 
-        hosts = parse_host_files(host_filename)
-        self.assertEqual(hosts, '172.31.32.7:8,172.31.33.9:8')
+            hosts = parse_host_files(host_filename)
+            self.assertEqual(hosts, '172.31.32.7:8,172.31.33.9:8')
 
     """
     Tests js_run.
@@ -421,12 +424,13 @@ class RunTests(unittest.TestCase):
             hosts='host1:4,host2:4,host3:4',
         )
 
-        rankfile_path = generate_jsrun_rankfile(settings)
+        with temppath() as rankfile_path:
+            rankfile_path = generate_jsrun_rankfile(settings, rankfile_path)
 
-        with open(rankfile_path, 'r') as file:
-            gen_rankfile = file.read()
+            with open(rankfile_path, 'r') as file:
+                gen_rankfile = file.read()
 
-        expected_rankfile = (
+            expected_rankfile = (
 """overlapping_rs: allow
 cpu_index_using: logical
 
@@ -438,4 +442,4 @@ rank: 3: { hostname: host1; cpu: {12-15} ; gpu: * ; mem: * }
 rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
 """)
 
-        self.assertMultiLineEqual(gen_rankfile, expected_rankfile)
+            self.assertMultiLineEqual(gen_rankfile, expected_rankfile)

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -82,10 +82,11 @@ class SparkTests(unittest.TestCase):
     def run(self, result=None):
         if os.environ.get('OMPI_COMM_WORLD_RANK', '0') != '0':
             # Running in MPI as a rank > 0, ignore.
+            # Purposefully skip these silently
             return
 
         if 'Open MPI' not in str(subprocess.check_output('mpirun --version', shell=True)):
-            return
+            self.skipTest("Open MPI not available")
 
         super(SparkTests, self).run(result)
 

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -141,11 +141,10 @@ class MPITests(tf.test.TestCase):
             elif size < 15:
                 threshold = 5e-4
             else:
-                break
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
 
             diff = self.evaluate(max_difference)
-            self.assertTrue(diff <= threshold,
-                            "hvd.allreduce produces incorrect results")
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
 
     def test_horovod_allreduce_cpu_fused(self):
         """Test on CPU that the allreduce correctly sums 1D, 2D, 3D tensors
@@ -172,7 +171,7 @@ class MPITests(tf.test.TestCase):
             elif size < 15:
                 threshold = 5e-4
             else:
-                break
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
 
             test = max_difference <= threshold
             tests.append(test)
@@ -183,11 +182,11 @@ class MPITests(tf.test.TestCase):
         """Test that the allreduce works on GPUs."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         local_rank = hvd.local_rank()
@@ -212,11 +211,10 @@ class MPITests(tf.test.TestCase):
             elif size < 15:
                 threshold = 5e-4
             else:
-                return
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
 
             diff = self.evaluate(max_difference)
-            self.assertTrue(diff <= threshold,
-                            "hvd.allreduce on GPU produces incorrect results")
+            self.assertTrue(diff <= threshold, "hvd.allreduce on GPU produces incorrect results")
 
     def test_horovod_allreduce_gpu_fused(self):
         """Test that the allreduce works on GPUs with Tensor Fusion.
@@ -226,11 +224,11 @@ class MPITests(tf.test.TestCase):
         a GPU data pointer."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         local_rank = hvd.local_rank()
@@ -256,7 +254,7 @@ class MPITests(tf.test.TestCase):
             elif size < 15:
                 threshold = 5e-4
             else:
-                return
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
 
             test = max_difference <= threshold
             tests.append(test)
@@ -271,11 +269,11 @@ class MPITests(tf.test.TestCase):
         a GPU data pointer."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         local_rank = hvd.local_rank()
@@ -303,7 +301,7 @@ class MPITests(tf.test.TestCase):
             elif size < 15:
                 threshold = 5e-4
             else:
-                return
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
 
             diff = self.evaluate(max_difference)
             self.assertTrue(diff <= threshold,
@@ -318,7 +316,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         # Same rank, different dimension
         dims = [17 + rank] * 3
@@ -344,7 +342,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         # Same rank, different dimension
         dims = [17] * 3
@@ -358,11 +356,11 @@ class MPITests(tf.test.TestCase):
         perform reduction on CPU and GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         local_rank = hvd.local_rank()
@@ -370,7 +368,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         device = "/gpu:%d" % local_rank if local_rank % 2 == 0 else "/cpu:0"
         with tf.device(device):
@@ -418,11 +416,11 @@ class MPITests(tf.test.TestCase):
         """Test the correctness of the allreduce gradient on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
-            return
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         local_rank = hvd.local_rank()
@@ -654,7 +652,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         tensor_size = [17] * 3
         tensor_size[1] = 10 * (rank + 1)
@@ -671,7 +669,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         tensor_size = [17] * 3
         dtype = tf.int32 if rank % 2 == 0 else tf.float32
@@ -738,11 +736,11 @@ class MPITests(tf.test.TestCase):
         """Test the correctness of the allgather gradient on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
-            # Skip if compiled with CUDA but without HOROVOD_GPU_ALLGATHER.
-            return
+            # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         rank = hvd.rank()
@@ -806,7 +804,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
                   tf.int32, tf.int64, tf.float16, tf.float32,
@@ -832,11 +830,11 @@ class MPITests(tf.test.TestCase):
         """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
-            # Skip if compiled with CUDA but without HOROVOD_GPU_BROADCAST.
-            return
+            # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         rank = hvd.rank()
@@ -845,7 +843,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
                   tf.int32, tf.int64, tf.float16, tf.float32,
@@ -876,7 +874,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         tensor_size = [17] * 3
         tensor_size[1] = 10 * (rank + 1)
@@ -893,7 +891,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         tensor_size = [17] * 3
         dtype = tf.int32 if rank % 2 == 0 else tf.float32
@@ -910,7 +908,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         tensor = tf.ones([17] * 3, dtype=tf.float32)
         with self.assertRaises(tf.errors.FailedPreconditionError):
@@ -924,7 +922,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         # As of TensorFlow v1.9, gradients are not supported on
         # integer tensors
@@ -962,11 +960,11 @@ class MPITests(tf.test.TestCase):
         """Test the correctness of the broadcast gradient on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            return
+            self.skipTest(("No GPUs available"))
 
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
-            # Skip if compiled with CUDA but without HOROVOD_GPU_BROADCAST.
-            return
+            # Skip if compiled with CUDA but without HOROVOD_GPU_ALLREDUCE.
+            self.skipTest("Not compiled with HOROVOD_GPU_ALLREDUCE")
 
         hvd.init()
         rank = hvd.rank()
@@ -975,7 +973,7 @@ class MPITests(tf.test.TestCase):
 
         # This test does not apply if there is only one worker.
         if size == 1:
-            return
+            self.skipTest("Only one worker available")
 
         # As of TensorFlow v1.9, gradients are not supported on
         # integer tensors
@@ -1014,7 +1012,7 @@ class MPITests(tf.test.TestCase):
         in eager execution mode. This call should raise a RuntimeError."""
 
         if not hvd.util._executing_eagerly():
-            return
+            self.skipTest("Only in eager execution mode")
 
         with self.assertRaises(RuntimeError):
             hvd.broadcast_global_variables(root_rank=0)
@@ -1024,7 +1022,7 @@ class MPITests(tf.test.TestCase):
         in graph execution mode. This call should not raise any exception."""
 
         if hvd.util._executing_eagerly():
-            return
+            self.skipTest("Not in eager execution mode")
 
         hvd.broadcast_global_variables(root_rank=0)
 

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tempfile
 import time
 import torch
 import unittest
@@ -25,6 +24,8 @@ import warnings
 
 import horovod.torch as hvd
 from horovod.common.util import env
+
+from common import temppath
 
 
 class TimelineTests(unittest.TestCase):
@@ -37,8 +38,8 @@ class TimelineTests(unittest.TestCase):
         warnings.simplefilter('module')
 
     def test_timeline(self):
-        with tempfile.NamedTemporaryFile() as t:
-            with env(HOROVOD_TIMELINE=t.name, HOROVOD_TIMELINE_MARK_CYCLES='1'):
+        with temppath() as t:
+            with env(HOROVOD_TIMELINE=t, HOROVOD_TIMELINE_MARK_CYCLES='1'):
                 hvd.init()
 
                 # Perform a simple allreduce operation
@@ -48,7 +49,7 @@ class TimelineTests(unittest.TestCase):
                 time.sleep(0.1)
 
                 if hvd.rank() == 0:
-                    with open(t.name, 'r') as tf:
+                    with open(t, 'r') as tf:
                         timeline_text = tf.read()
                         assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                         assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text


### PR DESCRIPTION
Make skipped tests explicit and provide a reason.
Use `common.temppath` for temporary files and auto-delete them after use.
Fixe race condition in `test_run.py` where `/tmp/hostfile` is being written by both MPI threads and one reads the unfinished file of the other thread and fails. Now both use unique temporary filename.