### PR TITLE
mxnet: add fp16 compression

### DIFF
--- a/examples/mxnet_imagenet_resnet50.py
+++ b/examples/mxnet_imagenet_resnet50.py
@@ -89,7 +89,8 @@ parser.add_argument('--log-interval', type=int, default=0,
                     help='number of batches to wait before logging (default: 0)')
 parser.add_argument('--save-frequency', type=int, default=0,
                     help='frequency of model saving (default: 0)')
-
+parser.add_argument('--fp16-allreduce', action='store_true', default=False,
+                    help='enable fp16 allreduce (default: False)')
 
 args = parser.parse_args()
 
@@ -322,7 +323,8 @@ def train_gluon():
     opt = mx.optimizer.create('sgd', **optimizer_params)
 
     # Horovod: create DistributedTrainer, a subclass of gluon.Trainer
-    trainer = hvd.DistributedTrainer(params, opt)
+    compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
+    trainer = hvd.DistributedTrainer(params, opt, compression=compression)
 
     # Create loss function and train metric
     loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/examples/mxnet_mnist.py
+++ b/examples/mxnet_mnist.py
@@ -24,6 +24,8 @@ parser.add_argument('--momentum', type=float, default=0.9,
                     help='SGD momentum (default: 0.9)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disable training on GPU (default: False)')
+parser.add_argument('--fp16-allreduce', action='store_true', default=False,
+                    help='enable fp16 allreduce (default: False)')
 args = parser.parse_args()
 
 if not args.no_cuda:
@@ -128,7 +130,8 @@ if params is not None:
     hvd.broadcast_parameters(params, root_rank=0)
 
 # Horovod: create DistributedTrainer, a subclass of gluon.Trainer
-trainer = hvd.DistributedTrainer(params, opt)
+compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
+trainer = hvd.DistributedTrainer(params, opt, compression=compression)
 
 # Create loss function and train metric
 loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/horovod/mxnet/compression.py
+++ b/horovod/mxnet/compression.py
@@ -66,7 +66,7 @@ class FP16Compressor(Compressor):
 
 
 class Compression(object):
-    """Optional gradient compression algorithm used during push_pull."""
+    """Optional gradient compression algorithm used during allreduce."""
 
     """Do not compress the gradients. This is the default."""
     none = NoneCompressor

--- a/horovod/mxnet/compression.py
+++ b/horovod/mxnet/compression.py
@@ -1,0 +1,75 @@
+# Copyright 2020 Amazon Inc. All Rights Reserved.
+# Copyright 2018 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Gradient compression algorithms."""
+
+import mxnet
+
+
+class Compressor(object):
+    """Interface for compressing and decompressing a given tensor."""
+    @staticmethod
+    def compress(tensor):
+        """Compresses a tensor and returns it with the context needed to decompress it."""
+        pass
+
+    @staticmethod
+    def decompress(tensor, ctx):
+        """Decompress the tensor with the given context."""
+        pass
+
+
+class NoneCompressor(Compressor):
+    """Default no-op compression."""
+    @staticmethod
+    def compress(tensor):
+        """Returns the tensor unmodified."""
+        return tensor, None
+
+    @staticmethod
+    def decompress(tensor, ctx):
+        """Returns the tensor unmodified."""
+        return tensor
+
+
+class FP16Compressor(Compressor):
+    """Compress all floating point gradients to 16-bit."""
+    @staticmethod
+    def compress(tensor):
+        """Downcasts the tensor to 16-bit."""
+        tensor_compressed = tensor
+        if 'float' in str(tensor.dtype):
+            # Only allow compression from other floating point types
+            tensor_compressed = tensor.astype('float16', copy=False)
+        return tensor_compressed, tensor.dtype
+
+    @staticmethod
+    def decompress(tensor, ctx):
+        """Upcasts the tensor to the initialization dtype."""
+        tensor_decompressed = tensor
+        dtype = ctx
+        if 'float' in str(dtype):
+            tensor_decompressed = tensor.astype(dtype, copy=False)
+        return tensor_decompressed
+
+
+class Compression(object):
+    """Optional gradient compression algorithm used during push_pull."""
+
+    """Do not compress the gradients. This is the default."""
+    none = NoneCompressor
+
+    """Compress all floating point gradients to 16-bit."""
+    fp16 = FP16Compressor

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -634,7 +634,6 @@ class MXTests(unittest.TestCase):
         net.hybridize(static_alloc=True)
 
         params = net.collect_params()
-        cnt = 0
         lr = 1E-4
         compression = hvd.Compression.fp16
         trainer = hvd.DistributedTrainer(
@@ -646,15 +645,9 @@ class MXTests(unittest.TestCase):
             with mx.autograd.record():
                 pred = net(src_data)
                 loss = mx.nd.abs(pred - dst_data).mean()
-                loss.backward()
+            loss.backward()
             # Begin to update the parameter
             trainer.step(1.0)
-            cnt += 1
-            l = loss.asscalar()
-            if cnt >= 10:
-                for key, param in params.items():
-                    hvd.allreduce_(param.list_data()[0])
-                cnt = 0
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
since horovod for mxnet supports allreduce for temporary tensors https://github.com/horovod/horovod/pull/1639 , a simple wrapper like this is sufficient.  

```python
    for i, param in enumerate(self._params):
            if param.grad_req != 'null':
                compressed, ctx = self._compression.compress(param.list_grad()[0])
                allreduce_(compressed, average=False,
                           name=param.name, priority=-i)
                param._grad[0] = self._compression.decompress(compressed, ctx)
```