### PR TITLE
Renaming retries to attempts

### DIFF
--- a/horovod/run/common/service/task_service.py
+++ b/horovod/run/common/service/task_service.py
@@ -156,11 +156,11 @@ class BasicTaskService(network.BasicService):
 
 class BasicTaskClient(network.BasicClient):
     def __init__(self, service_name, task_addresses, key, verbose,
-                 match_intf=False, retries=3):
+                 match_intf=False, attempts=3):
         super(BasicTaskClient, self).__init__(service_name,
                                               task_addresses, key, verbose,
                                               match_intf=match_intf,
-                                              retries=retries)
+                                              attempts=attempts)
 
     def run_command(self, command, env):
         self._send(RunCommandRequest(command, env))

--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -150,14 +150,14 @@ class BasicService(object):
 
 class BasicClient(object):
     def __init__(self, service_name, addresses, key, verbose, match_intf=False,
-                 probe_timeout=20, retries=3):
+                 probe_timeout=20, attempts=3):
         # Note: because of retry logic, ALL RPC calls are REQUIRED to be idempotent.
         self._verbose = verbose
         self._service_name = service_name
         self._wire = Wire(key)
         self._match_intf = match_intf
         self._probe_timeout = probe_timeout
-        self._retries = retries
+        self._attempts = attempts
         self._addresses = self._probe(addresses)
         if not self._addresses:
             raise NoValidAddressesFound(
@@ -195,7 +195,7 @@ class BasicClient(object):
         return result
 
     def _probe_one(self, intf, addr, result_queue):
-        for iter in range(self._retries):
+        for iter in range(self._attempts):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(self._probe_timeout)
             try:
@@ -243,7 +243,7 @@ class BasicClient(object):
                 sock.close()
 
     def _send_one(self, addr, req):
-        for iter in range(self._retries):
+        for iter in range(self._attempts):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
                 sock.connect(addr)
@@ -257,7 +257,7 @@ class BasicClient(object):
                     rfile.close()
                     wfile.close()
             except:
-                if iter == self._retries - 1:
+                if iter == self._attempts - 1:
                     # Raise exception on the last retry.
                     raise
             finally:

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -53,8 +53,8 @@ CACHE_FOLDER = os.path.join(os.path.expanduser('~'), '.horovod')
 # Cache entries will be stale if they are older than this number of minutes
 CACHE_STALENESS_THRESHOLD_MINUTES = 60
 
-# Number of retries for sshing into the hosts
-SSH_RETRIES = 5
+# Number of attempts for sshing into the hosts
+SSH_ATTEMPTS = 5
 
 
 @cache.use_cache()
@@ -73,7 +73,7 @@ def _check_all_hosts_ssh_successful(host_addresses, ssh_port=None):
         output_msg = ''
 
         # Try ssh 5 times
-        for i in range(SSH_RETRIES):
+        for i in range(SSH_ATTEMPTS):
             output = six.StringIO()
             try:
                 exit_code = safe_shell_exec.execute(command,

--- a/horovod/run/task/task_service.py
+++ b/horovod/run/task/task_service.py
@@ -64,12 +64,12 @@ class HorovodRunTaskService(task_service.BasicTaskService):
 
 class HorovodRunTaskClient(task_service.BasicTaskClient):
 
-    def __init__(self, index, task_addresses, key, verbose, match_intf=False, retries=3):
+    def __init__(self, index, task_addresses, key, verbose, match_intf=False, attempts=3):
         super(HorovodRunTaskClient, self).__init__(
             HorovodRunTaskService.NAME_FORMAT % index,
             task_addresses, key, verbose,
             match_intf=match_intf,
-            retries=retries)
+            attempts=attempts)
         self.index = index
 
     def task_to_task_address_check_completed(self):

--- a/horovod/run/task_fn.py
+++ b/horovod/run/task_fn.py
@@ -40,7 +40,7 @@ def _task_fn(index, driver_addresses, settings):
             settings.key,
             settings.verbose,
             match_intf=True,
-            retries=10)
+            attempts=10)
         driver.register_task_to_task_addresses(next_task_index,
                                                next_task.addresses())
         # Notify the next task that the address checks are completed.


### PR DESCRIPTION
Variables `retries` actually denote `attempts` semantics:

    for iter in range(self._retries)

There is the first attempt and then a number of retries. Setting retries to 0 should still perform the first attempt. So naming these variables attempts makes it obvious that 0 is not a sensible value.

You could even say:

    for retry in range(self._attempts)

where `retry == 0` is the first attempt and `retry > 0` is the index of retry happening (1, 2, ..., `attempts` - 1). This expression becomes more meaningful then:

    if retry == self._attempts - 1:
        # Raise exception on the last retry.
        raise

Signed-off-by: Enrico Minack <github@enrico.minack.dev>