### PR TITLE
Pass verbose from Estimator to SparkBackend

### DIFF
--- a/horovod/spark/common/estimator.py
+++ b/horovod/spark/common/estimator.py
@@ -84,7 +84,7 @@ class HorovodEstimator(Estimator, EstimatorParams):
     def _get_or_create_backend(self):
         backend = self.getBackend()
         if backend is None:
-            backend = SparkBackend(self.getNumProc())
+            backend = SparkBackend(self.getNumProc(), verbose=self.getVerbose())
         elif self.getNumProc() is not None:
             raise ValueError('At most one of parameters "backend" and "num_proc" may be specified')
         return backend


### PR DESCRIPTION
When I run the following code, currently I can not see the verbose=2 log from horovod.spark.runner like the generated mpirun command. We can create SparkBackend by using this verbose value to see the logs.

```
keras_estimator = hvd.KerasEstimator(num_proc=args.num_proc,
                                     store=store,
                                     model=model,
                                     optimizer=opt,
                                     loss='mae',
                                     metrics=[exp_rmspe],
                                     custom_objects=CUSTOM_OBJECTS,
                                     feature_cols=all_cols,
                                     label_cols=['Sales'],
                                     validation='Validation',
                                     batch_size=args.batch_size,
                                     epochs=args.epochs,
                                     verbose=2)
```