### PR TITLE
Fix compilation on macOS by disabling HOROVOD_THREAD_AFFINITY

### DIFF
--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -113,6 +113,7 @@ int64_t TensorShape::num_elements() const {
 
 const std::vector<int64_t>& TensorShape::to_vector() const { return shape_; }
 
+#ifdef __linux__
 void server_affinity_set(int affinity) {
   cpu_set_t cpuset;
   pthread_t current_thread = pthread_self();
@@ -135,6 +136,12 @@ void server_affinity_set(int affinity) {
     }
   }
 }
+#else
+void server_affinity_set(int affinity) {
+  // TODO(travis): explore equivalent for macOS
+  throw std::runtime_error("Environment variable HOROVOD_THREAD_AFFINITY is not supported on macOS.");
+}
+#endif
 
 } // namespace common
 } // namespace horovod

--- a/setup.py
+++ b/setup.py
@@ -581,7 +581,7 @@ def get_common_options(build_ext):
     cpp_flags = get_cpp_flags(build_ext)
     link_flags = get_link_flags(build_ext)
 
-    is_mac = os.uname()[0] == 'Darwin'
+    is_mac = sys.platform == 'darwin'
     compile_without_gloo = os.environ.get('HOROVOD_WITHOUT_GLOO')
     if compile_without_gloo:
         print('INFO: HOROVOD_WITHOUT_GLOO detected, skip compiling Horovod with Gloo.')


### PR DESCRIPTION
#1881 uses instructions not available on macOS.  This change avoids compiling with those instructions outside of Linux operating systems.

Signed-off-by: Travis Addair <taddair@uber.com>