### PR TITLE
Move task address registration into lancher

### DIFF
--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -134,7 +134,7 @@ class BasicService(object):
         return result
 
     def addresses(self):
-        return self._addresses
+        return self._addresses.copy()
 
     def shutdown(self):
         self._server.shutdown()

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -106,7 +106,9 @@ class SparkTests(unittest.TestCase):
 
         with spark_session('test_happy_run'):
             with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
-                res = horovod.spark.run(fn, use_mpi=use_mpi, use_gloo=use_gloo, verbose=2)
+                res = horovod.spark.run(fn, start_timeout=10,
+                                        use_mpi=use_mpi, use_gloo=use_gloo,
+                                        verbose=2)
                 self.assertListEqual([([0, 1], 0), ([0, 1], 1)], res)
 
     """
@@ -149,7 +151,7 @@ class SparkTests(unittest.TestCase):
             with is_built(gloo_is_built=False, mpi_is_built=True):
                 with mpi_implementation_flags():
                     with pytest.raises(Exception, match='^mpirun failed with exit code 127$'):
-                        horovod.spark.run(None, env={'PATH': '/nonexistent'}, verbose=0)
+                        horovod.spark.run(None, start_timeout=20, env={'PATH': '/nonexistent'}, verbose=0)
         self.assertLessEqual(time.time() - start, 10, 'Failure propagation took too long')
 
     """
@@ -295,7 +297,7 @@ class SparkTests(unittest.TestCase):
                     with spark_session('test_spark_run'):
                         with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
                             with pytest.raises(Exception, match=expected):
-                                horovod.spark.run(fn, use_mpi=use_mpi, use_gloo=use_gloo, verbose=2)
+                                horovod.spark.run(fn, start_timeout=10, use_mpi=use_mpi, use_gloo=use_gloo, verbose=2)
 
     """
     Performs an actual horovod.spark.run test using MPI or Gloo.


### PR DESCRIPTION
In Elastic Horovod on Spark we have to refactor the `_task_fn` because tasks that start after initial registration of `num_proc` will still need to go through the task-to-task-addresses registration, but tasks do not have enough knowledge about 'the next task', so the driver node should decide which task registers which 'neighbour' task's addresses.

Notable change is that the task service now creates a task client, connects to the neighbour task service and returns the addresses to the service's client: https://github.com/horovod/horovod/pull/1896/files#diff-01388c5900727b90e6d99c70abc42d7aR79-R87

**Question**: `horovod.run.driver.driver_service._driver_fn` uses the same logic to determine task-to-task-addresses from the Horovod workers. That logic could be refactored as well so that Spark and non-Spark code paths use same client-service interaction.