### PR TITLE
Remove method injection from testing.

### DIFF
--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -32,7 +32,7 @@ def is_jsrun_installed():
     return find_executable('jsrun') is not None
 
 
-def js_run(settings, nics, env, command, stdout=None, stderr=None, run_func=safe_shell_exec.execute):
+def js_run(settings, nics, env, command, stdout=None, stderr=None):
     """
     Runs Horovod with jsrun.
 
@@ -46,9 +46,6 @@ def js_run(settings, nics, env, command, stdout=None, stderr=None, run_func=safe
                 Only used when settings.run_func_mode is True.
         stderr: Stderr of the mpi process.
                 Only used when settings.run_func_mode is True.
-        run_func: Run function to use. Must have arguments 'command' and 'env'.
-                  Only used when settings.run_func_mode is True.
-                  Defaults to safe_shell_exec.execute.
     """
     mpi_impl_flags, _ = _get_mpi_implementation_flags(settings.tcp_flag)
     if mpi_impl_flags is None:
@@ -92,7 +89,7 @@ def js_run(settings, nics, env, command, stdout=None, stderr=None, run_func=safe
 
     # Execute the jsrun command.
     if settings.run_func_mode:
-        exit_code = run_func(command=jsrun_command, env=env, stdout=stdout, stderr=stderr)
+        exit_code = safe_shell_exec.execute(jsrun_command, env=env, stdout=stdout, stderr=stderr)
         if exit_code != 0:
             raise RuntimeError("jsrun failed with exit code {exit_code}".format(exit_code=exit_code))
     else:

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -73,7 +73,7 @@ def is_mpich():
     return _get_mpi_implementation() == _MPICH_IMPL
 
 
-def _get_mpi_implementation(execute=tiny_shell_exec.execute):
+def _get_mpi_implementation():
     """
     Detects the available MPI implementation by invoking `mpirun --version`.
     This command is executed by the given execute function, which takes the
@@ -88,7 +88,7 @@ def _get_mpi_implementation(execute=tiny_shell_exec.execute):
     :return: string representing identified implementation
     """
     command = 'mpirun --version'
-    res = execute(command)
+    res = tiny_shell_exec.execute(command)
     if res is None:
         return _MISSING_IMPL
     (output, exit_code) = res

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -121,7 +121,7 @@ def _get_mpi_implementation_flags(tcp_flag):
         return None, None
 
 
-def mpi_run(settings, nics, env, command, stdout=None, stderr=None, run_func=None):
+def mpi_run(settings, nics, env, command, stdout=None, stderr=None):
     """
     Runs mpi_run.
 
@@ -135,13 +135,7 @@ def mpi_run(settings, nics, env, command, stdout=None, stderr=None, run_func=Non
                 Only used when settings.run_func_mode is True.
         stderr: Stderr of the mpi process.
                 Only used when settings.run_func_mode is True.
-        run_func: Run function to use. Must have arguments 'command' and 'env'.
-                  Only used when settings.run_func_mode is True.
-                  Defaults to safe_shell_exec.execute.
     """
-    if run_func is None:
-        run_func = safe_shell_exec.execute
-
     mpi_impl_flags, impl_binding_args = _get_mpi_implementation_flags(settings.tcp_flag)
     if mpi_impl_flags is None:
         raise Exception(_MPI_NOT_FOUND_ERROR_MSG)
@@ -197,7 +191,7 @@ def mpi_run(settings, nics, env, command, stdout=None, stderr=None, run_func=Non
 
     # Execute the mpirun command.
     if settings.run_func_mode:
-        exit_code = run_func(command=mpirun_command, env=env, stdout=stdout, stderr=stderr)
+        exit_code = safe_shell_exec.execute(mpirun_command, env=env, stdout=stdout, stderr=stderr)
         if exit_code != 0:
             raise RuntimeError("mpirun failed with exit code {exit_code}".format(exit_code=exit_code))
     else:

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -32,7 +32,7 @@ def _exec_command_fn(driver_addresses, settings, env):
     return _exec_command
 
 
-def gloo_run(settings, nics, driver, env, exec_command=None):
+def gloo_run(settings, nics, driver, env):
     """
     Run distributed gloo jobs.
 
@@ -41,7 +41,6 @@ def gloo_run(settings, nics, driver, env, exec_command=None):
     :param nics: Interfaces to use by gloo.
     :param driver: The Spark driver service that tasks are connected to.
     :param env: Environment dictionary to use for running gloo jobs.
-    :param exec_command: Function to execute job commands.
     """
     # Each thread will use SparkTaskClient to launch the job on each remote host. If an
     # error occurs in one thread, entire process will be terminated. Otherwise,
@@ -56,6 +55,5 @@ def gloo_run(settings, nics, driver, env, exec_command=None):
     # Pass secret key through the environment variables.
     env[secret.HOROVOD_SECRET_KEY] = codec.dumps_base64(settings.key)
 
-    exec_command = _exec_command_fn(driver.addresses(), settings, env) \
-        if exec_command is None else exec_command
+    exec_command = _exec_command_fn(driver.addresses(), settings, env)
     launch_gloo(command, exec_command, settings, nics, {}, server_ip)

--- a/horovod/spark/mpi_run.py
+++ b/horovod/spark/mpi_run.py
@@ -17,10 +17,10 @@ import os
 import sys
 
 from horovod.run.mpi_run import mpi_run as hr_mpi_run
-from horovod.run.common.util import codec, safe_shell_exec, secret
+from horovod.run.common.util import codec, secret
 
 
-def mpi_run(settings, nics, driver, env, stdout=None, stderr=None, run_func=None):
+def mpi_run(settings, nics, driver, env, stdout=None, stderr=None):
     """
     Runs mpirun.
 
@@ -33,14 +33,9 @@ def mpi_run(settings, nics, driver, env, stdout=None, stderr=None, run_func=None
                    Only used when settings.run_func_mode is True.
     :param stderr: Stderr of the mpi process.
                    Only used when settings.run_func_mode is True.
-    :param run_func: Run function to use. Must have arguments 'command' and 'env'.
-                     Only used when settings.run_func_mode is True.
-                     Defaults to safe_shell_exec.execute.
     """
     if env is None:
         env = os.environ.copy()
-    if run_func is None:
-        run_func = safe_shell_exec.execute
 
     # Pass secret key through the environment variables.
     env[secret.HOROVOD_SECRET_KEY] = codec.dumps_base64(settings.key)
@@ -56,4 +51,4 @@ def mpi_run(settings, nics, driver, env, stdout=None, stderr=None, run_func=None
                '-m', 'horovod.spark.task.mpirun_exec_fn',
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))
-    hr_mpi_run(settings, nics, env, command, stdout=stdout, stderr=stderr, run_func=run_func)
+    hr_mpi_run(settings, nics, env, command, stdout=stdout, stderr=stderr)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -113,15 +113,14 @@ def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=No
         env = os.environ.copy()
 
     run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env, run_func),
