### PR TITLE
Add Join op (with support for AllReduce and TensorFlow )

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -35,6 +35,7 @@ from horovod.tensorflow.mpi_ops import Average, Sum, Adasum
 from horovod.tensorflow.mpi_ops import handle_average_backwards_compatibility, check_num_rank_power_of_2
 
 from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache
+from horovod.tensorflow.mpi_ops import join
 
 import tensorflow as tf
 import warnings

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -199,3 +199,7 @@ def _broadcast_grad(op, grad):
     if rank() != root_rank:
         return grad_reduced * 0
     return grad_reduced
+
+#add join for tf
+def join():
+    return MPI_LIB.horovod_join()


### PR DESCRIPTION
This PR is based on the problem #832 and implemented hvd.join() on the Tensorflow level.
The author @kit1980 has implemented join logic on the horovod framework and support for Pytorch. So this PR is based on the Join function provided by author kit1980 , adding join op support for Tensorflow
