### PR TITLE
Fix exception when the number of training process in Spark Estimator is large

### DIFF
--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -263,7 +263,7 @@ def _calculate_shuffle_buffer_size_fn():
         """
         local_size = hvd.local_size()
         local_sizes = hvd.allgather([local_size])
-        max_local_size = max(local_sizes)
+        max_local_size = int(max(local_sizes))
 
         if max_local_size > TOTAL_BUFFER_MEMORY_CAP_GIB:
             shuffle_buffer_size = TOTAL_BUFFER_MEMORY_CAP_GIB * BYTES_PER_GIB / avg_row_size / max_local_size


### PR DESCRIPTION
Fixed the following exception when num_proc in KerasEstimator is larger than 4 using tensorflow 2.0. I found in horovod/spark/keras/remote.py `calculate_shuffle_buffer_size`,  the `max_local_size ` was a tensor so it caused the following error.

```
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/horovod/spark/task/mpirun_exec_fn.py", line 57, in <module>
[1,6]<stderr>:    main(codec.loads_base64(sys.argv[1]), codec.loads_base64(sys.argv[2]))
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/horovod/spark/task/mpirun_exec_fn.py", line 50, in main
[1,6]<stderr>:    task_exec(driver_addresses, settings, 'OMPI_COMM_WORLD_RANK')
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/horovod/spark/task/__init__.py", line 53, in task_exec
[1,6]<stderr>:    result = fn(*args, **kwargs)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/horovod/spark/keras/remote.py", line 104, in train
[1,6]<stderr>:    hvd, avg_row_size, train_rows / hvd.size())
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/horovod/spark/keras/remote.py", line 269, in calculate_shuffle_buffer_size
[1,6]<stderr>:    shuffle_buffer_size = TOTAL_BUFFER_MEMORY_CAP_GIB * BYTES_PER_GIB / avg_row_size / max_local_size
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/ops/math_ops.py", line 924, in r_binary_op_wrapper
[1,6]<stderr>:    x = ops.convert_to_tensor(x, dtype=y.dtype.base_dtype, name="x")
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/ops.py", line 1184, in convert_to_tensor
[1,6]<stderr>:    return convert_to_tensor_v2(value, dtype, preferred_dtype, name)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/ops.py", line 1242, in convert_to_tensor_v2
[1,6]<stderr>:    as_ref=False)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/ops.py", line 1296, in internal_convert_to_tensor
[1,6]<stderr>:    ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/tensor_conversion_registry.py", line 52, in _default_conversion_function
[1,6]<stderr>:    return constant_op.constant(value, dtype, name=name)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/constant_op.py", line 227, in constant
[1,6]<stderr>:    allow_broadcast=True)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/constant_op.py", line 235, in _constant_impl
[1,6]<stderr>:    t = convert_to_eager_tensor(value, ctx, dtype)
[1,6]<stderr>:  File "/home/yuzhou/miniconda3/envs/horovod2/lib/python3.6/site-packages/tensorflow_core/python/framework/constant_op.py", line 96, in convert_to_eager_tensor
[1,6]<stderr>:    return ops.EagerTensor(value, ctx.device_name, dtype)
[1,6]<stderr>:TypeError: Cannot convert 194942451.75811347 to EagerTensor of dtype int32
```