-                   use_mpi, lambda: mpi_run(settings, nics, driver, env, stdout, stderr, run_func),
+                   use_mpi, lambda: mpi_run(settings, nics, driver, env, stdout, stderr),
                    False, lambda: None,
                    settings.verbose)
 
 
 def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
         use_mpi=None, use_gloo=None, extra_mpi_args=None,
-        env=None, stdout=None, stderr=None, verbose=1, nics=None,
-        run_func=None):
+        env=None, stdout=None, stderr=None, verbose=1, nics=None):
     """
     Runs Horovod in Spark.  Runs `num_proc` processes executing `fn` using the same amount of Spark tasks.
 
@@ -139,8 +138,6 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
         stderr: Horovod stderr is redirected to this stream. Defaults to sys.stderr.
         verbose: Debug output verbosity (0-2). Defaults to 1.
         nics: List of NICs for tcp network communication.
-        run_func: Run function to use. Must have arguments 'command', 'env', 'stdout', 'stderr'.
-                  Defaults to safe_shell_exec.execute.
 
     Returns:
         List of results returned by running `fn` on each rank.
@@ -222,7 +219,7 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
         driver.set_ranks_to_indices(ranks_to_indices)
 
         # Run the job
-        _launch_job(use_mpi, use_gloo, settings, driver, env, stdout, stderr, run_func)
+        _launch_job(use_mpi, use_gloo, settings, driver, env, stdout, stderr)
     except:
         # Terminate Spark job.
         spark_context.cancelJobGroup(spark_job_group)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -100,7 +100,7 @@ def _make_spark_thread(spark_context, spark_job_group, driver, result_queue,
     return spark_thread
 
 
-def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=None, run_func=None):
+def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=None):
     # Determine a set of common interfaces for task-to-task communication.
     nics = set(driver.task_addresses_for_tasks(0).keys())
     for index in range(1, settings.num_proc):
@@ -112,7 +112,7 @@ def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=No
     if env is None:
         env = os.environ.copy()
 
-    run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env, run_func),
+    run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env),
                    use_mpi, lambda: mpi_run(settings, nics, driver, env, stdout, stderr),
                    False, lambda: None,
                    settings.verbose)

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -364,7 +364,7 @@ class RunTests(unittest.TestCase):
             return ["--mock-mpi-impl-flags"], ["--mock-mpi-binding-args"]
 
         with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
-            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as run_func:
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as execute:
                 mpi_run(settings, None, {}, cmd)
 
                 # call the mocked _get_mpi_implementation_flags method
@@ -377,7 +377,7 @@ class RunTests(unittest.TestCase):
                                 '{mpi_flags}       '
                                 'cmd').format(binding_args=' '.join(binding_args), mpi_flags=' '.join(mpi_flags))
                 expected_env = {}
-                run_func.assert_called_once_with(expected_cmd, env=expected_env, stdout=None, stderr=None)
+                execute.assert_called_once_with(expected_cmd, env=expected_env, stdout=None, stderr=None)
 
     """
     Tests mpi_run on a large cluster.
