### PR TITLE
Added optional local version to package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1590,8 +1590,13 @@ all_frameworks_require_list = tensorflow_require_list + \
 if not os.environ.get('HOROVOD_WITHOUT_PYTORCH'):
     require_list.append('cffi>=1.4.0')
 
+
+def get_package_version():
+    return __version__ + "+" + os.environ['HOROVOD_LOCAL_VERSION'] if 'HOROVOD_LOCAL_VERSION' in os.environ else __version__
+
+
 setup(name='horovod',
-      version=__version__,
+      version=get_package_version(),
       packages=find_packages(),
       description='Distributed training framework for TensorFlow, Keras, PyTorch, and Apache MXNet.',
       author='The Horovod Authors',


### PR DESCRIPTION
Hi guys.

We are using Horovod/Gloo to distribute TensorFlow training on our Hadoop cluster. To do so, we build a wheel which fits our needs and which we publish on our private repository. When building the wheel, we would like to be able to add a local version to the public version so that:
- We clearly identify our local builds to public builds.
- We can build multiple time the same public version of Horovod, with different version of TensorFlow for example.
In this PR, I follow recommendations of https://www.python.org/dev/peps/pep-0440/#public-version-identifiers
What do you think ? Thanks.