### PR TITLE
Sync Batch Norm for PyTorch

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -156,3 +156,79 @@
    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   pytorch
+   From PyTorch:
+
+   Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+   Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+   Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+   Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+   Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+   Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+   Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+   Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+   Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+
+   From Caffe2:
+
+   Copyright (c) 2016-present, Facebook Inc. All rights reserved.
+
+   All contributions by Facebook:
+   Copyright (c) 2016 Facebook Inc.
+   
+   All contributions by Google:
+   Copyright (c) 2015 Google Inc.
+   All rights reserved.
+   
+   All contributions by Yangqing Jia:
+   Copyright (c) 2015 Yangqing Jia
+   All rights reserved.
+   
+   All contributions from Caffe:
+   Copyright(c) 2013, 2014, 2015, the respective contributors
+   All rights reserved.
+   
+   All other contributions:
+   Copyright(c) 2015, 2016 the respective contributors
+   All rights reserved.
+   
+   Caffe2 uses a copyright model similar to Caffe: each contributor holds
+   copyright over their contributions to Caffe2. The project versioning records
+   all such contribution and copyright details. If a contributor wants to further
+   mark their specific copyright on a particular contribution, they should
+   indicate their copyright solely in the commit message of the change when it is
+   committed.
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+      and IDIAP Research Institute nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+
+   The derived work can be found in the files:
+
+        - horovod/torch/sync_batch_norm.py