@@ -394,7 +394,7 @@ class RunTests(unittest.TestCase):
             return ["--mock-mpi-impl-flags"], ["--mock-mpi-binding-args"]
 
         with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
-            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as run_func:
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as execute:
                 mpi_run(settings, None, {}, cmd)
 
                 # call the mocked _get_mpi_implementation_flags method
@@ -409,7 +409,7 @@ class RunTests(unittest.TestCase):
                                 '{mpi_flags}       '
                                 'cmd').format(binding_args=' '.join(binding_args), mpi_flags=' '.join(mpi_flags))
                 expected_env = {}
-                run_func.assert_called_once_with(expected_cmd, env=expected_env, stdout=None, stderr=None)
+                execute.assert_called_once_with(expected_cmd, env=expected_env, stdout=None, stderr=None)
 
     """
     Tests mpi_run with full settings.
@@ -442,7 +442,7 @@ class RunTests(unittest.TestCase):
             return ["--mock-mpi-impl-flags"], []
 
         with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
-            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as run_func:
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as execute:
                 mpi_run(settings, nics, env, cmd, stdout=stdout, stderr=stderr)
 
                 # call the mocked _get_mpi_implementation_flags method
@@ -460,7 +460,7 @@ class RunTests(unittest.TestCase):
                                     '>mpi-extra args go here< '
                                     'cmd arg1 arg2').format(mpi_flags=' '.join(mpi_flags))
                 expected_env = {'env1': 'val1', 'env2': 'val2'}
-                run_func.assert_called_once_with(expected_command, env=expected_env, stdout=stdout, stderr=stderr)
+                execute.assert_called_once_with(expected_command, env=expected_env, stdout=stdout, stderr=stderr)
 
     def test_mpi_run_with_non_zero_exit(self):
         if not mpi_available():
@@ -515,7 +515,7 @@ class RunTests(unittest.TestCase):
             return ["--mock-mpi-impl-flags"], []
 
         with mock.patch("horovod.run.js_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
-            with mock.patch("horovod.run.js_run.safe_shell_exec.execute", return_value=0) as run_func:
+            with mock.patch("horovod.run.js_run.safe_shell_exec.execute", return_value=0) as execute:
                 js_run(settings, None, env, cmd, stdout=stdout, stderr=stderr)
 
                 # call the mocked _get_mpi_implementation_flags method
@@ -528,7 +528,7 @@ class RunTests(unittest.TestCase):
                                     '--smpiargs \'{mpi_args} >mpi-extra args go here<\' '
                                     'cmd arg1 arg2').format(mpi_args=' '.join(mpi_flags))
                 expected_env = {'env1': 'val1', 'env2': 'val2'}
-                run_func.assert_called_once_with(expected_command, env=expected_env, stdout=stdout, stderr=stderr)
+                execute.assert_called_once_with(expected_command, env=expected_env, stdout=stdout, stderr=stderr)
 
     """
     Tests generate_jsrun_rankfile.

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -155,96 +155,96 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run uses MPI properly.
     """
-    def test_spark_run_func_with_mpi(self):
+    def test_spark_run_with_mpi(self):
         with mpi_implementation_flags():
-            self.do_test_spark_run_func(use_mpi=True, use_gloo=False)
+            self.do_test_spark_run(use_mpi=True, use_gloo=False)
 
     """
     Test that horovod.spark.run uses Gloo properly.
     """
-    def test_spark_run_func_with_gloo(self):
-        self.do_test_spark_run_func(use_mpi=False, use_gloo=True)
+    def test_spark_run_with_gloo(self):
+        self.do_test_spark_run(use_mpi=False, use_gloo=True)
 
     """
     Actually tests that horovod.spark.run invokes mpi_run properly.
     """
-    def do_test_spark_run_func(self, use_mpi, use_gloo):
+    def do_test_spark_run(self, use_mpi, use_gloo):
         env = {'env1': 'val1', 'env2': 'val2'}
         expected_env = '-x env1 -x env2'
         extra_mpi_args = '<extra args go here>'
         with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
-            self._do_test_spark_run_func(num_proc=2, use_mpi=use_mpi, use_gloo=use_gloo,
-                                         extra_mpi_args=extra_mpi_args,
-                                         env=env, stdout='<stdout>', stderr='<stderr>',
-                                         cores=4, expected_np=2, expected_env=expected_env)
+            self._do_test_spark_run(num_proc=2, use_mpi=use_mpi, use_gloo=use_gloo,
+                                    extra_mpi_args=extra_mpi_args,
+                                    env=env, stdout='<stdout>', stderr='<stderr>',
+                                    cores=4, expected_np=2, expected_env=expected_env)
 
     """
     Test that horovod.spark.run defaults num_proc to spark parallelism using MPI.
     """
-    def test_spark_run_func_defaults_num_proc_to_spark_cores_with_mpi(self):
+    def test_spark_run_defaults_num_proc_to_spark_cores_with_mpi(self):
         with mpi_implementation_flags():
-            self.do_test_spark_run_func_defaults_num_proc_to_spark_cores(use_mpi=True, use_gloo=False)
+            self.do_test_spark_run_defaults_num_proc_to_spark_cores(use_mpi=True, use_gloo=False)
 
     """
     Test that horovod.spark.run defaults num_proc to spark parallelism using Gloo.
     """
-    def test_spark_run_func_defaults_num_proc_to_spark_cores_with_gloo(self):
-        self.do_test_spark_run_func_defaults_num_proc_to_spark_cores(use_mpi=False, use_gloo=True)
+    def test_spark_run_defaults_num_proc_to_spark_cores_with_gloo(self):
+        self.do_test_spark_run_defaults_num_proc_to_spark_cores(use_mpi=False, use_gloo=True)
 
     """
     Actually tests that horovod.spark.run defaults num_proc to spark parallelism.
     """
-    def do_test_spark_run_func_defaults_num_proc_to_spark_cores(self, use_mpi, use_gloo):
-        self._do_test_spark_run_func(num_proc=None, cores=2, expected_np=2,
-                                     use_mpi=use_mpi, use_gloo=use_gloo)
+    def do_test_spark_run_defaults_num_proc_to_spark_cores(self, use_mpi, use_gloo):
+        self._do_test_spark_run(num_proc=None, cores=2, expected_np=2,
+                                use_mpi=use_mpi, use_gloo=use_gloo)
 
     """
     Test that horovod.spark.run defaults env to the full system env using MPI.
     """
-    def test_spark_run_func_defaults_env_to_os_env_with_mpi(self):
+    def test_spark_run_defaults_env_to_os_env_with_mpi(self):
         with mpi_implementation_flags():
-            self.do_test_spark_run_func_defaults_env_to_os_env(use_mpi=True, use_gloo=False)
+            self.do_test_spark_run_defaults_env_to_os_env(use_mpi=True, use_gloo=False)
 
     """
     Test that horovod.spark.run defaults env to the full system env using Gloo.
     """
-    def test_spark_run_func_defaults_env_to_os_env_with_gloo(self):
-        self.do_test_spark_run_func_defaults_env_to_os_env(use_mpi=False, use_gloo=True)
+    def test_spark_run_defaults_env_to_os_env_with_gloo(self):
+        self.do_test_spark_run_defaults_env_to_os_env(use_mpi=False, use_gloo=True)
 
     """
     Actually tests that horovod.spark.run defaults env to the full system env.
     """
-    def do_test_spark_run_func_defaults_env_to_os_env(self, use_mpi, use_gloo):
+    def do_test_spark_run_defaults_env_to_os_env(self, use_mpi, use_gloo):
         env = {'env1': 'val1', 'env2': 'val2'}
         expected_env = '-x env1 -x env2'
 
         with override_env(env):
-            self._do_test_spark_run_func(env=None, use_mpi=use_mpi, use_gloo=use_gloo,
-                                         expected_env=expected_env)
+            self._do_test_spark_run(env=None, use_mpi=use_mpi, use_gloo=use_gloo,
+                                    expected_env=expected_env)
 
     """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using MPI.
     """
-    def test_spark_run_func_with_non_zero_exit_with_mpi(self):
+    def test_spark_run_with_non_zero_exit_with_mpi(self):
         expected = '^mpirun failed with exit code 1$'
         with mpi_implementation_flags():
-            self.do_test_spark_run_func_with_non_zero_exit(use_mpi=True, use_gloo=False,
-                                                           expected=expected)
+            self.do_test_spark_run_with_non_zero_exit(use_mpi=True, use_gloo=False,
+                                                      expected=expected)
 
     """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using Gloo.
     """
-    def test_spark_run_func_with_non_zero_exit_with_gloo(self):
+    def test_spark_run_with_non_zero_exit_with_gloo(self):
         expected = '^Gloo job detected that one or more processes exited with non-zero ' \
                    'status, thus causing the job to be terminated. The first process ' \
                    'to do so was:\nProcess name: [0-9]+\nExit code: 1$'
-        self.do_test_spark_run_func_with_non_zero_exit(use_mpi=False, use_gloo=True,
-                                                       expected=expected)
+        self.do_test_spark_run_with_non_zero_exit(use_mpi=False, use_gloo=True,
+                                                  expected=expected)
 
     """
     Actually tests that horovod.spark.run raises an exception on non-zero exit code of mpi_run.
     """
-    def do_test_spark_run_func_with_non_zero_exit(self, use_mpi, use_gloo, expected):
+    def do_test_spark_run_with_non_zero_exit(self, use_mpi, use_gloo, expected):
         def fn():
             return 0
 
@@ -259,7 +259,7 @@ class SparkTests(unittest.TestCase):
         with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
             with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=1):
                 with mock.patch("horovod.spark.gloo_run._exec_command_fn", side_effect=gloo_exec_command_fn):
-                    with spark_session('test_spark_run_func', cores=4):
+                    with spark_session('test_spark_run', cores=4):
                         with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
                             with pytest.raises(Exception, match=expected):
                                 horovod.spark.run(fn, use_mpi=use_mpi, use_gloo=use_gloo, verbose=2)
@@ -267,25 +267,25 @@ class SparkTests(unittest.TestCase):
     """
     Performs an actual horovod.spark.run test using MPI or Gloo.
     """
-    def _do_test_spark_run_func(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
-                                env={}, use_mpi=None, use_gloo=None,
-                                stdout=None, stderr=None, verbose=2,
-                                cores=2, expected_np=1, expected_env=''):
+    def _do_test_spark_run(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
+                           env={}, use_mpi=None, use_gloo=None,
+                           stdout=None, stderr=None, verbose=2,
+                           cores=2, expected_np=1, expected_env=''):
         if use_mpi:
-            self._do_test_spark_run_func_with_mpi(args, kwargs, num_proc, extra_mpi_args, env,
-                                                  stdout, stderr, verbose, cores,
-                                                  expected_np, expected_env)
+            self._do_test_spark_run_with_mpi(args, kwargs, num_proc, extra_mpi_args, env,
+                                             stdout, stderr, verbose, cores,
+                                             expected_np, expected_env)
         if use_gloo:
-            self._do_test_spark_run_func_with_gloo(args, kwargs, num_proc, extra_mpi_args, env,
-                                                   stdout, stderr, verbose, cores,
-                                                   expected_np, expected_env)
+            self._do_test_spark_run_with_gloo(args, kwargs, num_proc, extra_mpi_args, env,
+                                              stdout, stderr, verbose, cores,
+                                              expected_np, expected_env)
 
     """
     Performs an actual horovod.spark.run test using MPI.
     """
-    def _do_test_spark_run_func_with_mpi(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
-                                         env={}, stdout=None, stderr=None, verbose=2,
-                                         cores=2, expected_np=1, expected_env=''):
+    def _do_test_spark_run_with_mpi(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
+                                    env={}, stdout=None, stderr=None, verbose=2,
+                                    cores=2, expected_np=1, expected_env=''):
         def fn():
             return 1
 
@@ -293,12 +293,12 @@ class SparkTests(unittest.TestCase):
             return ["--mock-mpi-impl-flags"], ["--mock-mpi-binding-args"]
 
         with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
-            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as run_func:
-                with spark_session('test_spark_run_func', cores=cores):
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as execute:
+                with spark_session('test_spark_run', cores=cores):
                     with is_built(gloo_is_built=False, mpi_is_built=True):
                         with pytest.raises(Exception) as e:
-                            # we need to timeout horovod because our mocked run_func will block spark otherwise
-                            # this raises above exception, but allows us to catch run_func arguments
+                            # we need to timeout horovod because our mocked methods will block Spark
+                            # this raises above exception, but allows us to catch execute's arguments
                             horovod.spark.run(fn, args=args, kwargs=kwargs,
                                               num_proc=num_proc, start_timeout=1,
                                               use_mpi=True, use_gloo=False,
@@ -329,14 +329,14 @@ class SparkTests(unittest.TestCase):
                     mpi_flags=' '.join(mpi_flags),
                     extra_mpi_args=extra_mpi_args if extra_mpi_args else ''))
 
-                run_func.assert_called_once()
-                run_func_args, run_func_kwargs = run_func.call_args
+                execute.assert_called_once()
+                execute_args, execute_kwargs = execute.call_args
 
-        self.assertIsNotNone(run_func_args)
-        actual_command = run_func_args[0]
-        actual_env = run_func_kwargs.get('env')
-        actual_stdout = run_func_kwargs.get('stdout')
-        actual_stderr = run_func_kwargs.get('stderr')
+        self.assertIsNotNone(execute_args)
+        actual_command = execute_args[0]
+        actual_env = execute_kwargs.get('env')
+        actual_stdout = execute_kwargs.get('stdout')
+        actual_stderr = execute_kwargs.get('stderr')
 
         # for better comparison replace sections in actual_command that change across runs / hosts
         for replacement in ['-H [^ ]+', '-mca btl_tcp_if_include [^ ]+', '-x NCCL_SOCKET_IFNAME=[^ ]+',
@@ -359,9 +359,9 @@ class SparkTests(unittest.TestCase):
     """
     Performs an actual horovod.spark.run test using Gloo.
     """
-    def _do_test_spark_run_func_with_gloo(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
-                                          env={}, stdout=None, stderr=None, verbose=2,
-                                          cores=2, expected_np=1, expected_env=''):
+    def _do_test_spark_run_with_gloo(self, args=(), kwargs={}, num_proc=1, extra_mpi_args=None,
+                                     env={}, stdout=None, stderr=None, verbose=2,
+                                     cores=2, expected_np=1, expected_env=''):
         def fn():
             return 1
 
@@ -369,11 +369,11 @@ class SparkTests(unittest.TestCase):
         gloo_exec_command_fn = mock.MagicMock(return_value=exec_command)
 
         with mock.patch("horovod.spark.gloo_run._exec_command_fn", side_effect=gloo_exec_command_fn):
-            with spark_session('test_spark_run_func', cores=cores):
+            with spark_session('test_spark_run', cores=cores):
                 with is_built(gloo_is_built=True, mpi_is_built=False):
                     with pytest.raises(Exception) as e:
-                        # we need to timeout horovod because our mocked run_func will block spark otherwise
-                        # this raises above exception, but allows us to catch run_func arguments
+                        # we need to timeout horovod because our mocked methods will block Spark
+                        # this raises above exception, but allows us to catch execute's arguments
                         horovod.spark.run(fn, args=args, kwargs=kwargs,
                                           num_proc=num_proc, start_timeout=1,
                                           use_mpi=False, use_gloo=True,

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -31,7 +31,6 @@ import mock
 from mock import MagicMock
 import torch
 
-
 import pyspark
 
 from pyspark.ml.linalg import DenseVector, SparseVector, VectorUDT
@@ -227,35 +226,37 @@ class SparkTests(unittest.TestCase):
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using MPI.
     """
     def test_spark_run_func_with_non_zero_exit_with_mpi(self):
