### PR TITLE
rsh returns exit code for horovod.spark.gloo_run

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -279,28 +279,32 @@ run_spark_integration() {
   # Horovod Spark Estimator tests
   if [[ ${test} != *"tf1_1_0"* && ${test} != *"tf1_6_0"* && ${test} != *"torch0_"* && ${test} != *"mpich"* && ${test} != *"oneccl"* ]]; then
     if [[ ${test} != *"tf2"* && ${test} != *"tfhead"* ]]; then
-      run_test "${test}" "${queue}" \
-        ":spark: Spark Keras Rossmann Run (${test})" \
-        "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01\""
+      if [[ ! (  ${test} == *"py2"* && ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+        run_test "${test}" "${queue}" \
+          ":spark: Spark Keras Rossmann Run (${test})" \
+          "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01\""
 
-      run_test "${test}" "${queue}" \
-        ":spark: Spark Keras Rossmann Estimator (${test})" \
-        "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.01\""
+        run_test "${test}" "${queue}" \
+          ":spark: Spark Keras Rossmann Estimator (${test})" \
+          "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.01\""
+
+        run_test "${test}" "${queue}" \
+          ":spark: Spark Keras MNIST (${test})" \
+          "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""
+      fi
 
       if [[ ${queue} != *gpu* ]]; then
         run_test "${test}" "${queue}" \
           ":spark: PyTests Spark Estimators (${test})" \
           "bash -c \"cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py\""
       fi
-
-      run_test "${test}" "${queue}" \
-        ":spark: Spark Keras MNIST (${test})" \
-        "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""
     fi
 
-    run_test "${test}" "${queue}" \
-      ":spark: Spark Torch MNIST (${test})" \
-      "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""
+    if [[ ! (  ${test} == *"py2"* && ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+      run_test "${test}" "${queue}" \
+        ":spark: Spark Torch MNIST (${test})" \
+        "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""
+    fi
   fi
 }
 

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -85,7 +85,7 @@ run_test() {
   echo "      pull-retries: 3"
   echo "  - ecr#v1.2.0:"
   echo "      login: true"
-  echo "  timeout_in_minutes: 5"
+  echo "  timeout_in_minutes: 10"
   echo "  retry:"
   echo "    automatic: true"
   echo "  agents:"

--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -91,6 +91,7 @@ class BasicService(object):
         self._server, _ = find_port(
             lambda addr: socketserver.ThreadingTCPServer(
                 addr, self._make_handler()))
+        self._server._block_on_close = True
         self._port = self._server.socket.getsockname()[1]
         self._addresses = self._get_local_addresses()
         self._thread = in_thread(target=self._server.serve_forever)

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -657,7 +657,14 @@ def _run(args):
         return None
 
 
+def is_gloo_used(use_gloo=None, use_mpi=None, use_jsrun=None):
+    # determines whether run_controller will run gloo
+    # for the given (use_gloo, _, use_mpi, _, use_jsrun, _, _)
+    return use_gloo or (not use_mpi and not use_jsrun and not mpi_built())
+
+
 def run_controller(use_gloo, gloo_run, use_mpi, mpi_run, use_jsrun, js_run, verbosity):
+    # keep logic in sync with is_gloo_used(...)
     verbose = verbosity is not None and verbosity >= 2
     if use_gloo:
         if not gloo_built(verbose=verbose):

--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -92,11 +92,12 @@ def execute_function_multithreaded(fn,
     return results
 
 
-def in_thread(target, args=(), daemon=True, silent=False):
+def in_thread(target, args=(), name=None, daemon=True, silent=False):
     """
     Executes the given function in background.
     :param target: function
     :param args: function arguments
+    :param name: name of the thread
     :param daemon: run as daemon thread, do not block until thread is doe
     :param silent: swallows exceptions raised by target silently
     :return background thread
@@ -114,7 +115,7 @@ def in_thread(target, args=(), daemon=True, silent=False):
     else:
         fn = target
 
-    bg = threading.Thread(target=fn, args=args)
+    bg = threading.Thread(target=fn, args=args, name=name)
     bg.daemon = daemon
     bg.start()
     return bg

--- a/horovod/spark/driver/rsh.py
+++ b/horovod/spark/driver/rsh.py
@@ -13,17 +13,27 @@
 # limitations under the License.
 # ==============================================================================
 
+import threading
+import traceback
+
+from horovod.run.util.threads import on_event
 from horovod.spark.task import task_service
 from horovod.spark.driver import driver_service
 
 
-def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank):
+def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank,
+        background=True, event=None):
     """
     Method to run a command remotely given a host hash, local rank and driver addresses.
 
     This method connects to the SparkDriverService running on the Spark driver,
     retrieves all information required to connect to the task with given local rank
     of that host hash and invoke the command there.
+
+    The method returns immediately after launching the command if background is True (default).
+    When background is set to False, this method waits for command termination and returns
+    command's result. If there is an exception while waiting for the result (i.e. connection reset)
+    it returns -1.
 
     :param driver_addresses: driver's addresses
     :param key: used for encryption of parameters passed across the hosts
@@ -32,6 +42,8 @@ def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank):
     :param command: command and arguments to invoke
     :param env: environment to use
     :param local_rank: local rank on the host of task to run the command in
+    :param background: run command in background if True, returns command result otherwise
+    :param event: event to abort the command, only if background is True
     """
     if ':' in host_hash:
         raise Exception('Illegal host hash provided. Are you using Open MPI 4.0.0+?')
@@ -44,3 +56,18 @@ def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank):
     task_client = task_service.SparkTaskClient(task_index, task_addresses,
                                                key, verbose=settings.verbose)
     task_client.run_command(command, env)
+
+    if not background:
+        stop = None
+        if event is not None:
+            stop = threading.Event()
+            on_event(event, task_client.abort_command, stop=stop)
+
+        try:
+            return task_client.wait_for_command_exit_code()
+        except:
+            traceback.print_exc()
+            return -1
+        finally:
+            if stop is not None:
+                stop.set()

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -25,10 +25,8 @@ def _exec_command_fn(driver_addresses, key, settings, env):
     def _exec_command(command, alloc_info, event):
         host = alloc_info.hostname
         local_rank = alloc_info.local_rank
-        rsh(driver_addresses, key, settings, host, command, env, local_rank)
-        # this indicate successful command execution, not the result of the executed command
-        # the result of each task is collected through Spark at the end of horovod.spark.run.run()
-        return 0, time.time()
+        result = rsh(driver_addresses, key, settings, host, command, env, local_rank, False, event)
+        return result, time.time()
     return _exec_command
 
 

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -43,6 +43,9 @@ def gloo_run(settings, nics, driver, env):
     if env is None:
         env = {}
 
+    if sys.version_info < (3, 0, 0):
+        raise Exception('Horovod on Spark over Gloo only supported on Python3')
+
     # Each thread will use SparkTaskClient to launch the job on each remote host. If an
     # error occurs in one thread, entire process will be terminated. Otherwise,
     # threads will keep running and ssh session.

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -15,6 +15,7 @@
 
 import os
 import platform
+import time
 
 import pyspark
 from six.moves import queue
@@ -28,6 +29,8 @@ from horovod.run.common.util import timeout, host_hash, secret
 from horovod.run.common.util import settings as hvd_settings
 from horovod.spark.driver import driver_service, job_id
 
+
+MINIMUM_COMMAND_LIFETIME_S = 3
 
 # Spark will fail to initialize correctly locally on Mac OS without this
 if platform.system() == 'Darwin':
@@ -49,8 +52,11 @@ def _task_fn(index, driver_addresses, key, settings, use_gloo):
 
         # With Gloo all tasks wait for the command
         # With MPI task with first index executes orted which will run mpirun_exec_fn for all tasks.
+        minimum_lifetime_after_start = None
         if use_gloo or task_indices_on_this_host[0] == index:
             task.wait_for_command_start(settings.timeout)
+            minimum_lifetime_after_start = timeout.Timeout(MINIMUM_COMMAND_LIFETIME_S,
+                                                           message='Just measuring runtime')
             task.wait_for_command_termination()
         else:
             # The rest of tasks need to wait for the first task to finish.
@@ -60,6 +66,13 @@ def _task_fn(index, driver_addresses, key, settings, use_gloo):
                                              first_task_addresses, settings.key,
                                              settings.verbose)
             first_task_client.wait_for_command_termination()
+
+        # command terminated, make sure this task service does not shutdown too quickly after
+        # the client started the command as it needs some time to connect again
+        # to wait for the result after starting the command (see horovod.spark.driver.rsh).
+        if minimum_lifetime_after_start is not None:
+            time.sleep(minimum_lifetime_after_start.remaining())
+
         return task.fn_result()
     finally:
         task.shutdown()

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -24,7 +24,7 @@ from horovod.run.util.threads import in_thread
 from horovod.spark.task import task_service
 from horovod.spark.gloo_run import gloo_run
 from horovod.spark.mpi_run import mpi_run
-from horovod.run.runner import run_controller
+from horovod.run.runner import is_gloo_used, run_controller
 from horovod.run.common.util import timeout, host_hash, secret
 from horovod.run.common.util import settings as hvd_settings
 from horovod.spark.driver import driver_service, job_id
@@ -194,8 +194,9 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
     spark_job_group = 'horovod.spark.run.%d' % job_id.next_job_id()
     driver = driver_service.SparkDriverService(settings.num_proc, fn, args, kwargs,
                                                settings.key, settings.nics)
+    gloo_is_used = is_gloo_used(use_gloo=use_gloo, use_mpi=use_mpi, use_jsrun=False)
     spark_thread = _make_spark_thread(spark_context, spark_job_group, driver,
-                                      result_queue, settings, use_gloo)
+                                      result_queue, settings, gloo_is_used)
     try:
         # wait for all tasks to register, notify them and initiate task-to-task address registration
         _notify_and_register_task_addresses(driver, settings)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -75,6 +75,9 @@ def _task_fn(index, driver_addresses, key, settings, use_gloo):
 
         return task.fn_result()
     finally:
+        # this has to block on running requests (wait_for_command_exit_code)
+        # so they can finish serving the exit code
+        # shutdown does block with network.BasicService._server._block_on_close = True
         task.shutdown()
 
 

--- a/test/data/expected_buildkite_pipeline.yaml
+++ b/test/data/expected_buildkite_pipeline.yaml
@@ -914,64 +914,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras Rossmann Run (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 5
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Keras Rossmann Estimator (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 5
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
   command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 5
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 5
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Torch MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -1124,8 +1068,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
+- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
+  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -1138,8 +1082,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
+- label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
+  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -1306,8 +1250,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
+- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
+  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -1320,8 +1264,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
+- label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
+  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -1656,8 +1600,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: PyTests Spark Estimators (test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
+- label: ':spark: Spark Keras MNIST (test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0)'
+  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0
@@ -1670,8 +1614,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
+- label: ':spark: PyTests Spark Estimators (test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0)'
+  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0
@@ -1978,8 +1922,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: PyTests Spark Estimators (test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
+- label: ':spark: Spark Keras MNIST (test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
+  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
@@ -1992,8 +1936,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
+- label: ':spark: PyTests Spark Estimators (test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
+  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-gloo-py3_6-tf1_14_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0

--- a/test/data/expected_buildkite_pipeline.yaml
+++ b/test/data/expected_buildkite_pipeline.yaml
@@ -349,7 +349,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -363,7 +363,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -377,7 +377,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -391,7 +391,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -405,7 +405,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -419,7 +419,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -433,7 +433,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -447,7 +447,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -461,7 +461,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -475,7 +475,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -489,7 +489,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -503,7 +503,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -517,7 +517,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -531,7 +531,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -545,7 +545,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -559,7 +559,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -573,7 +573,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -587,7 +587,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -601,7 +601,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -615,7 +615,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -629,7 +629,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -643,7 +643,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -657,7 +657,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -671,7 +671,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -685,7 +685,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -699,7 +699,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -713,7 +713,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -727,7 +727,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -741,7 +741,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -755,7 +755,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -769,7 +769,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -783,7 +783,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -797,7 +797,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -811,7 +811,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -825,7 +825,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -839,7 +839,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -853,7 +853,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -867,7 +867,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -881,7 +881,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -895,7 +895,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -909,7 +909,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -923,7 +923,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -937,7 +937,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -951,7 +951,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -965,7 +965,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -979,7 +979,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -993,7 +993,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1007,7 +1007,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1021,7 +1021,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1035,7 +1035,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1049,7 +1049,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1063,7 +1063,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1077,7 +1077,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1091,7 +1091,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1105,7 +1105,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1119,7 +1119,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1133,7 +1133,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1147,7 +1147,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1161,7 +1161,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1175,7 +1175,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1189,7 +1189,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1203,7 +1203,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1217,7 +1217,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1231,7 +1231,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1245,7 +1245,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1259,7 +1259,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1273,7 +1273,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1287,7 +1287,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1301,7 +1301,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1315,7 +1315,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1329,7 +1329,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1343,7 +1343,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1357,7 +1357,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1371,7 +1371,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1385,7 +1385,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1399,7 +1399,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1413,7 +1413,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1427,7 +1427,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1441,7 +1441,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1455,7 +1455,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1469,7 +1469,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1483,7 +1483,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1497,7 +1497,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1511,7 +1511,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1525,7 +1525,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1539,7 +1539,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1553,7 +1553,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1567,7 +1567,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1581,7 +1581,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1595,7 +1595,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1609,7 +1609,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1623,7 +1623,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1637,7 +1637,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1651,7 +1651,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1665,7 +1665,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1679,7 +1679,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1693,7 +1693,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1707,7 +1707,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1721,7 +1721,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1735,7 +1735,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1749,7 +1749,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1763,7 +1763,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1777,7 +1777,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1791,7 +1791,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1805,7 +1805,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1819,7 +1819,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1833,7 +1833,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1847,7 +1847,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1861,7 +1861,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1875,7 +1875,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1889,7 +1889,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1903,7 +1903,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1917,7 +1917,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1931,7 +1931,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1945,7 +1945,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1959,7 +1959,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1973,7 +1973,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -1987,7 +1987,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2001,7 +2001,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2015,7 +2015,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2029,7 +2029,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2043,7 +2043,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2057,7 +2057,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2071,7 +2071,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2085,7 +2085,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2099,7 +2099,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2113,7 +2113,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2127,7 +2127,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2141,7 +2141,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2155,7 +2155,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2169,7 +2169,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2183,7 +2183,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2197,7 +2197,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2211,7 +2211,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2225,7 +2225,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2239,7 +2239,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2253,7 +2253,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2267,7 +2267,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2281,7 +2281,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2295,7 +2295,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2309,7 +2309,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2323,7 +2323,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2337,7 +2337,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2351,7 +2351,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2365,7 +2365,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2379,7 +2379,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2393,7 +2393,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2407,7 +2407,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2421,7 +2421,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2435,7 +2435,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2449,7 +2449,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2463,7 +2463,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2477,7 +2477,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2491,7 +2491,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2505,7 +2505,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2519,7 +2519,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2533,7 +2533,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2547,7 +2547,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2561,7 +2561,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2575,7 +2575,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2589,7 +2589,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2603,7 +2603,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2617,7 +2617,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2631,7 +2631,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2645,7 +2645,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2659,7 +2659,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2673,7 +2673,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2687,7 +2687,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2701,7 +2701,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2715,7 +2715,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2729,7 +2729,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2743,7 +2743,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2757,7 +2757,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2771,7 +2771,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2785,7 +2785,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2799,7 +2799,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2814,7 +2814,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2828,7 +2828,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2842,7 +2842,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2856,7 +2856,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2870,7 +2870,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2884,7 +2884,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2898,7 +2898,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2913,7 +2913,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2927,7 +2927,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2941,7 +2941,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2955,7 +2955,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2969,7 +2969,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2983,7 +2983,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -2997,7 +2997,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3011,7 +3011,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3025,7 +3025,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3039,7 +3039,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3053,7 +3053,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3067,7 +3067,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3081,7 +3081,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3095,7 +3095,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3109,7 +3109,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3123,7 +3123,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3137,7 +3137,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3151,7 +3151,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3165,7 +3165,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3179,7 +3179,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3193,7 +3193,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3207,7 +3207,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3221,7 +3221,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3235,7 +3235,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3249,7 +3249,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3263,7 +3263,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3277,7 +3277,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3291,7 +3291,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3305,7 +3305,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3319,7 +3319,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3333,7 +3333,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3347,7 +3347,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3361,7 +3361,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3375,7 +3375,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3389,7 +3389,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3403,7 +3403,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3417,7 +3417,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3431,7 +3431,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3445,7 +3445,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3459,7 +3459,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3473,7 +3473,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3487,7 +3487,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3501,7 +3501,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3515,7 +3515,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3529,7 +3529,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3543,7 +3543,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3557,7 +3557,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3571,7 +3571,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3585,7 +3585,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3599,7 +3599,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3613,7 +3613,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3627,7 +3627,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3641,7 +3641,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:
@@ -3655,7 +3655,7 @@ steps:
       pull-retries: 3
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   retry:
     automatic: true
   agents:

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -331,17 +331,17 @@ class RunTests(unittest.TestCase):
         fn.assert_not_called()
 
     def test_safe_shell_exec_captures_stdout(self):
-        self._do_test_safe_shell_exec('echo hello', 0, 'hello\n', '')
+        self.do_test_safe_shell_exec('echo hello', 0, 'hello\n', '')
 
     def test_safe_shell_exec_captures_stderr(self):
-        self._do_test_safe_shell_exec('echo hello >&2', 0, '', 'hello\n')
+        self.do_test_safe_shell_exec('echo hello >&2', 0, '', 'hello\n')
 
     def test_safe_shell_exec_captures_last_line_wo_eol(self):
         cmd = 'bash -c "echo -e -n \\"hello\nstdout\\"; echo -e -n \\"hello\nstderr\\" >&2"'
-        self._do_test_safe_shell_exec(cmd, 0, 'hello\nstdout', 'hello\nstderr')
+        self.do_test_safe_shell_exec(cmd, 0, 'hello\nstdout', 'hello\nstderr')
 
     def test_safe_shell_exec_returns_exit_code(self):
-        self._do_test_safe_shell_exec('false', 1, '', '')
+        self.do_test_safe_shell_exec('false', 1, '', '')
 
     def test_safe_shell_exec_interrupts_on_event(self):
         # interrupt execute in one second
@@ -350,7 +350,7 @@ class RunTests(unittest.TestCase):
 
         sleep = 10
         start = time.time()
-        self._do_test_safe_shell_exec('sleep {}'.format(sleep), 143, '', None, interrupt)
+        self.do_test_safe_shell_exec('sleep {}'.format(sleep), 143, '', None, interrupt)
         duration = time.time() - start
 
         self.assertGreaterEqual(duration, 1.0)
@@ -391,7 +391,7 @@ class RunTests(unittest.TestCase):
             self.assertFalse(parent.is_running())
             self.assertFalse(child.is_running())
 
-    def _do_test_safe_shell_exec(self, cmd, expected_exit_code, expected_stdout, expected_stderr, event=None):
+    def do_test_safe_shell_exec(self, cmd, expected_exit_code, expected_stdout, expected_stderr, event=None):
         stdout = six.StringIO()
         stderr = six.StringIO()
         res = safe_shell_exec.execute(cmd, stdout=stdout, stderr=stderr, events=[event])

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -20,17 +20,47 @@ from __future__ import print_function
 import unittest
 import threading
 import time
+import sys
 import warnings
 
+from distutils.version import LooseVersion
 from six.moves import queue
 
 import pytest
-import mock
-from mock import MagicMock
 
-import horovod
 from horovod.run.common.service.task_service import BasicTaskClient, BasicTaskService
-from horovod.run.common.util import secret
+from horovod.run.common.util import network, secret
+from horovod.run.util.threads import in_thread
+
+
+class SleepRequest(object):
+    pass
+
+
+class TestSleepService(network.BasicService):
+    def __init__(self, key, duration):
+        super(TestSleepService, self).__init__('test service', key, nics=None)
+        self._duration = duration
+
+    def _handle(self, req, client_address):
+        if isinstance(req, SleepRequest):
+            print('{}: sleeping for client {}'.format(time.time(), client_address))
+            time.sleep(self._duration)
+            return network.AckResponse()
+
+        return super(TestSleepService, self)._handle(req, client_address)
+
+
+class TestSleepClient(network.BasicClient):
+    def __init__(self, service_addresses, key, attempts=1):
+        super(TestSleepClient, self).__init__('test service',
+                                              service_addresses,
+                                              key,
+                                              verbose=2,
+                                              attempts=attempts)
+
+    def sleep(self):
+        self._send(SleepRequest())
 
 
 class NetworkTests(unittest.TestCase):
@@ -42,62 +72,47 @@ class NetworkTests(unittest.TestCase):
         super(NetworkTests, self).__init__(*args, **kwargs)
         warnings.simplefilter('module')
 
-    def test_concurrent_requests(self):
-        """
-        Tests the BasicTaskService can handle concurrent requests, as well as
-        the BasicTaskClient can sent requests from multiple threads.
-        A client executes a long running command and waits for termination.
-        That wait is a long running request. During wait a separate thread
-        polls the service for termination state.
-        """
-        def check_terminated(client, events):
-            (started, terminated, shutdown) = events
-            requests = 0
-            command_terminated = None
+    def test_concurrent_requests_basic(self):
+        sleep = 2.0
+        key = secret.make_secret_key()
+        service = TestSleepService(key, duration=sleep)
+        client = TestSleepClient(service.addresses(), key, attempts=1)
 
-            while not shutdown.is_set():
-                requests += 1
-                command_terminated = client.command_terminated()
-                if requests > 10:
-                    started.set()
-                if command_terminated:
-                    terminated.set()
-                    break
+        start = time.time()
+        threads = list([in_thread(client.sleep, daemon=False) for _ in range(1)])
+        for thread in threads:
+            thread.join(sleep + 1.0)
+            self.assertFalse(thread.is_alive(), 'thread should have terminated by now')
+        duration = time.time() - start
+        print('concurrent requests completed in {} seconds'.format(duration))
 
-            print('client contacted the service {} times'.format(requests))
-            self.assertTrue(command_terminated, msg='command should have terminated')
-            self.assertGreater(requests, 10, msg='we should have done at least some requests')
-            self.assertTrue(shutdown.wait(10.0), msg='main thread should have finished by now')
+        self.assertGreaterEqual(duration, sleep, 'sleep requests should have been completed')
+        self.assertLess(duration, sleep + 1.0, 'sleep requests should have been concurrent')
 
-        for multi_threaded_client in [False, True]:
-            key = secret.make_secret_key()
-            service_name = 'test-service'
-            service = BasicTaskService(service_name, key, nics=None, verbose=2)
+    @pytest.mark.skipif(sys.version_info < (3,0),
+                        reason='block on shutdown is supported in Spark 3.0 and above')
+    def test_shutdown_during_request_basic(self):
+        sleep = 2.0
+        key = secret.make_secret_key()
+        service = TestSleepService(key, duration=sleep)
+        client = TestSleepClient(service.addresses(), key, attempts=1)
 
-            client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
-            parallel_client = client if multi_threaded_client \
-                else BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+        start = time.time()
+        threads = list([in_thread(client.sleep, name='request {}'.format(i+1), daemon=False) for i in range(5)])
+        time.sleep(sleep / 2.0)
+        service.shutdown()
+        duration = time.time() - start
+        print('shutdown completed in {} seconds'.format(duration))
+        self.assertGreaterEqual(duration, sleep, 'sleep requests should have been completed')
+        self.assertLess(duration, sleep + 1.0, 'sleep requests should have been concurrent')
 
-            started = threading.Event()
-            terminated = threading.Event()
-            shutdown = threading.Event()
-            events = (started, terminated, shutdown)
-            thread = threading.Thread(target=check_terminated, args=(parallel_client, events))
-            thread.start()
-            self.assertTrue(started.wait(1.0), msg='thread should have started by now')
+        for thread in threads:
+            thread.join(0.1)
+            self.assertFalse(thread.is_alive(), 'thread should have terminated by now')
 
-            try:
-                client.run_command('sleep 1', env={})
-                client.wait_for_command_termination()
-                self.assertTrue(terminated.wait(1.0), msg='thread should have recognized termination')
-                self.assertTrue(thread.is_alive(), msg='thread should still be alive, check exceptions')
-            finally:
-                shutdown.set()
-                thread.join(1.0)
-
-            self.assertFalse(thread.is_alive(), msg='thread did not exit on term event')
-
-    def test_shutdown_during_request(self):
+    @pytest.mark.skipif(sys.version_info < (3,0),
+                        reason='block on shutdown is supported in Spark 3.0 and above')
+    def test_shutdown_during_request_basic_task(self):
         result_queue = queue.Queue(1)
 
         def wait_for_exit_code(client, queue):
@@ -114,15 +129,17 @@ class NetworkTests(unittest.TestCase):
         client.run_command('sleep 2', {})  # execute command
         time.sleep(0.5)  # give the thread some time to connect before shutdown
         service.shutdown()  # shutdown should wait on request to finish
+        duration = time.time() - start
+        self.assertGreaterEqual(duration, 2)
 
         # we cannot call after shutdown
-        with pytest.raises(Exception, match='^\\[Errno 104\\] Connection reset by peer$'):
+        with pytest.raises(Exception, match=r'^(\[[Ee]rrno 104\] Connection reset by peer)'
+                                            r'|(\[[Ee]rrno 111\] Connection refused)$'):
             client.command_result()
 
         # but still our long running request succeeded
-        thread.join(1)
-        duration = time.time() - start
-        self.assertGreater(duration, 2)
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
 
     def test_exit_code(self):
         """test non-zero exit code"""

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -116,7 +116,7 @@ class NetworkTests(unittest.TestCase):
         service.shutdown()  # shutdown should wait on request to finish
 
         # we cannot call after shutdown
-        with pytest.raises(ConnectionResetError, match='^\\[Errno 104\\] Connection reset by peer$'):
+        with pytest.raises(Exception, match='^\\[Errno 104\\] Connection reset by peer$'):
             client.command_result()
 
         # but still our long running request succeeded

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,0 +1,136 @@
+# Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import threading
+import time
+import warnings
+
+from six.moves import queue
+
+import pytest
+import mock
+from mock import MagicMock
+
+import horovod
+from horovod.run.common.service.task_service import BasicTaskClient, BasicTaskService
+from horovod.run.common.util import secret
+
+
+class NetworkTests(unittest.TestCase):
+    """
+    Tests for horovod.run.common.service.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(NetworkTests, self).__init__(*args, **kwargs)
+        warnings.simplefilter('module')
+
+    def test_concurrent_requests(self):
+        """
+        Tests the BasicTaskService can handle concurrent requests, as well as
+        the BasicTaskClient can sent requests from multiple threads.
+        A client executes a long running command and waits for termination.
+        That wait is a long running request. During wait a separate thread
+        polls the service for termination state.
+        """
+        def check_terminated(client, events):
+            (started, terminated, shutdown) = events
+            requests = 0
+            command_terminated = None
+
+            while not shutdown.is_set():
+                requests += 1
+                command_terminated = client.command_terminated()
+                if requests > 10:
+                    started.set()
+                if command_terminated:
+                    terminated.set()
+                    break
+
+            print('client contacted the service {} times'.format(requests))
+            self.assertTrue(command_terminated, msg='command should have terminated')
+            self.assertGreater(requests, 10, msg='we should have done at least some requests')
+            self.assertTrue(shutdown.wait(10.0), msg='main thread should have finished by now')
+
+        for multi_threaded_client in [False, True]:
+            key = secret.make_secret_key()
+            service_name = 'test-service'
+            service = BasicTaskService(service_name, key, nics=None, verbose=2)
+
+            client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+            parallel_client = client if multi_threaded_client \
+                else BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+
+            started = threading.Event()
+            terminated = threading.Event()
+            shutdown = threading.Event()
+            events = (started, terminated, shutdown)
+            thread = threading.Thread(target=check_terminated, args=(parallel_client, events))
+            thread.start()
+            self.assertTrue(started.wait(1.0), msg='thread should have started by now')
+
+            try:
+                client.run_command('sleep 1', env={})
+                client.wait_for_command_termination()
+                self.assertTrue(terminated.wait(1.0), msg='thread should have recognized termination')
+                self.assertTrue(thread.is_alive(), msg='thread should still be alive, check exceptions')
+            finally:
+                shutdown.set()
+                thread.join(1.0)
+
+            self.assertFalse(thread.is_alive(), msg='thread did not exit on term event')
+
+    def test_shutdown_during_request(self):
+        result_queue = queue.Queue(1)
+
+        def wait_for_exit_code(client, queue):
+            queue.put(client.wait_for_command_exit_code())
+
+        key = secret.make_secret_key()
+        service_name = 'test-service'
+        service = BasicTaskService(service_name, key, nics=None, verbose=2)
+        client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+        thread = threading.Thread(target=wait_for_exit_code, args=(client, result_queue))
+
+        start = time.time()
+        thread.start()  # wait for command exit code
+        client.run_command('sleep 2', {})  # execute command
+        time.sleep(0.5)  # give the thread some time to connect before shutdown
+        service.shutdown()  # shutdown should wait on request to finish
+
+        # we cannot call after shutdown
+        with pytest.raises(ConnectionResetError, match='^\\[Errno 104\\] Connection reset by peer$'):
+            client.command_result()
+
+        # but still our long running request succeeded
+        thread.join(1)
+        duration = time.time() - start
+        self.assertGreater(duration, 2)
+
+    def test_exit_code(self):
+        """test non-zero exit code"""
+        key = secret.make_secret_key()
+        service_name = 'test-service'
+        service = BasicTaskService(service_name, key, nics=None, verbose=2)
+        client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+
+        client.run_command('false', {})
+        res = client.wait_for_command_exit_code()
+        self.assertEqual(1, res)

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -82,6 +82,14 @@ class SparkTests(unittest.TestCase):
 
         super(SparkTests, self).run(result)
 
+    @pytest.mark.skipif(sys.version_info >= (3, 0), reason='Skipped on Python 3')
+    def test_run_throws_on_python2(self):
+        if not gloo_built():
+            self.skipTest("Gloo is not available")
+
+        with pytest.raises(Exception, match='^Horovod on Spark over Gloo only supported on Python3$'):
+            self.do_test_happy_run(use_mpi=False, use_gloo=True)
+
     """
     Test that horovod.spark.run works properly in a simple setup using MPI.
     """
@@ -94,7 +102,9 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run works properly in a simple setup using Gloo.
     """
-    def test_happy_run_wih_gloo(self):
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
+    def test_happy_run_with_gloo(self):
         if not gloo_built():
             self.skipTest("Gloo is not available")
 
@@ -128,6 +138,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run times out when it does not start up fast enough using Gloo.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_timeout_with_gloo(self):
         if not gloo_built():
             self.skipTest("Gloo is not available")
@@ -169,6 +181,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run uses Gloo properly.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_with_gloo(self):
         self.do_test_spark_run(use_mpi=False, use_gloo=True)
 
@@ -195,6 +209,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run does not default to spark parallelism given num_proc using Gloo.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_num_proc_precedes_spark_cores_with_gloo(self):
         self.do_test_spark_run_num_proc_precedes_spark_cores(use_mpi=False, use_gloo=True)
 
@@ -228,6 +244,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run defaults num_proc to spark parallelism using Gloo.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_defaults_num_proc_to_spark_cores_with_gloo(self):
         self.do_test_spark_run_defaults_num_proc_to_spark_cores(use_mpi=False, use_gloo=True)
 
@@ -248,6 +266,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run defaults env to the full system env using Gloo.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_does_not_default_env_to_os_env_with_gloo(self):
         self.do_test_spark_run_does_not_default_env_to_os_env(use_mpi=False, use_gloo=True)
 
@@ -274,6 +294,8 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using Gloo.
     """
+    @pytest.mark.skipif(sys.version_info < (3, 0),
+                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_with_non_zero_exit_with_gloo(self):
         expected = '^Gloo job detected that one or more processes exited with non-zero ' \
                    'status, thus causing the job to be terminated. The first process ' \

--- a/test/test_spark_keras.py
+++ b/test/test_spark_keras.py
@@ -20,12 +20,14 @@ import warnings
 
 import mock
 import numpy as np
+import sys
 import tensorflow as tf
 
 import pyspark.sql.types as T
 from pyspark.ml.linalg import DenseVector, SparseVector
 from pyspark.sql.functions import udf
 
+from horovod.run.runner import is_gloo_used
 import horovod.spark.keras as hvd
 from horovod.spark.common import constants, util
 from horovod.spark.keras import remote
@@ -72,6 +74,9 @@ class SparkKerasTests(tf.test.TestCase):
         warnings.simplefilter('module')
 
     def test_fit_model(self):
+        if sys.version_info < (3, 0, 0) and is_gloo_used():
+            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
+
         model = create_xor_model()
         optimizer = tf.keras.optimizers.SGD(lr=0.1)
         loss = 'binary_crossentropy'
@@ -100,6 +105,9 @@ class SparkKerasTests(tf.test.TestCase):
                 assert pred.dtype == np.float32
 
     def test_fit_model_multiclass(self):
+        if sys.version_info < (3, 0, 0) and is_gloo_used():
+            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
+
         model = create_mnist_model()
         optimizer = tf.keras.optimizers.Adadelta(1.0)
         loss = tf.keras.losses.categorical_crossentropy

--- a/test/test_spark_torch.py
+++ b/test/test_spark_torch.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import sys
 import unittest
 import warnings
 
@@ -29,6 +30,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 import torch.optim as optim
 
+from horovod.run.runner import is_gloo_used
 import horovod.spark.torch as hvd
 from horovod.spark.common import constants, util
 from horovod.spark.torch import remote
@@ -62,6 +64,9 @@ class SparkTorchTests(unittest.TestCase):
         warnings.simplefilter('module')
 
     def test_fit_model(self):
+        if sys.version_info < (3, 0, 0) and is_gloo_used():
+            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
+
         model = create_xor_model()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss = F.binary_cross_entropy


### PR DESCRIPTION
This completes the new Spark over Gloo implementation by making `exec_command` in `horovod.spark.gloo_run` wait for the command executed via `rsh` and return its exit code. Further it reacts on the given `event` and aborts the command in that case.

For this, the `BasicTaskClient` can send `WaitForCommandExitCodeRequest` which blocks until command terminates on the service and returns its exit code. Turns the polling loop that sends a `CommandTerminatedRequest` request every second into an event-base notification by pushing the loop into the service. In static Horovod over Spark these requests are sent over localhost, but elastic Horovod on Spark will use this to wait for training functions' termination, which would send a request per second to each task service over the network.

`BasicService` and `BasicClient` support concurrent requests. `horovod.spark.runner._task_fn` requires `service.shutdown` to wait for all running requests to finish. Every Spark worker runs `_task_fn`, which runs the task service. It waits on command completion and then shuts down the service again. In Spark over Gloo and Elastic Horovod over Spark (which uses gloo) we will launch those commands via `rsh`, which also waits for task completion to retrieve the command's exit code. If `service.shutdown` would not wait for those requests to finish, the driver would not retrieve exit codes and dies. This is only supported by setting  `BasicService._server._block_on_close = True`. This wait has no timeout so all requests are expected to terminate logically. There are unit tests that tests for this via `BasicTaskService` and `BasicTaskClient` /  `BasicService` and `BasicClient`.

**Note**: this includes https://github.com/horovod/horovod/pull/1860, https://github.com/horovod/horovod/pull/1869 and https://github.com/horovod/horovod/pull/1870 so should be reviewed / merged after that PR.