### PR TITLE
Rename horovodrun to horovod in strings and comments

### DIFF
--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -161,10 +161,10 @@ class BasicClient(object):
         self._addresses = self._probe(addresses)
         if not self._addresses:
             raise NoValidAddressesFound(
-                'Horovodrun was unable to connect to {service_name} on any '
+                'Horovod was unable to connect to {service_name} on any '
                 'of the following addresses: {addresses}.\n\n'
                 'One possible cause of this problem is that '
-                'horovodrun currently requires every host to have at '
+                'horovod currently requires every host to have at '
                 'least one routable network interface with the same '
                 'name across all of the hosts. '
                 'You can run \"ifconfig -a\" '

--- a/horovod/run/driver/driver_service.py
+++ b/horovod/run/driver/driver_service.py
@@ -26,7 +26,7 @@ from horovod.run.common.util import codec, safe_shell_exec
 from horovod.run.task import task_service
 
 class HorovodRunDriverService(driver_service.BasicDriverService):
-    NAME = 'horovodrun driver service'
+    NAME = 'horovod driver service'
 
     def __init__(self, num_hosts, key, nics):
         super(HorovodRunDriverService, self).__init__(num_hosts,
@@ -79,7 +79,7 @@ def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
                                                 stderr=host_output)
             if exit_code != 0:
                 print(
-                    'Launching horovodrun task function was not '
+                    'Launching horovod task function was not '
                     'successful:\n{host_output}'
                     .format(host_output=host_output.getvalue()))
                 os._exit(exit_code)
@@ -117,7 +117,7 @@ def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
     # Each thread will use ssh command to launch the server on one task. If an
     # error occurs in one thread, entire process will be terminated. Otherwise,
     # threads will keep running and ssh session -- and the the task server --
-    # will be bound to the thread. In case, the horovodrun process dies, all
+    # will be bound to the thread. In case, the horovod process dies, all
     # the ssh sessions and all the task servers will die as well.
     threads.execute_function_multithreaded(_exec_command,
                                            args_list,
@@ -143,12 +143,11 @@ def _driver_fn(all_host_names, local_host_names, settings):
     :return: example: ['eth0', 'eth1']
     :rtype: list[string]
     """
-    # Launch a TCP server called service service on the host running
-    # horovodrun.
+    # Launch a TCP server called service service on the host running horovod
     driver = HorovodRunDriverService(
         settings.num_hosts, settings.key, settings.nic)
     if settings.verbose >= 2:
-        print('Launched horovodrun server.')
+        print('Launched horovod server.')
     # Have all the workers register themselves with the service service.
     _launch_task_servers(all_host_names, local_host_names,
                          driver.addresses(), settings)
@@ -204,7 +203,7 @@ def get_common_interfaces(settings, all_host_names, remote_host_names, fn_cache)
     :type all_host_names: list(string)
     :param remote_host_names: list of the remote host names.
     :type remote_host_names: list(string)
-    :param fn_cache: Cache storing the results of checks performed by horovodrun
+    :param fn_cache: Cache storing the results of checks performed by horovod
     :type fn_cache: Horovod.run.util.cache.Cache
     :return: List of common interfaces
     '''

--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -56,7 +56,7 @@ def js_run(settings, nics, env, command, stdout=None, stderr=None, run_func=safe
 
     if not is_jsrun_installed():
         raise Exception(
-            'horovodrun convenience script does not find the jsrun command.\n\n'
+            'horovod does not find the jsrun command.\n\n'
             'Please, make sure you are running on a cluster with jsrun installed or '
             'use one of the other launchers.')
 

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -42,7 +42,7 @@ _NO_BINDING_ARGS = ['-bind-to none', '-map-by slot']
 _SOCKET_BINDING_ARGS = ['-bind-to socket', '-map-by socket', '-rank-by core']
 
 # MPI not found error message
-_MPI_NOT_FOUND_ERROR_MSG= ('horovodrun convenience script does not find an installed MPI.\n\n'
+_MPI_NOT_FOUND_ERROR_MSG= ('horovod does not find an installed MPI.\n\n'
                            'Choose one of:\n'
                            '1. Install Open MPI 4.0.0+ or IBM Spectrum MPI or MPICH and re-install Horovod '
                            '(use --no-cache-dir pip option).\n'

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -47,7 +47,7 @@ from horovod.run.http.http_client import read_data_from_kvstore, put_data_into_k
 from horovod.run.http.http_server import KVStoreServer
 
 
-# Cached information of horovodrun functions be stored in this directory
+# Cached information of horovod functions be stored in this directory
 CACHE_FOLDER = os.path.join(os.path.expanduser('~'), '.horovod')
 
 # Cache entries will be stale if they are older than this number of minutes
@@ -596,7 +596,7 @@ def _run(args):
                                      run_func_mode=args.run_func is not None,
                                      nics=nics_set)
 
-    # This cache stores the results of checks performed by horovodrun
+    # This cache stores the results of checks performed by horovod
     # during the initialization step. It can be disabled by setting
     # --disable-cache flag.
     fn_cache = None

--- a/horovod/run/task/task_service.py
+++ b/horovod/run/task/task_service.py
@@ -29,7 +29,7 @@ class TaskToTaskAddressCheckFinishedSignalResponse(object):
 
 
 class HorovodRunTaskService(task_service.BasicTaskService):
-    NAME_FORMAT = 'horovodrun task service #%d'
+    NAME_FORMAT = 'horovod task service #%d'
 
     def __init__(self, index, key, nics, service_env_keys=None):
         super(HorovodRunTaskService, self).__init__(


### PR DESCRIPTION
Horovod can be run from API as well, not just from the
horovodrun convenience script. Log and error messages
referring to horovodrun may be confusing then, especially
running Horovod on Spark.