### PR TITLE
Move thread patterns into in_thread and on_event

### DIFF
--- a/horovod/run/common/service/task_service.py
+++ b/horovod/run/common/service/task_service.py
@@ -18,6 +18,7 @@ import time
 
 from horovod.run.common.util import network
 from horovod.run.common.util import safe_shell_exec
+from horovod.run.util.threads import in_thread
 
 
 class RunCommandRequest(object):
@@ -95,11 +96,10 @@ class BasicTaskService(network.BasicService):
                             print("Task service env: {} = {}".format(key, value))
 
                     # We only permit executing exactly one command, so this is idempotent.
-                    self._command_thread = threading.Thread(
+                    self._command_thread = in_thread(
                         target=safe_shell_exec.execute,
-                        args=(req.command, req.env))
-                    self._command_thread.daemon = True
-                    self._command_thread.start()
+                        args=(req.command, req.env)
+                    )
             finally:
                 self._wait_cond.notify_all()
                 self._wait_cond.release()

--- a/horovod/run/common/util/safe_shell_exec.py
+++ b/horovod/run/common/util/safe_shell_exec.py
@@ -145,7 +145,7 @@ def execute(command, env=None, stdout=None, stderr=None, index=None, event=None)
     stop = None
     if event is not None:
         stop = threading.Event()
-        on_event(event, os.kill, (middleman_pid, signal.SIGTERM), stop=stop)
+        on_event(event, os.kill, (middleman_pid, signal.SIGTERM), stop=stop, silent=True)
 
     try:
         res, status = os.waitpid(middleman_pid, 0)

--- a/horovod/run/common/util/safe_shell_exec.py
+++ b/horovod/run/common/util/safe_shell_exec.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 
+from horovod.run.util.threads import in_thread, on_event
 
 GRACEFUL_TERMINATION_TIME_S = 5
 
@@ -115,17 +116,9 @@ def execute(command, env=None, stdout=None, stderr=None, index=None, event=None)
             os.read(r, 1)
             terminate_executor_shell_and_children(executor_shell.pid)
 
-        bg = threading.Thread(target=kill_executor_children_if_parent_dies)
-        bg.daemon = True
-        bg.start()
+        in_thread(kill_executor_children_if_parent_dies)
 
-        def kill_executor_children_if_sigterm_received():
-            sigterm_received.wait()
-            terminate_executor_shell_and_children(executor_shell.pid)
-
-        bg = threading.Thread(target=kill_executor_children_if_sigterm_received)
-        bg.daemon = True
-        bg.start()
+        on_event(sigterm_received, terminate_executor_shell_and_children, args=executor_shell.pid)
 
         exit_code = executor_shell.wait()
         os._exit(exit_code)
@@ -142,26 +135,15 @@ def execute(command, env=None, stdout=None, stderr=None, index=None, event=None)
         stdout = sys.stdout
     if stderr is None:
         stderr = sys.stderr
-    stdout_fwd = threading.Thread(target=forward_stream, args=(stdout_r, stdout, 'stdout', index))
-    stderr_fwd = threading.Thread(target=forward_stream, args=(stderr_r, stderr, 'stderr', index))
-    stdout_fwd.start()
-    stderr_fwd.start()
 
-    def kill_middleman_if_master_thread_terminate():
-        event.wait()
-        try:
-            os.kill(middleman_pid, signal.SIGTERM)
-        except:
-            # The process has already been killed elsewhere
-            pass
+    stdout_fwd = in_thread(target=forward_stream, args=(stdout_r, stdout, 'stdout', index))
+    stderr_fwd = in_thread(target=forward_stream, args=(stderr_r, stderr, 'stderr', index))
 
     # TODO: Currently this requires explicitly declaration of the event and signal handler to set
     #  the event (gloo_run.py:_launch_jobs()). Need to figure out a generalized way to hide this behind
     #  interfaces.
     if event is not None:
