### PR TITLE
Enable setting Horovod background thread affinity in general.

### DIFF
--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -85,6 +85,7 @@ namespace common {
 #define HOROVOD_CCL "CCL"
 #define HOROVOD_GLOO "GLOO"
 #define HOROVOD_ADASUM_MPI_CHUNK_SIZE "HOROVOD_ADASUM_MPI_CHUNK_SIZE"
+#define HOROVOD_THREAD_AFFINITY "HOROVOD_THREAD_AFFINITY"
 
 // String constant for gloo interface.
 #define GLOO_DEFAULT_IFACE ""
@@ -248,6 +249,9 @@ struct TensorTableEntry {
   StatusCallback callback;
 };
 using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
+
+// Set affinity function
+void server_affinity_set(int affinity);
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -331,8 +331,19 @@ void PerformOperation(Response response, HorovodGlobalState& state) {
 bool RunLoopOnce(HorovodGlobalState& state);
 
 void BackgroundThreadLoop(HorovodGlobalState& state) {
-  // Initialize ccl context
+  // Set background thread affinity
+  auto horovod_thread_affinity = std::getenv(HOROVOD_THREAD_AFFINITY);
 #if HAVE_CCL
+  if (horovod_thread_affinity != nullptr) {
+    horovod_thread_affinity = std::getenv(HOROVOD_CCL_BGT_AFFINITY);
+  }
+#endif
+  if (horovod_thread_affinity != nullptr) {
+      int core = std::strtol(horovod_thread_affinity, nullptr, 10);
+      server_affinity_set(core);
+  }
+#if HAVE_CCL
+  // Initialize ccl context
   if (state.cpu_operation == LibType::CCL) {
     ccl_context.Init();
   }


### PR DESCRIPTION
This PR converts the ability to set the Horovod background thread affinity from a CCL backend specific option to one that is generally available. This is controllable via the new environment variable `HOROVOD_THREAD_AFFINITY`. The behavior of the existing `HOROVOD_CCL_BGT_AFFINITY` environment variable is retained. 