-        run_func = MagicMock(return_value=1)
         expected = '^mpirun failed with exit code 1$'
         with mpi_implementation_flags():
             self.do_test_spark_run_func_with_non_zero_exit(use_mpi=True, use_gloo=False,
-                                                           run_func=run_func, expected=expected)
+                                                           expected=expected)
 
     """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using Gloo.
     """
     def test_spark_run_func_with_non_zero_exit_with_gloo(self):
-        run_func = MagicMock(return_value=(1, 1.0))
         expected = '^Gloo job detected that one or more processes exited with non-zero ' \
                    'status, thus causing the job to be terminated. The first process ' \
                    'to do so was:\nProcess name: [0-9]+\nExit code: 1$'
         self.do_test_spark_run_func_with_non_zero_exit(use_mpi=False, use_gloo=True,
-                                                       run_func=run_func, expected=expected)
+                                                       expected=expected)
 
     """
     Actually tests that horovod.spark.run raises an exception on non-zero exit code of mpi_run.
     """
-    def do_test_spark_run_func_with_non_zero_exit(self, use_mpi, use_gloo, run_func, expected):
+    def do_test_spark_run_func_with_non_zero_exit(self, use_mpi, use_gloo, expected):
         def fn():
             return 0
 
-        with spark_session('test_spark_run_func', cores=4):
-            with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
-                with pytest.raises(Exception, match=expected) as e:
-                    horovod.spark.run(fn, use_mpi=use_mpi, use_gloo=use_gloo,
-                                      verbose=2, run_func=run_func)
+        def mpi_impl_flags(tcp):
+            return ["--mock-mpi-impl-flags"], ["--mock-mpi-binding-args"]
+
+        with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=1):
+                with spark_session('test_spark_run_func', cores=4):
+                    with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
+                        with pytest.raises(Exception, match=expected):
+                            horovod.spark.run(fn, use_mpi=use_mpi, use_gloo=use_gloo, verbose=2)
 
     """
     Performs an actual horovod.spark.run test using MPI or Gloo.
@@ -282,70 +283,72 @@ class SparkTests(unittest.TestCase):
         def fn():
             return 1
 
-        run_func = MagicMock(return_value=0)
+        def mpi_impl_flags(tcp):
+            return ["--mock-mpi-impl-flags"], ["--mock-mpi-binding-args"]
 
-        with spark_session('test_spark_run_func', cores=cores):
-            with is_built(gloo_is_built=False, mpi_is_built=True):
-                with pytest.raises(Exception) as e:
-                    # we need to timeout horovod because our mocked run_func will block spark otherwise
-                    # this raises above exception, but allows us to catch run_func arguments
-                    horovod.spark.run(fn, args=args, kwargs=kwargs,
-                                      num_proc=num_proc, start_timeout=1,
-                                      use_mpi=True, use_gloo=False,
-                                      extra_mpi_args=extra_mpi_args, env=env,
-                                      stdout=stdout, stderr=stderr, verbose=verbose,
-                                      run_func=run_func)
+        with mock.patch("horovod.run.mpi_run._get_mpi_implementation_flags", side_effect=mpi_impl_flags):
+            with mock.patch("horovod.run.mpi_run.safe_shell_exec.execute", return_value=0) as run_func:
+                with spark_session('test_spark_run_func', cores=cores):
+                    with is_built(gloo_is_built=False, mpi_is_built=True):
+                        with pytest.raises(Exception) as e:
+                            # we need to timeout horovod because our mocked run_func will block spark otherwise
+                            # this raises above exception, but allows us to catch run_func arguments
+                            horovod.spark.run(fn, args=args, kwargs=kwargs,
+                                              num_proc=num_proc, start_timeout=1,
+                                              use_mpi=True, use_gloo=False,
+                                              extra_mpi_args=extra_mpi_args, env=env,
+                                              stdout=stdout, stderr=stderr, verbose=verbose)
 
-        self.assertFalse(str(e.value).startswith('Timed out waiting for Spark tasks to start.'),
-                         'Spark timed out before mpi_run was called, test setup is broken.')
-        self.assertEqual('Spark job has failed, see the error above.', str(e.value))
+                self.assertFalse(str(e.value).startswith('Timed out waiting for Spark tasks to start.'),
+                                 'Spark timed out before mpi_run was called, test setup is broken.')
+                self.assertEqual(str(e.value), 'Spark job has failed, see the error above.')
 
-        run_func_args, run_func_kwargs = run_func.call_args
+                # call the mocked _get_mpi_implementation_flags method
+                mpi_flags, binding_args = horovod.run.mpi_run._get_mpi_implementation_flags(False)
+                self.assertIsNotNone(mpi_flags)
+                expected_command = ('mpirun '
+                                    '--allow-run-as-root --tag-output '
+                                    '-np {expected_np} -H [^ ]+ '
+                                    '{binding_args} '
+                                    '{mpi_flags}  '
+                                    '-mca btl_tcp_if_include [^ ]+ -x NCCL_SOCKET_IFNAME=[^ ]+  '
+                                    '-x _HOROVOD_SECRET_KEY {expected_env}'
+                                    '{extra_mpi_args} '
+                                    '-x NCCL_DEBUG=INFO '
+                                    r'-mca plm_rsh_agent "[^"]+python[0-9]* -m horovod.spark.driver.mpirun_rsh [^ ]+ [^ ]+" '
+                                    r'[^"]+python[0-9]* -m horovod.spark.task.mpirun_exec_fn [^ ]+ [^ ]+'.format(
+                    expected_np=expected_np,
+                    binding_args=' '.join(binding_args),
+                    expected_env=expected_env + ' ' if expected_env else '',
+                    mpi_flags=' '.join(mpi_flags),
+                    extra_mpi_args=extra_mpi_args if extra_mpi_args else ''))
+
+                run_func.assert_called_once()
+                run_func_args, run_func_kwargs = run_func.call_args
+
+        self.assertIsNotNone(run_func_args)
+        actual_command = run_func_args[0]
         actual_env = run_func_kwargs.get('env')
         actual_stdout = run_func_kwargs.get('stdout')
         actual_stderr = run_func_kwargs.get('stderr')
 
-        self.assertEqual(1, run_func.call_count)
-        self.assertEqual(run_func_args, ())
-        if env:
-            self.assertEqual(env, actual_env)
-        else:
-            self.assertIsNotNone(actual_env)
-        self.assertEqual(stdout, actual_stdout)
-        self.assertEqual(stderr, actual_stderr)
-
-        # call the possibly mocked _get_mpi_implementation_flags method
-        mpi_flags, binding_args = horovod.run.mpi_run._get_mpi_implementation_flags(False)
-        self.assertIsNotNone(mpi_flags)
-        expected_command = ('mpirun '
-                            '--allow-run-as-root --tag-output '
-                            '-np {expected_np} -H [^ ]+ '
-                            '{binding_args} '
-                            '{mpi_flags}  '
-                            '-mca btl_tcp_if_include [^ ]+ -x NCCL_SOCKET_IFNAME=[^ ]+  '
-                            '-x _HOROVOD_SECRET_KEY {expected_env}'
-                            '{extra_mpi_args} '
-                            '-x NCCL_DEBUG=INFO '
-                            r'-mca plm_rsh_agent "[^"]+python[0-9]* -m horovod.spark.driver.mpirun_rsh [^ ]+ [^ ]+" '
-                            r'[^"]+python[0-9]* -m horovod.spark.task.mpirun_exec_fn [^ ]+ [^ ]+'.format(
-            expected_np=expected_np,
-            binding_args=' '.join(binding_args),
-            expected_env=expected_env + ' ' if expected_env else '',
-            mpi_flags=' '.join(mpi_flags),
-            extra_mpi_args=extra_mpi_args if extra_mpi_args else ''))
-
         # for better comparison replace sections in actual_command that change across runs / hosts
-        actual_command = run_func_kwargs.get('command')
         for replacement in ['-H [^ ]+', '-mca btl_tcp_if_include [^ ]+', '-x NCCL_SOCKET_IFNAME=[^ ]+',
                             r'"[^"]+python[0-9]*', r' [^"]+python[0-9]*',
                             '-m horovod.spark.driver.mpirun_rsh [^ ]+ [^ ]+"',
                             '-m horovod.spark.task.mpirun_exec_fn [^ ]+ [^ ]+']:
             actual_command = re.sub(replacement, replacement, actual_command, 1)
 
-        self.assertEqual(expected_command, actual_command)
         actual_secret = actual_env.pop('_HOROVOD_SECRET_KEY', None)
+        self.assertEqual(actual_command, expected_command)
+        if env:
+            self.assertEqual(env, actual_env)
+        else:
+            self.assertIsNotNone(actual_env)
         self.assertIsNotNone(actual_secret)
         self.assertTrue(len(actual_secret) > 0)
+        self.assertEqual(stdout, actual_stdout)
+        self.assertEqual(stderr, actual_stderr)
 
     """
     Performs an actual horovod.spark.run test using Gloo.
@@ -367,8 +370,7 @@ class SparkTests(unittest.TestCase):
                                       num_proc=num_proc, start_timeout=1,
                                       use_mpi=False, use_gloo=True,
                                       extra_mpi_args=extra_mpi_args, env=env,
-                                      stdout=stdout, stderr=stderr, verbose=verbose,
-                                      run_func=run_func)
+                                      stdout=stdout, stderr=stderr, verbose=verbose)
 
         self.assertFalse(str(e.value).startswith('Timed out waiting for Spark tasks to start.'),
                          'Spark timed out before mpi_run was called, test setup is broken.')


### PR DESCRIPTION
Replaces method injection with better `mock.patch` approach in unit testing.

Removes `run_func` from `mpi_run` and `js_run`.
Removes `exec_command` from `gloo_run`.
Removes `execute` from `_get_mpi_implementation`.

Conflicts with #1807, should be merged later.