### PR TITLE
Use forkserver for pytorch dataloader

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.test.cpu
     privileged: true
+    shm_size: 8gb
   test-cpu-openmpi-py2_7-tf1_1_0-keras2_0_0-torch0_4_0-mxnet1_4_1-pyspark2_3_2:
     extends: test-cpu-base
     build:
@@ -205,6 +206,7 @@ services:
     environment:
       - CUDA_VISIBLE_DEVICES
     privileged: true
+    shm_size: 8gb
   test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-gpu-base
     build:

--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -217,7 +217,8 @@ if __name__ == '__main__':
     kwargs = {'num_workers': 4, 'pin_memory': True} if args.cuda else {}
     # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
     # issues with Infiniband implementations that are not fork-safe
-    if mp._supports_context and 'forkserver' in mp.get_all_start_methods():
+    if (args.cuda and hasattr(mp, '_supports_context') and mp._supports_context and
+            'forkserver' in mp.get_all_start_methods()):
         kwargs['multiprocessing_context'] = 'forkserver'
 
     train_dataset = \

--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -217,8 +217,8 @@ if __name__ == '__main__':
     kwargs = {'num_workers': 4, 'pin_memory': True} if args.cuda else {}
     # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
     # issues with Infiniband implementations that are not fork-safe
-    if (args.cuda and hasattr(mp, '_supports_context') and mp._supports_context and
-            'forkserver' in mp.get_all_start_methods()):
+    if (kwargs.get('num_workers', 0) > 0 and hasattr(mp, '_supports_context') and
+            mp._supports_context and 'forkserver' in mp.get_all_start_methods()):
         kwargs['multiprocessing_context'] = 'forkserver'
 
     train_dataset = \

--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import torch
 import argparse
 import torch.backends.cudnn as cudnn
+import torch.multiprocessing as mp
 import torch.nn.functional as F
 import torch.optim as optim
 import torch.utils.data.distributed
@@ -54,123 +55,6 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
 parser.add_argument('--seed', type=int, default=42,
                     help='random seed')
 
