### PR TITLE
Use parameter names when scheduling broadcasts in MXNet broadcast_parameters.

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -151,4 +151,4 @@ def broadcast_parameters(params, root_rank=0):
 
     # Run broadcasts.
     for tensor, name in zip(tensors, names):
-        broadcast_(tensor, root_rank, name=name)
+        broadcast_(tensor, root_rank, name=str(name))

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -113,7 +113,7 @@ def _append_broadcast_init(param, root_rank):
     init_impl = getattr(param, '_init_impl')
     def wrapped_init_impl(self, *args, **kwargs):
         init_impl(*args, **kwargs)
-        broadcast_(self.data(), root_rank=root_rank)
+        broadcast_(self.data(), root_rank=root_rank, name=self.name)
     return wrapped_init_impl
 
 
@@ -133,12 +133,14 @@ def broadcast_parameters(params, root_rank=0):
     if size() == 1: return
 
     tensors = []
+    names = []
     if isinstance(params, dict):
-        tensors = [p for _, p in sorted(params.items())]
+        names, tensors = zip(*params.items())
     elif isinstance(params, mx.gluon.parameter.ParameterDict):
-        for _, p in sorted(params.items()):
+        for name, p in sorted(params.items()):
             try:
                 tensors.append(p.data())
+                names.append(name)
             except mx.gluon.parameter.DeferredInitializationError:
                 # Inject wrapper method with post-initialization broadcast to
                 # handle parameters with deferred initialization
@@ -148,5 +150,5 @@ def broadcast_parameters(params, root_rank=0):
         raise ValueError('invalid params of type: %s' % type(params))
 
     # Run broadcasts.
-    for i, tensor in enumerate(tensors):
-        broadcast_(tensor, root_rank, str(i))
+    for tensor, name in zip(tensors, names):
+        broadcast_(tensor, root_rank, name=name)


### PR DESCRIPTION
Fixes a bug introduced by #1718. In that commit, some syncs were removed in `broadcast_parameters`. This led to an issue where back to back calls to `broadcast_parameters` would possibly crash due to duplicate name usage, as the broadcast calls within that function use `str(i)` for naming, where `i` is just an index in the list of tensors. 
These back to back calls commonly arise when running symbolic models in MXNet, for example in the MXNet RN50 example script:
```
    # Horovod: fetch and broadcast parameters
    (arg_params, aux_params) = mod.get_params()
    if arg_params is not None:
        hvd.broadcast_parameters(arg_params, root_rank=0)
    if aux_params is not None:
        hvd.broadcast_parameters(aux_params, root_rank=0)
```

To fix this, we can replace the `str(i)` naming for the broadcasts with the actual parameter names. 

On a similar note, I also added parameter name usage to the broadcasts in `wrapped_init_impl` since I also think this is required. Unless there is a guaranteed ordering of deferred initializations, letting Horovod generate default names, which are based on an atomically increasing index, for these broadcasts is unsafe. 