-        bg_thread = threading.Thread(target=kill_middleman_if_master_thread_terminate)
-        bg_thread.daemon = True
-        bg_thread.start()
+        on_event(event, os.kill, (middleman_pid, signal.SIGTERM))
 
     try:
         res, status = os.waitpid(middleman_pid, 0)

--- a/horovod/run/common/util/safe_shell_exec.py
+++ b/horovod/run/common/util/safe_shell_exec.py
@@ -118,7 +118,7 @@ def execute(command, env=None, stdout=None, stderr=None, index=None, event=None)
 
         in_thread(kill_executor_children_if_parent_dies)
 
-        on_event(sigterm_received, terminate_executor_shell_and_children, args=executor_shell.pid)
+        on_event(sigterm_received, terminate_executor_shell_and_children, args=(executor_shell.pid,))
 
         exit_code = executor_shell.wait()
         os._exit(exit_code)

--- a/horovod/run/http/http_server.py
+++ b/horovod/run/http/http_server.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+
 import collections
+import socket
+import threading
 
 from six.moves import BaseHTTPServer, SimpleHTTPServer
+
+from horovod.run.util.threads import in_thread
 from horovod.run.util.network import find_port
-import threading
-import socket
 
 # Timeout for reading from a single request
 SINGLE_REQUEST_TIMEOUT = 3
@@ -190,9 +193,7 @@ class RendezvousServer:
             print('Rendezvous INFO: HTTP rendezvous server started.')
 
         # start the listening loop
-        self.listen_thread = threading.Thread(target=self.listen_loop)
-        self.listen_thread.daemon = True
-        self.listen_thread.start()
+        self.listen_thread = in_thread(target=self.listen_loop)
 
         return port
 
@@ -232,10 +233,7 @@ class KVStoreServer:
             lambda addr: KVStoreHTTPServer(
                 addr, KVStoreHandler, self.verbose))
 
-        self.listen_thread = threading.Thread(
-            target=lambda: self.httpd.serve_forever())
-        self.listen_thread.daemon = True
-        self.listen_thread.start()
+        self.listen_thread = in_thread(target=self.httpd.serve_forever)
 
         if self.verbose:
             print('KVStoreServer INFO: KVStore server started. Listen on port ' + str(port))