--- a/docs/mocks.py
+++ b/docs/mocks.py
@@ -65,6 +65,9 @@ MOCK_MODULES = [
     'keras.backend',
 
     'torch',
+    'torch.autograd.function',
+    'torch.nn.functional',
+    'torch.nn.modules.batchnorm',
     'torch.utils',
     'torch.utils.data',
     'torch.utils.tensorboard',

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -52,6 +52,7 @@ from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built
 from horovod.torch.mpi_ops import nccl_built, ddl_built, ccl_built
 from horovod.torch.mpi_ops import Average, Sum, Adasum
+from horovod.torch.sync_batch_norm import SyncBatchNorm
 
 import torch
 import collections

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -24,6 +24,11 @@ import torch.nn.functional as F
 from torch.nn.modules.batchnorm import _BatchNorm
 
 
+# Backward compat for old PyTorch
+if not hasattr(torch.jit, 'unused'):
+    torch.jit.unused = lambda x: x
+
+
 class SyncBatchNorm(_BatchNorm):
     """
     Applies synchronous version of N-dimensional BatchNorm.  In this version, normalization

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -62,7 +62,7 @@ class SyncBatchNorm(_BatchNorm):
         if self.training and self.track_running_stats:
             self.num_batches_tracked = self.num_batches_tracked + 1
 
-        if size() == 1 or (not self.training and self.track_running_stats):
+        if (not self.training and self.track_running_stats) or size() == 1:
             return F.batch_norm(
                 input, self.running_mean, self.running_var, self.weight, self.bias,
                 self.training or not self.track_running_stats, self.momentum, self.eps)

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -92,8 +92,6 @@ class _SyncBatchNorm(Function):
         input = input.contiguous()
 
         size = input.numel() // input.size(1)
-        if size == 1:
-            raise ValueError('Expected more than 1 value per channel when training, got input size {}'.format(size))
         count = torch.tensor([size])
 
         # calculate mean/invstd for input.

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -1,0 +1,175 @@
+# Based on https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/_functions.py
+# Modifications copyright 2020 Maka Autonomous Robotic Systems
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from horovod.torch.mpi_ops import allgather_async, allreduce_async, Sum, size, synchronize
+
+from distutils.version import LooseVersion
+
+import torch
+from torch.autograd.function import Function
+import torch.nn.functional as F
+from torch.nn.modules.batchnorm import _BatchNorm
+
+
+class SyncBatchNorm(_BatchNorm):
+    """
+    Applies synchronous version of N-dimensional BatchNorm.  In this version, normalization
+    parameters are synchronized across workers during forward pass.  This is very useful in
+    situations where each GPU can fit a very small number of examples.
+
+    See https://pytorch.org/docs/stable/nn.html#batchnorm2d for more details about BatchNorm.
+
+    Arguments:
+        num_features: number of channels `C` from the shape `(N, C, ...)`
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        momentum: the value used for the running_mean and running_var
+            computation. Can be set to `None` for cumulative moving average
+            (i.e. simple average). Default: 0.1
+        affine: a boolean value that when set to `True`, this module has
+            learnable affine parameters. Default: `True`
+        track_running_stats: a boolean value that when set to `True`, this
+            module tracks the running mean and variance, and when set to `False`,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: `True`
+    """
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True, track_running_stats=True):
+        super().__init__(num_features, eps, momentum, affine, track_running_stats)
+
+    def _check_input_dim(self, input):
+        if input.dim() < 2:
+            raise ValueError('expected at least 2D input (got {}D input)'.format(input.dim()))
+
+    def forward(self, input):
+        # currently only GPU input is supported
+        if not input.is_cuda:
+            raise ValueError('SyncBatchNorm expected input tensor to be on GPU')
+
+        self._check_input_dim(input)
+
+        if self.training and self.track_running_stats:
+            self.num_batches_tracked = self.num_batches_tracked + 1
+
+        if size() == 1 or (not self.training and self.track_running_stats):
+            return F.batch_norm(
+                input, self.running_mean, self.running_var, self.weight, self.bias,
+                self.training or not self.track_running_stats, self.momentum, self.eps)
+        else:
+            return _SyncBatchNorm.apply(
+                input, self.weight, self.bias, self.running_mean, self.running_var,
+                self.eps, self.momentum)
+
+
+class _SyncBatchNorm(Function):
+    @staticmethod
+    def forward(self, input, weight, bias, running_mean, running_var, eps, momentum):
+        input = input.contiguous()
+
+        size = input.numel() // input.size(1)
+        if size == 1:
+            raise ValueError('Expected more than 1 value per channel when training, got input size {}'.format(size))
+        count = torch.tensor([size])
+
+        # calculate mean/invstd for input.
+        mean, invstd = torch.batch_norm_stats(input, eps)
+
+        count_handle = allgather_async(count.unsqueeze(0), name='sync_batch_norm.count')
+        mean_handle = allgather_async(mean.unsqueeze(0), name='sync_batch_norm.mean')
+        invstd_handle = allgather_async(invstd.unsqueeze(0), name='sync_batch_norm.invstd')
+
+        # wait on the async communication to finish
+        count_all = synchronize(count_handle)
+        mean_all = synchronize(mean_handle)
+        invstd_all = synchronize(invstd_handle)
+
+        if LooseVersion(torch.__version__) < LooseVersion('1.6.0'):
+            # backwards compatibility
+            counts_for_bngswc = count_all.view(-1).tolist()
+        else:
+            counts_for_bngswc = count_all.view(-1).float().to(input.device)
+
+        # calculate global mean & invstd
+        mean, invstd = torch.batch_norm_gather_stats_with_counts(
+            input,
+            mean_all,
+            invstd_all,
+            running_mean,
+            running_var,
+            momentum,
+            eps,
+            counts_for_bngswc
+        )
+
+        self.save_for_backward(input, weight, mean, invstd, count_all)
+
+        # apply element-wise normalization
+        return torch.batch_norm_elemt(input, weight, bias, mean, invstd, eps)
+
+    @staticmethod
+    def backward(self, grad_output):
+        grad_output = grad_output.contiguous()
+        saved_input, weight, mean, invstd, count_all = self.saved_tensors
+        grad_input = grad_weight = grad_bias = None
+
+        # calculate local stats as well as grad_weight / grad_bias
+        sum_dy, sum_dy_xmu, grad_weight, grad_bias = torch.batch_norm_backward_reduce(
+            grad_output,
+            saved_input,
+            mean,
+            invstd,
+            weight,
+            self.needs_input_grad[0],
+            self.needs_input_grad[1],
+            self.needs_input_grad[2]
+        )
+
+        if self.needs_input_grad[0]:
+            # synchronizing stats used to calculate input gradient.
+            sum_dy_handle = allreduce_async(sum_dy, op=Sum, name='sync_batch_norm.sum_dy')
+            sum_dy_xmu_handle = allreduce_async(sum_dy_xmu, op=Sum, name='sync_batch_norm.sum_dy_xmu')
+
+            # wait on the async communication to finish
+            sum_dy = synchronize(sum_dy_handle)
+            sum_dy_xmu = synchronize(sum_dy_xmu_handle)
+
+            if LooseVersion(torch.__version__) < LooseVersion('1.6.0'):
+                # before 1.6.0, sum_dy was sum of means from every worker, so we just 
+                # need to divide it by number of workers
+                mean_dy = sum_dy / size()
+                mean_dy_xmu = sum_dy_xmu / size()
+            else:
+                mean_dy = sum_dy / count_all.sum()
+                mean_dy_xmu = sum_dy_xmu / count_all.sum()
+
+            # backward pass for gradient calculation
+            grad_input = torch.batch_norm_backward_elemt(
+                grad_output,
+                saved_input,
+                mean,
+                invstd,
+                weight,
+                mean_dy,
+                mean_dy_xmu
+            )
+
+        # synchronizing of grad_weight / grad_bias is not needed as distributed
+        # training would handle all reduce.
+        if weight is None or not self.needs_input_grad[1]:
+            grad_weight = None
+
+        if weight is None or not self.needs_input_grad[2]:
+            grad_bias = None
+
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None, None

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -24,6 +24,7 @@ import inspect
 import itertools
 import os
 import pytest
+import sys
 import unittest
 import warnings
 
@@ -1672,6 +1673,10 @@ class TorchTests(unittest.TestCase):
         """Tests Horovod version of SyncBatchNorm."""
         if not torch.cuda.is_available():
             self.skipTest("No GPUs available")
+
+        if sys.version_info < (3,):
+            # TODO: remove this check after Py2 deprecation
+            self.skipTest("Python 3 only feature")
 
         hvd.init()
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1675,38 +1675,51 @@ class TorchTests(unittest.TestCase):
 
         hvd.init()
 
-        sync_bn = hvd.SyncBatchNorm(num_features=4)
-        sync_bn.cuda(hvd.local_rank())
+        ts_list = [
+            torch.stack([
+                torch.tensor([
+                    [r, r + 1],
+                    [r * 2, r * 2 + 1],
+                    [r * 3, r * 3 + 1],
+                    [r * 4, r * 4 + 1]
+                ])
+                for r in range(hvd.size())
+            ]),
+            torch.stack([
+                torch.tensor([
+                    [r + 1],
+                    [r * 2 + 1],
+                    [r * 3 + 1],
+                    [r * 4 + 1]
+                ])
+                for r in range(hvd.size())
+            ]),
+        ]
 
-        bn = torch.nn.BatchNorm1d(num_features=4)
-        bn.cuda(hvd.local_rank())
+        for ts in ts_list:
+            sync_bn = hvd.SyncBatchNorm(num_features=4)
+            sync_bn.cuda(hvd.local_rank())
 
-        ts = torch.stack([
-            torch.tensor([
-                [r, r + 1],
-                [r * 2, r * 2 + 1],
-                [r * 3, r * 3 + 1],
-                [r * 4, r * 4 + 1]
-            ])
-            for r in range(hvd.size())
-        ]).cuda(hvd.local_rank()).float()
+            bn = torch.nn.BatchNorm1d(num_features=4)
+            bn.cuda(hvd.local_rank())
 
-        ts1 = ts.clone().requires_grad_()
-        ts2 = ts.clone().requires_grad_()
+            ts = ts.cuda(hvd.local_rank()).float()
+            ts1 = ts.clone().requires_grad_()
+            ts2 = ts.clone().requires_grad_()
 
-        # Training
-        sync_bn_out = sync_bn(ts1[hvd.rank()].unsqueeze(0))
-        bn_out = bn(ts2)
-        assert (sync_bn_out - bn_out[hvd.rank()].unsqueeze(0)).abs().sum() < 1e-6
-        assert (sync_bn.running_mean - bn.running_mean).abs().sum() < 1e-6
-        assert (sync_bn.running_var - bn.running_var).abs().sum() < 1e-6
+            # Training
+            sync_bn_out = sync_bn(ts1[hvd.rank()].unsqueeze(0))
+            bn_out = bn(ts2)
+            assert (sync_bn_out - bn_out[hvd.rank()].unsqueeze(0)).abs().sum() < 1e-6
+            assert (sync_bn.running_mean - bn.running_mean).abs().sum() < 1e-6
+            assert (sync_bn.running_var - bn.running_var).abs().sum() < 1e-6
 
-        # Gradients
-        sync_bn_out.sum().backward()
-        bn_out.mean(dim=0).sum().backward()
-        assert (hvd.allreduce(sync_bn.weight.grad, name='sync_bn.weight.grad') - bn.weight.grad).abs().sum() < 1e-6
-        assert (hvd.allreduce(sync_bn.bias.grad, name='sync_bn.bias.grad') - bn.bias.grad).abs().sum() < 1e-6
-        assert (hvd.allreduce(ts1.grad, name='ts1.grad') - ts2.grad).abs().sum() < 1e-6
+            # Gradients
+            sync_bn_out.sum().backward()
+            bn_out.mean(dim=0).sum().backward()
+            assert (hvd.allreduce(sync_bn.weight.grad, name='sync_bn.weight.grad') - bn.weight.grad).abs().sum() < 1e-6
+            assert (hvd.allreduce(sync_bn.bias.grad, name='sync_bn.bias.grad') - bn.bias.grad).abs().sum() < 1e-6
+            assert (hvd.allreduce(ts1.grad, name='ts1.grad') - ts2.grad).abs().sum() < 1e-6
 
 if __name__ == "__main__":
    unittest.main()


### PR DESCRIPTION
Implementation of https://pytorch.org/docs/stable/nn.html#syncbatchnorm using Horovod.  Current version uses optimized CUDA kernels written for PyTorch and have two different invocations because they changed.  We can consider making our own implementation if it turns out to be a hassle.

## Why Sync Batch Norm?
As evidenced by https://arxiv.org/abs/1804.07612, small batches are great for training neural networks.  However, https://arxiv.org/abs/1803.08494 noted that multi-GPU training with small-batch BatchNorm is detrimental to performance.

SyncBatchNorm improves training where each worker can only hold few examples (1..4) and total number of workers is not too high - at which point it starts to lose its regularization abilities.

Fixes #1384