-args = parser.parse_args()
-args.cuda = not args.no_cuda and torch.cuda.is_available()
-
-allreduce_batch_size = args.batch_size * args.batches_per_allreduce
-
-hvd.init()
-torch.manual_seed(args.seed)
-
-if args.cuda:
-    # Horovod: pin GPU to local rank.
-    torch.cuda.set_device(hvd.local_rank())
-    torch.cuda.manual_seed(args.seed)
-
-cudnn.benchmark = True
-
-# If set > 0, will resume training from a given checkpoint.
-resume_from_epoch = 0
-for try_epoch in range(args.epochs, 0, -1):
-    if os.path.exists(args.checkpoint_format.format(epoch=try_epoch)):
-        resume_from_epoch = try_epoch
-        break
-
-# Horovod: broadcast resume_from_epoch from rank 0 (which will have
-# checkpoints) to other ranks.
-resume_from_epoch = hvd.broadcast(torch.tensor(resume_from_epoch), root_rank=0,
-                                  name='resume_from_epoch').item()
-
-# Horovod: print logs on the first worker.
-verbose = 1 if hvd.rank() == 0 else 0
-
-# Horovod: write TensorBoard logs on first worker.
-try:
-    if LooseVersion(torch.__version__) >= LooseVersion('1.2.0'):
-        from torch.utils.tensorboard import SummaryWriter
-    else:
-        from tensorboardX import SummaryWriter
-    log_writer = SummaryWriter(args.log_dir) if hvd.rank() == 0 else None
-except ImportError:
-    log_writer = None
-
-# Horovod: limit # of CPU threads to be used per worker.
-torch.set_num_threads(4)
-
-kwargs = {'num_workers': 4, 'pin_memory': True} if args.cuda else {}
-train_dataset = \
-    datasets.ImageFolder(args.train_dir,
-                         transform=transforms.Compose([
-                             transforms.RandomResizedCrop(224),
-                             transforms.RandomHorizontalFlip(),
-                             transforms.ToTensor(),
-                             transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                                  std=[0.229, 0.224, 0.225])
-                         ]))
-# Horovod: use DistributedSampler to partition data among workers. Manually specify
-# `num_replicas=hvd.size()` and `rank=hvd.rank()`.
-train_sampler = torch.utils.data.distributed.DistributedSampler(
-    train_dataset, num_replicas=hvd.size(), rank=hvd.rank())
-train_loader = torch.utils.data.DataLoader(
-    train_dataset, batch_size=allreduce_batch_size,
-    sampler=train_sampler, **kwargs)
-
-val_dataset = \
-    datasets.ImageFolder(args.val_dir,
-                         transform=transforms.Compose([
-                             transforms.Resize(256),
-                             transforms.CenterCrop(224),
-                             transforms.ToTensor(),
-                             transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                                  std=[0.229, 0.224, 0.225])
-                         ]))
-val_sampler = torch.utils.data.distributed.DistributedSampler(
-    val_dataset, num_replicas=hvd.size(), rank=hvd.rank())
-val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=args.val_batch_size,
-                                         sampler=val_sampler, **kwargs)
-
-
-# Set up standard ResNet-50 model.
-model = models.resnet50()
-
-# By default, Adasum doesn't need scaling up learning rate.
-# For sum/average with gradient Accumulation: scale learning rate by batches_per_allreduce
-lr_scaler = args.batches_per_allreduce * hvd.size() if not args.use_adasum else 1
-
-if args.cuda:
-    # Move model to GPU.
-    model.cuda()
-    # If using GPU Adasum allreduce, scale learning rate by local_size.
-    if args.use_adasum and hvd.nccl_built():
-        lr_scaler = args.batches_per_allreduce * hvd.local_size()
-
-# Horovod: scale learning rate by the number of GPUs.
-optimizer = optim.SGD(model.parameters(),
-                      lr=(args.base_lr *
-                          lr_scaler),
-                      momentum=args.momentum, weight_decay=args.wd)
-
-# Horovod: (optional) compression algorithm.
-compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
-
-# Horovod: wrap optimizer with DistributedOptimizer.
-optimizer = hvd.DistributedOptimizer(
-    optimizer, named_parameters=model.named_parameters(),
-    compression=compression,
-    backward_passes_per_step=args.batches_per_allreduce,
-    op=hvd.Adasum if args.use_adasum else hvd.Average)
-
-# Restore from a previous checkpoint, if initial_epoch is specified.
-# Horovod: restore on the first worker which will broadcast weights to other workers.
-if resume_from_epoch > 0 and hvd.rank() == 0:
-    filepath = args.checkpoint_format.format(epoch=resume_from_epoch)
-    checkpoint = torch.load(filepath)
-    model.load_state_dict(checkpoint['model'])
-    optimizer.load_state_dict(checkpoint['optimizer'])
-
-# Horovod: broadcast parameters & optimizer state.
-hvd.broadcast_parameters(model.state_dict(), root_rank=0)
-hvd.broadcast_optimizer_state(optimizer, root_rank=0)
 
 def train(epoch):
     model.train()
@@ -286,7 +170,131 @@ class Metric(object):
         return self.sum / self.n
 
 
