### PR TITLE
Various changes to improve latency of background thread loop.

### DIFF
--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -324,6 +324,10 @@ void Response::add_tensor_name(const std::string& value) {
   tensor_names_.push_back(value);
 }
 
+void Response::add_tensor_name(std::string&& value) {
+  tensor_names_.push_back(std::move(value));
+}
+
 const std::string& Response::error_message() const { return error_message_; }
 
 void Response::set_error_message(const std::string& value) {
@@ -427,6 +431,10 @@ void ResponseList::set_shutdown(bool value) { shutdown_ = value; }
 
 void ResponseList::add_response(const Response& value) {
   responses_.push_back(value);
+}
+
+void ResponseList::add_response(Response&& value) {
+  responses_.push_back(std::move(value));
 }
 
 void ResponseList::emplace_response(Response&& value) {

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -154,6 +154,8 @@ public:
 
   void add_tensor_name(const std::string& value);
 
+  void add_tensor_name(std::string&& value);
+
   // Empty unless response_type is ERROR.
   const std::string& error_message() const;
 
@@ -198,6 +200,8 @@ public:
   void set_responses(const std::vector<Response>& value);
 
   void add_response(const Response& value);
+
+  void add_response(Response&& value);
 
   void emplace_response(Response&& value);
 

--- a/horovod/common/tensor_queue.h
+++ b/horovod/common/tensor_queue.h
@@ -46,6 +46,8 @@ public:
 
   void PushMessageToQueue(Request& message);
 
+  void PushMessagesToQueue(std::deque<Request>& messages);
+
   void RemoveJoinTensor();
 
 protected:

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ def get_supported_instruction_set_flags(flags_to_check):
 
 def get_cpp_flags(build_ext):
     last_err = None
-    default_flags = ['-std=c++11', '-fPIC', '-O2', '-Wall', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
+    default_flags = ['-std=c++11', '-fPIC', '-O3', '-Wall', '-fassociative-math', '-ffast-math', '-ftree-vectorize', '-funsafe-math-optimizations']
     build_arch_flags_env = os.environ.get('HOROVOD_BUILD_ARCH_FLAGS')
     build_arch_flags = get_supported_instruction_set_flags(['-mf16c', '-mavx', '-mfma']) if build_arch_flags_env is None else build_arch_flags_env.split()
     if sys.platform == 'darwin':
@@ -1154,7 +1154,7 @@ def is_torch_cuda():
             headers=['horovod/torch/dummy.h'],
             sources=[],
             with_cuda=True,
-            extra_compile_args=['-std=c11', '-fPIC', '-O2']
+            extra_compile_args=['-std=c11', '-fPIC', '-O3']
         )
         cuda_test_ext.build()
         return True
@@ -1282,7 +1282,7 @@ def build_torch_extension(build_ext, global_options, torch_version):
             language='c',
             package=True,
             sources=[],
-            extra_compile_args=['-std=c11', '-fPIC', '-O2']
+            extra_compile_args=['-std=c11', '-fPIC', '-O3']
         )
         ffi_impl = create_extension(
             name='horovod.torch.mpi_lib_impl',


### PR DESCRIPTION
This PR contains mostly small changes to improve the latency of the background thread loop. Mostly comprised of using references and `std::move` when possible to avoid extraneous copies. Also introduces `TensorQueue::PushMessagesToQueue` method to avoid repeatedly taking a lock on a mutex when replacing uncached messages to the state queue in the previous logic when each message was replaced individually with `TensorQueue::PushMessageToQueue`. Lastly, changes default CPU compilation flags to `-O3` from `-O2`.
