### PR TITLE
Renamed _HAS_ALL_REDUCE_SUM_GRAD to _HAS_AGGREGATE_GRAD for TensorFlow 2.2 changes

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
                                  compression, sparse_as_dense):
     class _DistributedOptimizer(keras.optimizers.Optimizer):
-        _HAS_ALL_REDUCE_SUM_GRAD = True
+        _HAS_AGGREGATE_GRAD = True
 
         def __init__(self, **kwargs):
             self._name = name or "Distributed%s" % self.__class__.__base__.__name__


### PR DESCRIPTION
See: https://github.com/tensorflow/tensorflow/issues/37765#issuecomment-603496575

TensorFlow team had to rename this variable in order to avoid breaking other parts of their code.  Because this code has not been released yet, this change is safe to make to optimizer.

Signed-off-by: Travis Addair <taddair@uber.com>