-for epoch in range(resume_from_epoch, args.epochs):
-    train(epoch)
-    validate(epoch)
-    save_checkpoint(epoch)
+if __name__ == '__main__':
+    args = parser.parse_args()
+    args.cuda = not args.no_cuda and torch.cuda.is_available()
+
+    allreduce_batch_size = args.batch_size * args.batches_per_allreduce
+
+    hvd.init()
+    torch.manual_seed(args.seed)
+
+    if args.cuda:
+        # Horovod: pin GPU to local rank.
+        torch.cuda.set_device(hvd.local_rank())
+        torch.cuda.manual_seed(args.seed)
+
+    cudnn.benchmark = True
+
+    # If set > 0, will resume training from a given checkpoint.
+    resume_from_epoch = 0
+    for try_epoch in range(args.epochs, 0, -1):
+        if os.path.exists(args.checkpoint_format.format(epoch=try_epoch)):
+            resume_from_epoch = try_epoch
+            break
+
+    # Horovod: broadcast resume_from_epoch from rank 0 (which will have
+    # checkpoints) to other ranks.
+    resume_from_epoch = hvd.broadcast(torch.tensor(resume_from_epoch), root_rank=0,
+                                      name='resume_from_epoch').item()
+
+    # Horovod: print logs on the first worker.
+    verbose = 1 if hvd.rank() == 0 else 0
+
+    # Horovod: write TensorBoard logs on first worker.
+    try:
+        if LooseVersion(torch.__version__) >= LooseVersion('1.2.0'):
+            from torch.utils.tensorboard import SummaryWriter
+        else:
+            from tensorboardX import SummaryWriter
+        log_writer = SummaryWriter(args.log_dir) if hvd.rank() == 0 else None
+    except ImportError:
+        log_writer = None
+
+    # Horovod: limit # of CPU threads to be used per worker.
+    torch.set_num_threads(4)
+
+    kwargs = {'num_workers': 4, 'pin_memory': True} if args.cuda else {}
+    # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
+    # issues with Infiniband implementations that are not fork-safe
+    if mp._supports_context and 'forkserver' in mp.get_all_start_methods():
+        kwargs['multiprocessing_context'] = 'forkserver'
+
+    train_dataset = \
+        datasets.ImageFolder(args.train_dir,
+                             transform=transforms.Compose([
+                                 transforms.RandomResizedCrop(224),
+                                 transforms.RandomHorizontalFlip(),
+                                 transforms.ToTensor(),
+                                 transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                                      std=[0.229, 0.224, 0.225])
+                             ]))
+    # Horovod: use DistributedSampler to partition data among workers. Manually specify
+    # `num_replicas=hvd.size()` and `rank=hvd.rank()`.
+    train_sampler = torch.utils.data.distributed.DistributedSampler(
+        train_dataset, num_replicas=hvd.size(), rank=hvd.rank())
+    train_loader = torch.utils.data.DataLoader(
+        train_dataset, batch_size=allreduce_batch_size,
+        sampler=train_sampler, **kwargs)
+
+    val_dataset = \
+        datasets.ImageFolder(args.val_dir,
+                             transform=transforms.Compose([
+                                 transforms.Resize(256),
+                                 transforms.CenterCrop(224),
+                                 transforms.ToTensor(),
+                                 transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                                      std=[0.229, 0.224, 0.225])
+                             ]))
+    val_sampler = torch.utils.data.distributed.DistributedSampler(
+        val_dataset, num_replicas=hvd.size(), rank=hvd.rank())
+    val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=args.val_batch_size,
+                                             sampler=val_sampler, **kwargs)
+
+
+    # Set up standard ResNet-50 model.
+    model = models.resnet50()
+
+    # By default, Adasum doesn't need scaling up learning rate.
+    # For sum/average with gradient Accumulation: scale learning rate by batches_per_allreduce
+    lr_scaler = args.batches_per_allreduce * hvd.size() if not args.use_adasum else 1
+
+    if args.cuda:
+        # Move model to GPU.
+        model.cuda()
+        # If using GPU Adasum allreduce, scale learning rate by local_size.
+        if args.use_adasum and hvd.nccl_built():
+            lr_scaler = args.batches_per_allreduce * hvd.local_size()
+
+    # Horovod: scale learning rate by the number of GPUs.
+    optimizer = optim.SGD(model.parameters(),
+                          lr=(args.base_lr *
+                              lr_scaler),
+                          momentum=args.momentum, weight_decay=args.wd)
+
+    # Horovod: (optional) compression algorithm.
+    compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
+
+    # Horovod: wrap optimizer with DistributedOptimizer.
+    optimizer = hvd.DistributedOptimizer(
+        optimizer, named_parameters=model.named_parameters(),
+        compression=compression,
+        backward_passes_per_step=args.batches_per_allreduce,
+        op=hvd.Adasum if args.use_adasum else hvd.Average)
+
+    # Restore from a previous checkpoint, if initial_epoch is specified.
+    # Horovod: restore on the first worker which will broadcast weights to other workers.
+    if resume_from_epoch > 0 and hvd.rank() == 0:
+        filepath = args.checkpoint_format.format(epoch=resume_from_epoch)
+        checkpoint = torch.load(filepath)
+        model.load_state_dict(checkpoint['model'])
+        optimizer.load_state_dict(checkpoint['optimizer'])
+
+    # Horovod: broadcast parameters & optimizer state.
+    hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+    hvd.broadcast_optimizer_state(optimizer, root_rank=0)
+
+    for epoch in range(resume_from_epoch, args.epochs):
+        train(epoch)
+        validate(epoch)
+        save_checkpoint(epoch)

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -1,26 +1,12 @@
 from __future__ import print_function
 import argparse
+import torch.multiprocessing as mp
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
 import torch.utils.data.distributed
 import horovod.torch as hvd
