### PR TITLE
Fix horovodrun LSF feature

### DIFF
--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -693,9 +693,9 @@ def run_controller(use_gloo, gloo_run, use_mpi, mpi_run, use_jsrun, js_run, verb
 def _launch_job(args, remote_host_names, settings, nics, command):
     env = os.environ.copy()
     config_parser.set_env_from_args(env, args)
-    driver_ip = network._get_driver_ip(nics)
 
     def gloo_run_fn():
+        driver_ip = network._get_driver_ip(nics)
         gloo_run(settings, remote_host_names, nics, env, driver_ip, command)
 
     def mpi_run_fn():

--- a/horovod/run/util/lsf.py
+++ b/horovod/run/util/lsf.py
@@ -36,10 +36,10 @@ class LSFUtils:
     def get_allocation_info():
         """Returns and sets the static CSM allocation info."""
         if not LSFUtils._csm_allocation_info:
-            lsf_job_id = os.environ["LSB_JOBID"].strip()
+            lsf_allocation_id = os.environ["CSM_ALLOCATION_ID"].strip()
             output = six.StringIO()
-            exit_code = safe_shell_exec.execute("{cmd} -j {job}".format(
-                cmd=LSFUtils._CSM_ALLOCATION_QUERY, job=lsf_job_id),
+            exit_code = safe_shell_exec.execute("{cmd} -a {allocation}".format(
+                cmd=LSFUtils._CSM_ALLOCATION_QUERY, allocation=lsf_allocation_id),
                 stdout=output, stderr=output)
             if exit_code != 0:
                 raise RuntimeError(

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -42,7 +42,7 @@ from horovod.run.js_run import js_run, generate_jsrun_rankfile
 from horovod.run.mpi_run import _get_mpi_implementation, _get_mpi_implementation_flags,\
     _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_available, mpi_run,\
     _OMPI_IMPL, _SMPI_IMPL, _MPICH_IMPL, _UNKNOWN_IMPL, _MISSING_IMPL
-from horovod.run.runner import parse_args, parse_host_files, run_controller
+from horovod.run.runner import parse_args, parse_host_files, run_controller, HorovodArgs, _run
 from horovod.run.util.threads import in_thread, on_event
 
 from common import is_built, lsf_and_jsrun, override_args, override_env, temppath, delay, wait
@@ -746,3 +746,17 @@ rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
 """)
 
             self.assertMultiLineEqual(gen_rankfile, expected_rankfile)
+
+    """
+    Tests horovod.run.runner._run with jsrun
+    """
+    @mock.patch('horovod.run.js_run.is_jsrun_installed', MagicMock(return_value=True))
+    @mock.patch('horovod.run.util.lsf.LSFUtils.get_compute_hosts', MagicMock(return_value=['host1', 'host2']))
+    @mock.patch('horovod.run.util.lsf.LSFUtils.get_num_gpus', MagicMock(return_value=2))
+    @mock.patch('horovod.run.util.network.filter_local_addresses', MagicMock(return_value=['host1', 'host2']))
+    @mock.patch('horovod.run.runner._check_all_hosts_ssh_successful', MagicMock())
+    @mock.patch('horovod.run.runner.run_controller')
+    def test_run_with_jsrun(self, mocked_run_controller):
+        hargs = HorovodArgs()
+        _run(hargs)
+        mocked_run_controller.assert_called_once()

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -750,7 +750,7 @@ rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
     """
     Tests horovod.run.runner._run with jsrun
     """
-    @mock.patch('horovod.run.js_run.is_jsrun_installed', MagicMock(return_value=True))
+    @mock.patch('horovod.run.util.lsf.LSFUtils.using_lsf', MagicMock(return_value=True))
     @mock.patch('horovod.run.util.lsf.LSFUtils.get_compute_hosts', MagicMock(return_value=['host1', 'host2']))
     @mock.patch('horovod.run.util.lsf.LSFUtils.get_num_gpus', MagicMock(return_value=2))
     @mock.patch('horovod.run.util.network.filter_local_addresses', MagicMock(return_value=['host1', 'host2']))


### PR DESCRIPTION
1- Remove _get_driver_ip from LSF code path (inserted by #1807)
2- Switch query from LSB_JOBID to CSM_ALLOCATION_ID because LSB_JOBID
may point to several allocations

Also, add unit test for bug 1.