### PR TITLE
More renaming of common_intfs to nics (cf. #1808)

### DIFF
--- a/horovod/run/driver/driver_service.py
+++ b/horovod/run/driver/driver_service.py
@@ -176,23 +176,21 @@ def _driver_fn(all_host_names, local_host_names, settings):
         # interfaces that are not really connected to any external networks
         # such as lo0 with address 127.0.0.1.
         if settings.verbose >= 2:
-            print('Waiting for hosts to perform host-to-host '
-                  'interface checking.')
+            print('Waiting for hosts to perform host-to-host interface checking.')
         driver.wait_for_task_to_task_address_updates(settings.timeout)
         if settings.verbose >= 2:
             print('Host-to-host interface checking successful.')
         # Determine a set of common interfaces for task-to-task communication.
-        common_intfs = set(driver.task_addresses_for_tasks(0).keys())
+        nics = set(driver.task_addresses_for_tasks(0).keys())
         for index in range(1, settings.num_hosts):
-            common_intfs.intersection_update(
+            nics.intersection_update(
                 driver.task_addresses_for_tasks(index).keys())
-        if not common_intfs:
+        if not nics:
             raise Exception(
-                'Unable to find a set of common task-to-task communication '
-                'interfaces: %s'
+                'Unable to find a set of common task-to-task communication interfaces: %s'
                 % [(index, driver.task_addresses_for_tasks(index))
                    for index in range(settings.num_hosts)])
-        return common_intfs
+        return nics
     finally:
         driver.shutdown()
 

--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -32,14 +32,14 @@ def is_jsrun_installed():
     return find_executable('jsrun') is not None
 
 
-def js_run(settings, common_intfs, env, command, stdout=None, stderr=None, run_func=safe_shell_exec.execute):
+def js_run(settings, nics, env, command, stdout=None, stderr=None, run_func=safe_shell_exec.execute):
     """
     Runs Horovod with jsrun.
 
     Args:
         settings: Settings for running jsrun.
                   Note: settings.num_proc and settings.hosts must not be None.
-        common_intfs: Interfaces to include by jsrun.
+        nics: Interfaces to include by jsrun.
         env: Environment dictionary to use for running jsrun.
         command: Command and arguments to run as a list of string.
         stdout: Stdout of the mpi process.
@@ -60,8 +60,8 @@ def js_run(settings, common_intfs, env, command, stdout=None, stderr=None, run_f
             'Please, make sure you are running on a cluster with jsrun installed or '
             'use one of the other launchers.')
 
-    if common_intfs and 'NCCL_SOCKET_IFNAME' not in env:
-        env['NCCL_SOCKET_IFNAME'] = ','.join(common_intfs)
+    if nics and 'NCCL_SOCKET_IFNAME' not in env:
+        env['NCCL_SOCKET_IFNAME'] = ','.join(nics)
 
     smpiargs = ' '.join(mpi_impl_flags)
     if settings.extra_mpi_args:

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -107,10 +107,10 @@ def mpi_run(settings, nics, env, command, stdout=None, stderr=None, run_func=saf
     # There is no need to specify localhost.
     hosts_arg = '-H {hosts}'.format(hosts=settings.hosts)
 
-    tcp_intf_arg = '-mca btl_tcp_if_include {common_intfs}'.format(
-        common_intfs=','.join(nics)) if nics else ''
-    nccl_socket_intf_arg = '-x NCCL_SOCKET_IFNAME={common_intfs}'.format(
-        common_intfs=','.join(nics)) if nics else ''
+    tcp_intf_arg = '-mca btl_tcp_if_include {nics}'.format(
+        nics=','.join(nics)) if nics else ''
+    nccl_socket_intf_arg = '-x NCCL_SOCKET_IFNAME={nics}'.format(
+        nics=','.join(nics)) if nics else ''
 
     # On large cluster runs (e.g. Summit), we need extra settings to work around OpenMPI issues
     if settings.num_hosts and settings.num_hosts >= _LARGE_CLUSTER_THRESHOLD:

--- a/horovod/run/util/network.py
+++ b/horovod/run/util/network.py
@@ -78,12 +78,12 @@ def find_port(server_factory):
     raise Exception('Unable to find a port to bind to.')
 
 
-def _get_driver_ip(common_intfs):
+def _get_driver_ip(nics):
     """
-    :param common_intfs: object return by `_driver_fn`
+    :param nics: object return by `_driver_fn`
     :return: driver ip. We make sure all workers can connect to this ip.
     """
-    iface = list(common_intfs)[0]
+    iface = list(nics)[0]
     driver_ip = None
     for addr in net_if_addrs()[iface]:
         if addr.family == AF_INET:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -315,7 +315,7 @@ class RunTests(unittest.TestCase):
             self.skipTest("MPI is not available")
 
         cmd = ['cmd', 'arg1', 'arg2']
-        common_intfs = ['eth0', 'eth1']
+        nics = ['eth0', 'eth1']
         env = {'env1': 'val1', 'env2': 'val2'}
         stdout = '<stdout>'
         stderr = '<stderr>'
@@ -335,7 +335,7 @@ class RunTests(unittest.TestCase):
         )
         run_func = MagicMock(return_value=0)
 
-        mpi_run(settings, common_intfs, env, cmd, stdout=stdout, stderr=stderr, run_func=run_func)
+        mpi_run(settings, nics, env, cmd, stdout=stdout, stderr=stderr, run_func=run_func)
 
         mpi_flags, _ = _get_mpi_implementation_flags(False)
         self.assertIsNotNone(mpi_flags)


### PR DESCRIPTION
There are some more places where `common_intfs` is mentioned. Renaming those to `nics` as well for sake of naming consistency.