-
-# Temporary patch this script until the MNIST dataset download issue get resolved
-# https://github.com/pytorch/vision/issues/1938
-import urllib
-try:
-    # For python 2
-    class AppURLopener(urllib.FancyURLopener):
-        version = "Mozilla/5.0"
-
-    urllib._urlopener = AppURLopener()
-except AttributeError:
-    # For python 3
-    opener = urllib.request.build_opener()
-    opener.addheaders = [('User-agent', 'Mozilla/5.0')]
-    urllib.request.install_opener(opener)
 
 # Training settings
 parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
@@ -45,46 +31,6 @@ parser.add_argument('--fp16-allreduce', action='store_true', default=False,
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
 
-args = parser.parse_args()
-args.cuda = not args.no_cuda and torch.cuda.is_available()
-
-# Horovod: initialize library.
-hvd.init()
-torch.manual_seed(args.seed)
-
-if args.cuda:
-    # Horovod: pin GPU to local rank.
-    torch.cuda.set_device(hvd.local_rank())
-    torch.cuda.manual_seed(args.seed)
-
-
-# Horovod: limit # of CPU threads to be used per worker.
-torch.set_num_threads(1)
-
-kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
-train_dataset = \
-    datasets.MNIST('data-%d' % hvd.rank(), train=True, download=True,
-                   transform=transforms.Compose([
-                       transforms.ToTensor(),
-                       transforms.Normalize((0.1307,), (0.3081,))
-                   ]))
-# Horovod: use DistributedSampler to partition the training data.
-train_sampler = torch.utils.data.distributed.DistributedSampler(
-    train_dataset, num_replicas=hvd.size(), rank=hvd.rank())
-train_loader = torch.utils.data.DataLoader(
-    train_dataset, batch_size=args.batch_size, sampler=train_sampler, **kwargs)
-
-test_dataset = \
-    datasets.MNIST('data-%d' % hvd.rank(), train=False, transform=transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize((0.1307,), (0.3081,))
-    ]))
-# Horovod: use DistributedSampler to partition the test data.
-test_sampler = torch.utils.data.distributed.DistributedSampler(
-    test_dataset, num_replicas=hvd.size(), rank=hvd.rank())
-test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=args.test_batch_size,
-                                          sampler=test_sampler, **kwargs)
-
 
 class Net(nn.Module):
     def __init__(self):
@@ -103,36 +49,6 @@ class Net(nn.Module):
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
         return F.log_softmax(x)
-
-
-model = Net()
-
-# By default, Adasum doesn't need scaling up learning rate.
-lr_scaler = hvd.size() if not args.use_adasum else 1
-
-if args.cuda:
-    # Move model to GPU.
-    model.cuda()
-    # If using GPU Adasum allreduce, scale learning rate by local_size.
-    if args.use_adasum and hvd.nccl_built():
-        lr_scaler = hvd.local_size()
-
-# Horovod: scale learning rate by lr_scaler.
-optimizer = optim.SGD(model.parameters(), lr=args.lr * lr_scaler,
-                      momentum=args.momentum)
-
-# Horovod: broadcast parameters & optimizer state.
-hvd.broadcast_parameters(model.state_dict(), root_rank=0)
-hvd.broadcast_optimizer_state(optimizer, root_rank=0)
-
-# Horovod: (optional) compression algorithm.
-compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
-
-# Horovod: wrap optimizer with DistributedOptimizer.
-optimizer = hvd.DistributedOptimizer(optimizer,
-                                     named_parameters=model.named_parameters(),
-                                     compression=compression,
-                                     op=hvd.Adasum if args.use_adasum else hvd.Average)
 
 
 def train(epoch):
@@ -190,6 +106,81 @@ def test():
             test_loss, 100. * test_accuracy))
 
 