--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -136,12 +136,12 @@ def on_event(event, func, args=(), stop=None, check_interval_seconds=1.0, silent
     if stop is None:
         def fn():
             event.wait()
-            func()
+            func(*args)
     else:
         def fn():
             while not event.is_set() and not stop.is_set():
                 event.wait(timeout=check_interval_seconds)
             if not stop.is_set():
-                func()
+                func(*args)
 
-    return in_thread(fn, args, silent=silent)
+    return in_thread(fn, silent=silent)

--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -101,6 +101,10 @@ def in_thread(target, args=(), daemon=True, silent=False):
     :param silent: swallows exceptions raised by target silently
     :return background thread
     """
+    if not isinstance(args, tuple):
+        raise ValueError('args must be a tuple, not {}, for a single argument use (arg,)'
+                         .format(type(args)))
+
     if silent:
         def fn(*args):
             try:
@@ -133,6 +137,10 @@ def on_event(event, func, args=(), stop=None, check_interval_seconds=1.0, silent
     :param silent: swallows exceptions raised by target silently
     :return: thread
     """
+    if not isinstance(args, tuple):
+        raise ValueError('args must be a tuple, not {}, for a single argument use (arg,)'
+                         .format(type(args)))
+
     if stop is None:
         def fn():
             event.wait()

--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -63,10 +63,7 @@ def execute_function_multithreaded(fn,
     number_of_threads = min(max_concurrent_executions, len(args_list))
 
     for _ in range(number_of_threads):
-        thread = threading.Thread(target=fn_execute)
-        if not block_until_all_done:
-            thread.daemon = True
-        thread.start()
+        thread = in_thread(target=fn_execute, daemon=not block_until_all_done)
         threads.append(thread)
 
     # Returns the results only if block_until_all_done is set.
@@ -93,3 +90,58 @@ def execute_function_multithreaded(fn,
                 'Some threads for func {func} did not complete '
                 'successfully.'.format(func=fn.__name__))
     return results
+
+
+def in_thread(target, args=(), daemon=True, silent=False):
+    """
+    Executes the given function in background.
+    :param target: function
+    :param args: function arguments
+    :param daemon: run as daemon thread, do not block until thread is doe
+    :param silent: swallows exceptions raised by target silently
+    :return background thread
+    """
+    if silent:
+        def fn(*args):
+            try:
+                target(*args)
+            except:
+                pass
+        target = fn
+
+    bg = threading.Thread(target=target, args=args)
+    bg.daemon = daemon
+    bg.start()
+    return bg
+
+
+def on_event(event, func, args=(), stop=None, check_interval_seconds=1.0, silent=False):
+    """
+    Executes the given function in a separate thread when event is set.
+    That threat can be stopped by setting the optional stop event.
+    The stop event is check regularly every check_interval_seconds.
+    Exceptions will silently be swallowed when silent is True.
+
+    :param event: event that triggers func
+    :type event: threading.Event
+    :param func: function to trigger
+    :param args: function arguments
+    :param stop: event to stop thread
+    :type stop: threading.Event
+    :param check_interval_seconds: interval in seconds to check the stop event
+    :type check_interval_seconds: float
+    :param silent: swallows exceptions raised by target silently
+    :return: thread
+    """
+    if stop is None:
+        def fn():
+            event.wait()
+            func()
+    else:
+        def fn():
+            while not event.is_set() and not stop.is_set():
+                event.wait(timeout=check_interval_seconds)
+            if not stop.is_set():
+                func()
+
+    return in_thread(fn, args, silent=silent)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -15,11 +15,11 @@
 
 import os
 import platform
-import threading
 
 import pyspark
 from six.moves import queue
 
+from horovod.run.util.threads import in_thread
 from horovod.spark.task import task_service
 from horovod.spark.gloo_run import gloo_run
 from horovod.spark.mpi_run import mpi_run
@@ -103,8 +103,7 @@ def _make_spark_thread(spark_context, spark_job_group, driver, result_queue,
             driver.notify_spark_job_failed()
             raise
 
-    spark_thread = threading.Thread(target=run_spark)
-    spark_thread.start()
+    spark_thread = in_thread(target=run_spark, daemon=False)
     return spark_thread
 
 

--- a/horovod/spark/task/__init__.py
+++ b/horovod/spark/task/__init__.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 
 import os
-import threading
 import time
 
+from horovod.run.util.threads import in_thread
 from horovod.spark.task import task_info, task_service
 from horovod.spark.task.task_info import get_available_devices
 from horovod.spark.driver import driver_service
@@ -37,9 +37,7 @@ def _parent_process_monitor(initial_ppid):
 
 def task_exec(driver_addresses, settings, rank_env):
     # Die if parent process terminates
-    bg = threading.Thread(target=_parent_process_monitor, args=(os.getppid(),))
-    bg.daemon = True
-    bg.start()
+    in_thread(target=_parent_process_monitor, args=(os.getppid(),))
 
     key = codec.loads_base64(os.environ[secret.HOROVOD_SECRET_KEY])
     rank = int(os.environ[rank_env])

--- a/test/common.py
+++ b/test/common.py
@@ -23,8 +23,11 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 
 import mock
+
+from horovod.run.util.threads import in_thread
 
 
 def mpi_env_rank_and_size():
@@ -61,6 +64,14 @@ def mpi_env_rank_and_size():
     # Default to rank zero and size one if there are no environment variables
     return 0, 1
 
+
+def delay(func, seconds):
+    """Delays the execution of func in a separate thread by given seconds."""
+    def fn():
+        time.sleep(seconds)
+        func()
+
+    t = in_thread(target=fn)
 
 @contextlib.contextmanager
 def tempdir():

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -232,7 +232,7 @@ class RunTests(unittest.TestCase):
         fn.assert_called_once_with(1, 2)
 
         fn = mock.Mock()
-        with pytest.raises(ValueError, match="^args must be a tuple, not <class 'int'>, "
+        with pytest.raises(ValueError, match="^args must be a tuple, not <(class|type) 'int'>, "
                                              "for a single argument use \\(arg,\\)$"):
             in_thread(fn, args=1)
         fn.assert_not_called()
@@ -313,7 +313,7 @@ class RunTests(unittest.TestCase):
         # test non-tuple args
         event = threading.Event()
         fn = mock.Mock()
-        with pytest.raises(ValueError, match="^args must be a tuple, not <class 'int'>, "
+        with pytest.raises(ValueError, match="^args must be a tuple, not <(class|type) 'int'>, "
                                              "for a single argument use \\(arg,\\)$"):
             on_event(event, fn, args=1)
         fn.assert_not_called()

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 import copy
 import os
 import itertools
+import threading
+import time
 import unittest
 import warnings
 
@@ -30,11 +32,12 @@ from mock import MagicMock
 import horovod
 from horovod.run.common.util import codec, config_parser, secret, settings as hvd_settings, timeout
 from horovod.run.common.util.host_hash import _hash, host_hash
+from horovod.run.js_run import js_run, generate_jsrun_rankfile
 from horovod.run.mpi_run import _get_mpi_implementation, _get_mpi_implementation_flags,\
     _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_available, mpi_run,\
     _OMPI_IMPL, _SMPI_IMPL, _MPICH_IMPL, _UNKNOWN_IMPL, _MISSING_IMPL
 from horovod.run.runner import parse_args, parse_host_files, run_controller
-from horovod.run.js_run import js_run, generate_jsrun_rankfile
+from horovod.run.util.threads import on_event
 
 from common import is_built, lsf_and_jsrun, override_args, override_env, temppath
 
@@ -213,6 +216,79 @@ class RunTests(unittest.TestCase):
                            '--fusion-threshold-mb', '-1'):
             with pytest.raises(ValueError):
                 parse_args()
+
+    def test_on_event(self):
+        # a happy run without args and stop event
+        event = threading.Event()
+        fn = mock.Mock()
+        thread = on_event(event, fn)
+        fn.assert_not_called()
+        event.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once()
+
+        # a happy run with args but without stop event
+        event = threading.Event()
+        fn = mock.Mock()
+        thread = on_event(event, fn, ('a', 1))
+        fn.assert_not_called()
+        event.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once()
+        fn.assert_called_once_with('a', 1)
+
+        # a happy run with stop event but unused
+        event = threading.Event()
+        stop = threading.Event()
+        fn = mock.Mock()
+        thread = on_event(event, fn, stop=stop, check_interval_seconds=0.01)
+        fn.assert_not_called()
+        event.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once()
+        stop.set()
+        time.sleep(0.1)
+        fn.assert_called_once()
+
+        # stop the thread before we set the event
+        event = threading.Event()
+        stop = threading.Event()
+        fn = mock.Mock()
+        thread = on_event(event, fn, stop=stop, check_interval_seconds=0.01)
+        fn.assert_not_called()
+        stop.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_not_called()
+        event.set()
+        time.sleep(0.1)
+        fn.assert_not_called()
+
+        # test with exception
+        def exception():
+            raise Exception("Test Exception")
+
+        event = threading.Event()
+        fn = mock.Mock(side_effect=exception)
+        thread = on_event(event, fn)
+        fn.assert_not_called()
+        event.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once()
+
+        # test with exception but silent
+        event = threading.Event()
+        fn = mock.Mock(side_effect=exception)
+        thread = on_event(event, fn)
+        fn.assert_not_called()
+        event.set()
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once()
 
     def test_hash(self):
         hash = _hash("test string")


### PR DESCRIPTION
- Create a (daemon) thread with a single line: in_thread
- Create a thread that executes a function on an event: on_event
- Create a method that delays a parallel function call (for testing): delay
- Clean-up wait-on-event thread in safe_shell_exec