### PR TITLE
Fix stdout / stderr reading issue and add tests

### DIFF
--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -111,9 +111,10 @@ def in_thread(target, args=(), daemon=True, silent=False):
                 target(*args)
             except:
                 pass
-        target = fn
+    else:
+        fn = target
 
-    bg = threading.Thread(target=target, args=args)
+    bg = threading.Thread(target=fn, args=args)
     bg.daemon = daemon
     bg.start()
     return bg

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -232,6 +232,12 @@ class RunTests(unittest.TestCase):
         fn.assert_called_once_with(1, 2)
 
         fn = mock.Mock()
+        thread = in_thread(fn, args=(1, 2), silent=True)
+        thread.join(1.0)
+        self.assertFalse(thread.is_alive())
+        fn.assert_called_once_with(1, 2)
+
+        fn = mock.Mock()
         with pytest.raises(ValueError, match="^args must be a tuple, not <(class|type) 'int'>, "
                                              "for a single argument use \\(arg,\\)$"):
             in_thread(fn, args=1)


### PR DESCRIPTION
The `forward_stream` method in `safe_shell_exec` looses the last line of stdout / stderr if it does not end with an EOL. Also adds tests around `safe_shell_exec.execute`.

**Note**: This includes PR https://github.com/horovod/horovod/pull/1869 so should be reviewed / merged after that.