-for epoch in range(1, args.epochs + 1):
-    train(epoch)
-    test()
+if __name__ == '__main__':
+    args = parser.parse_args()
+    args.cuda = not args.no_cuda and torch.cuda.is_available()
+
+    # Horovod: initialize library.
+    hvd.init()
+    torch.manual_seed(args.seed)
+
+    if args.cuda:
+        # Horovod: pin GPU to local rank.
+        torch.cuda.set_device(hvd.local_rank())
+        torch.cuda.manual_seed(args.seed)
+
+
+    # Horovod: limit # of CPU threads to be used per worker.
+    torch.set_num_threads(1)
+
+    kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
+    # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
+    # issues with Infiniband implementations that are not fork-safe
+    if mp._supports_context and 'forkserver' in mp.get_all_start_methods():
+        kwargs['multiprocessing_context'] = 'forkserver'
+
+    train_dataset = \
+        datasets.MNIST('data-%d' % hvd.rank(), train=True, download=True,
+                       transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ]))
+    # Horovod: use DistributedSampler to partition the training data.
+    train_sampler = torch.utils.data.distributed.DistributedSampler(
+        train_dataset, num_replicas=hvd.size(), rank=hvd.rank())
+    train_loader = torch.utils.data.DataLoader(
+        train_dataset, batch_size=args.batch_size, sampler=train_sampler, **kwargs)
+
+    test_dataset = \
+        datasets.MNIST('data-%d' % hvd.rank(), train=False, transform=transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.1307,), (0.3081,))
+        ]))
+    # Horovod: use DistributedSampler to partition the test data.
+    test_sampler = torch.utils.data.distributed.DistributedSampler(
+        test_dataset, num_replicas=hvd.size(), rank=hvd.rank())
+    test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=args.test_batch_size,
+                                              sampler=test_sampler, **kwargs)
+
+    model = Net()
+
+    # By default, Adasum doesn't need scaling up learning rate.
+    lr_scaler = hvd.size() if not args.use_adasum else 1
+
+    if args.cuda:
+        # Move model to GPU.
+        model.cuda()
+        # If using GPU Adasum allreduce, scale learning rate by local_size.
+        if args.use_adasum and hvd.nccl_built():
+            lr_scaler = hvd.local_size()
+
+    # Horovod: scale learning rate by lr_scaler.
+    optimizer = optim.SGD(model.parameters(), lr=args.lr * lr_scaler,
+                          momentum=args.momentum)
+
+    # Horovod: broadcast parameters & optimizer state.
+    hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+    hvd.broadcast_optimizer_state(optimizer, root_rank=0)
+
+    # Horovod: (optional) compression algorithm.
+    compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
+
+    # Horovod: wrap optimizer with DistributedOptimizer.
+    optimizer = hvd.DistributedOptimizer(optimizer,
+                                         named_parameters=model.named_parameters(),
+                                         compression=compression,
+                                         op=hvd.Adasum if args.use_adasum else hvd.Average)
+
+    for epoch in range(1, args.epochs + 1):
+        train(epoch)
+        test()

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -126,7 +126,8 @@ if __name__ == '__main__':
     kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
     # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
     # issues with Infiniband implementations that are not fork-safe
-    if mp._supports_context and 'forkserver' in mp.get_all_start_methods():
+    if (args.cuda and hasattr(mp, '_supports_context') and mp._supports_context and
+            'forkserver' in mp.get_all_start_methods()):
         kwargs['multiprocessing_context'] = 'forkserver'
 
     train_dataset = \

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -126,8 +126,8 @@ if __name__ == '__main__':
     kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
     # When supported, use 'forkserver' to spawn dataloader workers instead of 'fork' to prevent
     # issues with Infiniband implementations that are not fork-safe
-    if (args.cuda and hasattr(mp, '_supports_context') and mp._supports_context and
-            'forkserver' in mp.get_all_start_methods()):
+    if (kwargs.get('num_workers', 0) > 0 and hasattr(mp, '_supports_context') and
+            mp._supports_context and 'forkserver' in mp.get_all_start_methods()):
         kwargs['multiprocessing_context'] = 'forkserver'
 
     train_dataset = \


### PR DESCRIPTION
Some Infiniband implementations are not fork-safe (e.g. Summit MPI)
In this case PyTorch recommands to use 'forkserver' or 'spawn' to start
the dataloader workers.
See warning at https://github.com/pytorch/pytorch/blob/3789db40f20156f1c5fb5a8da3f26a613edcdf28/torch/nn/parallel/distributed.py#L137

To use 'forkserver' or 'spawn', the global state of the main script
needs to be nested under "if __name__ == '__main__':" to prevent the spawned
processes from re-executing the code.
See https://docs.python.org/3/library/multiprocessing.html#programming-guidelines

Signed-off-by: Nicolas V Castet <nvcastet@us.ibm.com>