### PR TITLE
Add support for gradient_predivide_factor and averaging in Horovod backend.

### DIFF
--- a/Jenkinsfile.ppc64le
+++ b/Jenkinsfile.ppc64le
@@ -25,6 +25,7 @@ pipeline {
                       git submodule update --init --recursive
                       . ${CONDA_INIT}
                       conda activate ${CONDA_ENV}
+                      conda install -y cmake make
                       set -xe
                       HOROVOD_WITHOUT_MXNET=1 HOROVOD_WITHOUT_GLOO=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_TENSORFLOW=1 \
                           HOROVOD_CUDA_HOME=$CONDA_PREFIX HOROVOD_GPU_BROADCAST=NCCL HOROVOD_GPU_ALLREDUCE=NCCL \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include * *.h *.hpp *.cc *.md
+recursive-include * *.h *.hpp *.cc *.cu *.md
 
 include LICENSE horovod.lds horovod.exp
 prune .eggs
@@ -19,3 +19,6 @@ exclude third_party/eigen/Eigen/src/SparseCholesky/*
 graft third_party/gloo/cmake
 recursive-include third_party/gloo CMakeLists.txt
 recursive-include third_party/gloo *.in
+
+# include cmake related files for CUDA compilation
+include horovod/common/ops/cuda/CMakeLists.txt

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -224,6 +224,7 @@ Possible values are given in curly brackets: {}.
 * ``HOROVOD_CUDA_HOME`` - path where CUDA include and lib directories can be found.
 * ``HOROVOD_CUDA_INCLUDE`` - path to CUDA include directory.
 * ``HOROVOD_CUDA_LIB`` - path to CUDA lib directory.
+* ``HOROVOD_BUILD_CUDA_CC_LIST`` - List of compute capabilities to build Horovod CUDA kernels for (example: ``HOROVOD_BUILD_CUDA_CC_LIST=60,70,75``)
 * ``HOROVOD_ROCM_HOME`` - path where ROCm include and lib directories can be found.
 * ``HOROVOD_NCCL_HOME`` - path where NCCL include and lib directories can be found.
 * ``HOROVOD_NCCL_INCLUDE`` - path to NCCL include directory.

--- a/examples/mxnet_imagenet_resnet50.py
+++ b/examples/mxnet_imagenet_resnet50.py
@@ -89,6 +89,8 @@ parser.add_argument('--log-interval', type=int, default=0,
                     help='number of batches to wait before logging (default: 0)')
 parser.add_argument('--save-frequency', type=int, default=0,
                     help='frequency of model saving (default: 0)')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 
 args = parser.parse_args()
@@ -322,7 +324,8 @@ def train_gluon():
     opt = mx.optimizer.create('sgd', **optimizer_params)
 
     # Horovod: create DistributedTrainer, a subclass of gluon.Trainer
-    trainer = hvd.DistributedTrainer(params, opt)
+    trainer = hvd.DistributedTrainer(params, opt,
+                                     gradient_predivide_factor=args.gradient_predivide_factor)
 
     # Create loss function and train metric
     loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()
@@ -427,7 +430,8 @@ def train_module():
     opt = mx.optimizer.create('sgd', **optimizer_params)
 
     # Horovod: wrap optimizer with DistributedOptimizer
-    dist_opt = hvd.DistributedOptimizer(opt)
+    dist_opt = hvd.DistributedOptimizer(opt,
+                                        gradient_predivide_factor=args.gradient_predivide_factor)
 
     # Setup validation data and callback during training
     eval_data = None

--- a/examples/mxnet_mnist.py
+++ b/examples/mxnet_mnist.py
@@ -24,6 +24,8 @@ parser.add_argument('--momentum', type=float, default=0.9,
                     help='SGD momentum (default: 0.9)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disable training on GPU (default: False)')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 args = parser.parse_args()
 
 if not args.no_cuda:
@@ -128,7 +130,8 @@ if params is not None:
     hvd.broadcast_parameters(params, root_rank=0)
 
 # Horovod: create DistributedTrainer, a subclass of gluon.Trainer
-trainer = hvd.DistributedTrainer(params, opt)
+trainer = hvd.DistributedTrainer(params, opt,
+                                 gradient_predivide_factor=args.gradient_predivide_factor)
 
 # Create loss function and train metric
 loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -31,6 +31,8 @@ parser.add_argument('--batches-per-allreduce', type=int, default=1,
                          'total batch size.')
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 # Default settings from https://arxiv.org/abs/1706.02677.
 parser.add_argument('--batch-size', type=int, default=32,
@@ -272,7 +274,8 @@ if __name__ == '__main__':
         optimizer, named_parameters=model.named_parameters(),
         compression=compression,
         backward_passes_per_step=args.batches_per_allreduce,
-        op=hvd.Adasum if args.use_adasum else hvd.Average)
+        op=hvd.Adasum if args.use_adasum else hvd.Average,
+        gradient_predivide_factor=args.gradient_predivide_factor)
 
     # Restore from a previous checkpoint, if initial_epoch is specified.
     # Horovod: restore on the first worker which will broadcast weights to other workers.

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -29,6 +29,8 @@ parser.add_argument('--fp16-allreduce', action='store_true', default=False,
                     help='use fp16 compression during allreduce')
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 
 class Net(nn.Module):
@@ -179,7 +181,8 @@ if __name__ == '__main__':
     optimizer = hvd.DistributedOptimizer(optimizer,
                                          named_parameters=model.named_parameters(),
                                          compression=compression,
-                                         op=hvd.Adasum if args.use_adasum else hvd.Average)
+                                         op=hvd.Adasum if args.use_adasum else hvd.Average,
+                                         gradient_predivide_factor=args.gradient_predivide_factor)
 
     for epoch in range(1, args.epochs + 1):
         train(epoch)

--- a/examples/pytorch_synthetic_benchmark.py
+++ b/examples/pytorch_synthetic_benchmark.py
@@ -31,6 +31,8 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
 
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()
@@ -65,7 +67,8 @@ compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.n
 optimizer = hvd.DistributedOptimizer(optimizer,
                                      named_parameters=model.named_parameters(),
                                      compression=compression,
-                                     op=hvd.Adasum if args.use_adasum else hvd.Average)
+                                     op=hvd.Adasum if args.use_adasum else hvd.Average,
+                                     gradient_predivide_factor=args.gradient_predivide_factor)
 
 # Horovod: broadcast parameters & optimizer state.
 hvd.broadcast_parameters(model.state_dict(), root_rank=0)

--- a/examples/pytorch_synthetic_benchmark.py
+++ b/examples/pytorch_synthetic_benchmark.py
@@ -31,8 +31,6 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
 
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()
@@ -67,8 +65,7 @@ compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.n
 optimizer = hvd.DistributedOptimizer(optimizer,
                                      named_parameters=model.named_parameters(),
                                      compression=compression,
-                                     op=hvd.Adasum if args.use_adasum else hvd.Average,
-                                     gradient_predivide_factor=args.gradient_predivide_factor)
+                                     op=hvd.Adasum if args.use_adasum else hvd.Average)
 
 # Horovod: broadcast parameters & optimizer state.
 hvd.broadcast_parameters(model.state_dict(), root_rank=0)

--- a/examples/tensorflow2_keras_mnist.py
+++ b/examples/tensorflow2_keras_mnist.py
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import argparse
 
 import tensorflow as tf
 import horovod.tensorflow.keras as hvd
-
-# Training settings
-parser = argparse.ArgumentParser(description='Tensorflow2 Keras MNIST Example')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
-args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -58,7 +51,7 @@ scaled_lr = 0.001 * hvd.size()
 opt = tf.optimizers.Adam(scaled_lr)
 
 # Horovod: add Horovod DistributedOptimizer.
-opt = hvd.DistributedOptimizer(opt, gradient_predivide_factor=args.gradient_predivide_factor)
+opt = hvd.DistributedOptimizer(opt)
 
 # Horovod: Specify `experimental_run_tf_function=False` to ensure TensorFlow
 # uses hvd.DistributedOptimizer() to compute gradients.

--- a/examples/tensorflow2_keras_mnist.py
+++ b/examples/tensorflow2_keras_mnist.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import argparse
 
 import tensorflow as tf
 import horovod.tensorflow.keras as hvd
+
+# Training settings
+parser = argparse.ArgumentParser(description='Tensorflow2 Keras MNIST Example')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
+args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -51,7 +58,7 @@ scaled_lr = 0.001 * hvd.size()
 opt = tf.optimizers.Adam(scaled_lr)
 
 # Horovod: add Horovod DistributedOptimizer.
-opt = hvd.DistributedOptimizer(opt)
+opt = hvd.DistributedOptimizer(opt, gradient_predivide_factor=args.gradient_predivide_factor)
 
 # Horovod: Specify `experimental_run_tf_function=False` to ensure TensorFlow
 # uses hvd.DistributedOptimizer() to compute gradients.

--- a/examples/tensorflow2_mnist.py
+++ b/examples/tensorflow2_mnist.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import argparse
 
 import tensorflow as tf
 import horovod.tensorflow as hvd
+
+# Training settings
+parser = argparse.ArgumentParser(description='Tensorflow2 MNIST Example')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
+args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -61,7 +68,7 @@ def training_step(images, labels, first_batch):
         loss_value = loss(labels, probs)
 
     # Horovod: add Horovod Distributed GradientTape.
-    tape = hvd.DistributedGradientTape(tape)
+    tape = hvd.DistributedGradientTape(tape, gradient_predivide_factor=args.gradient_predivide_factor)
 
     grads = tape.gradient(loss_value, mnist_model.trainable_variables)
     opt.apply_gradients(zip(grads, mnist_model.trainable_variables))

--- a/examples/tensorflow2_mnist.py
+++ b/examples/tensorflow2_mnist.py
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import argparse
 
 import tensorflow as tf
 import horovod.tensorflow as hvd
-
-# Training settings
-parser = argparse.ArgumentParser(description='Tensorflow2 MNIST Example')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
-args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -68,7 +61,7 @@ def training_step(images, labels, first_batch):
         loss_value = loss(labels, probs)
 
     # Horovod: add Horovod Distributed GradientTape.
-    tape = hvd.DistributedGradientTape(tape, gradient_predivide_factor=args.gradient_predivide_factor)
+    tape = hvd.DistributedGradientTape(tape)
 
     grads = tape.gradient(loss_value, mnist_model.trainable_variables)
     opt.apply_gradients(zip(grads, mnist_model.trainable_variables))

--- a/examples/tensorflow2_synthetic_benchmark.py
+++ b/examples/tensorflow2_synthetic_benchmark.py
@@ -42,6 +42,9 @@ parser.add_argument('--num-iters', type=int, default=10,
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
+
 args = parser.parse_args()
 args.cuda = not args.no_cuda
 
@@ -77,7 +80,8 @@ def benchmark_step(first_batch):
         loss = tf.losses.sparse_categorical_crossentropy(target, probs)
 
     # Horovod: add Horovod Distributed GradientTape.
-    tape = hvd.DistributedGradientTape(tape, compression=compression)
+    tape = hvd.DistributedGradientTape(tape, compression=compression,
+                                       gradient_predivide_factor=args.gradient_predivide_factor)
 
     gradients = tape.gradient(loss, model.trainable_variables)
     opt.apply_gradients(zip(gradients, model.trainable_variables))

--- a/examples/tensorflow2_synthetic_benchmark.py
+++ b/examples/tensorflow2_synthetic_benchmark.py
@@ -42,8 +42,6 @@ parser.add_argument('--num-iters', type=int, default=10,
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda
@@ -80,8 +78,7 @@ def benchmark_step(first_batch):
         loss = tf.losses.sparse_categorical_crossentropy(target, probs)
 
     # Horovod: add Horovod Distributed GradientTape.
-    tape = hvd.DistributedGradientTape(tape, compression=compression,
-                                       gradient_predivide_factor=args.gradient_predivide_factor)
+    tape = hvd.DistributedGradientTape(tape, compression=compression)
 
     gradients = tape.gradient(loss, model.trainable_variables)
     opt.apply_gradients(zip(gradients, model.trainable_variables))

--- a/examples/tensorflow_keras_mnist.py
+++ b/examples/tensorflow_keras_mnist.py
@@ -1,4 +1,3 @@
-import argparse
 import math
 
 import tensorflow as tf
@@ -10,12 +9,6 @@ from tensorflow.keras.layers import Conv2D, MaxPooling2D
 from tensorflow.keras import backend as K
 
 import horovod.tensorflow.keras as hvd
-
-# Training settings
-parser = argparse.ArgumentParser(description='Tensorflow Keras MNIST Example')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
-args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -75,7 +68,7 @@ model.add(Dense(num_classes, activation='softmax'))
 opt = keras.optimizers.Adadelta(1.0 * hvd.size())
 
 # Horovod: add Horovod Distributed Optimizer.
-opt = hvd.DistributedOptimizer(opt, gradient_predivide_factor=args.gradient_predivide_factor)
+opt = hvd.DistributedOptimizer(opt)
 
 model.compile(loss=keras.losses.categorical_crossentropy,
               optimizer=opt,

--- a/examples/tensorflow_keras_mnist.py
+++ b/examples/tensorflow_keras_mnist.py
@@ -1,3 +1,4 @@
+import argparse
 import math
 
 import tensorflow as tf
@@ -9,6 +10,12 @@ from tensorflow.keras.layers import Conv2D, MaxPooling2D
 from tensorflow.keras import backend as K
 
 import horovod.tensorflow.keras as hvd
+
+# Training settings
+parser = argparse.ArgumentParser(description='Tensorflow Keras MNIST Example')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
+args = parser.parse_args()
 
 # Horovod: initialize Horovod.
 hvd.init()
@@ -68,7 +75,7 @@ model.add(Dense(num_classes, activation='softmax'))
 opt = keras.optimizers.Adadelta(1.0 * hvd.size())
 
 # Horovod: add Horovod Distributed Optimizer.
-opt = hvd.DistributedOptimizer(opt)
+opt = hvd.DistributedOptimizer(opt, gradient_predivide_factor=args.gradient_predivide_factor)
 
 model.compile(loss=keras.losses.categorical_crossentropy,
               optimizer=opt,

--- a/examples/tensorflow_mnist.py
+++ b/examples/tensorflow_mnist.py
@@ -30,6 +30,8 @@ tf.logging.set_verbosity(tf.logging.INFO)
 parser = argparse.ArgumentParser(description='Tensorflow MNIST Example')
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 args = parser.parse_args()
 
 def conv_model(feature, target, mode):
@@ -127,7 +129,8 @@ def main(_):
     opt = tf.train.AdamOptimizer(0.001 * lr_scaler)
 
     # Horovod: add Horovod Distributed Optimizer.
-    opt = hvd.DistributedOptimizer(opt, op=hvd.Adasum if args.use_adasum else hvd.Average)
+    opt = hvd.DistributedOptimizer(opt, op=hvd.Adasum if args.use_adasum else hvd.Average,
+                                   gradient_predivide_factor=args.gradient_predivide_factor)
 
     global_step = tf.train.get_or_create_global_step()
     train_op = opt.minimize(loss, global_step=global_step)

--- a/examples/tensorflow_mnist_eager.py
+++ b/examples/tensorflow_mnist_eager.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import argparse
 
 import tensorflow as tf
 import horovod.tensorflow as hvd
 
+# Training settings
+parser = argparse.ArgumentParser(description='Tensorflow Keras MNIST Example')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
+args = parser.parse_args()
 
 def main(_):
     # Horovod: initialize Horovod.
@@ -59,7 +65,8 @@ def main(_):
             loss_value = tf.losses.sparse_softmax_cross_entropy(labels, logits)
 
         # Horovod: add Horovod Distributed GradientTape.
-        tape = hvd.DistributedGradientTape(tape)
+        tape = hvd.DistributedGradientTape(tape,
+                                           gradient_predivide_factor=args.gradient_predivide_factor)
 
         grads = tape.gradient(loss_value, mnist_model.variables)
         opt.apply_gradients(zip(grads, mnist_model.variables),

--- a/examples/tensorflow_mnist_eager.py
+++ b/examples/tensorflow_mnist_eager.py
@@ -12,16 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import argparse
 
 import tensorflow as tf
 import horovod.tensorflow as hvd
-
-# Training settings
-parser = argparse.ArgumentParser(description='Tensorflow Keras MNIST Example')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
-args = parser.parse_args()
 
 def main(_):
     # Horovod: initialize Horovod.
@@ -65,8 +58,7 @@ def main(_):
             loss_value = tf.losses.sparse_softmax_cross_entropy(labels, logits)
 
         # Horovod: add Horovod Distributed GradientTape.
-        tape = hvd.DistributedGradientTape(tape,
-                                           gradient_predivide_factor=args.gradient_predivide_factor)
+        tape = hvd.DistributedGradientTape(tape)
 
         grads = tape.gradient(loss_value, mnist_model.variables)
         opt.apply_gradients(zip(grads, mnist_model.variables),

--- a/examples/tensorflow_synthetic_benchmark.py
+++ b/examples/tensorflow_synthetic_benchmark.py
@@ -31,6 +31,8 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
+parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
+                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda
@@ -65,7 +67,8 @@ opt = tf.train.GradientDescentOptimizer(0.01 * lr_scaler)
 compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
 
 # Horovod: wrap optimizer with DistributedOptimizer.
-opt = hvd.DistributedOptimizer(opt, compression=compression, op=hvd.Adasum if args.use_adasum else hvd.Average)
+opt = hvd.DistributedOptimizer(opt, compression=compression, op=hvd.Adasum if args.use_adasum else hvd.Average,
+                               gradient_predivide_factor=args.gradient_predivide_factor)
 
 init = tf.global_variables_initializer()
 bcast_op = hvd.broadcast_global_variables(0)

--- a/examples/tensorflow_synthetic_benchmark.py
+++ b/examples/tensorflow_synthetic_benchmark.py
@@ -31,8 +31,6 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 parser.add_argument('--use-adasum', action='store_true', default=False,
                     help='use adasum algorithm to do reduction')
-parser.add_argument('--gradient-predivide-factor', type=float, default=1.0,
-                    help='apply gradient predivide factor in optimizer (default: 1.0)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda
@@ -67,8 +65,7 @@ opt = tf.train.GradientDescentOptimizer(0.01 * lr_scaler)
 compression = hvd.Compression.fp16 if args.fp16_allreduce else hvd.Compression.none
 
 # Horovod: wrap optimizer with DistributedOptimizer.
-opt = hvd.DistributedOptimizer(opt, compression=compression, op=hvd.Adasum if args.use_adasum else hvd.Average,
-                               gradient_predivide_factor=args.gradient_predivide_factor)
+opt = hvd.DistributedOptimizer(opt, compression=compression, op=hvd.Adasum if args.use_adasum else hvd.Average)
 
 init = tf.global_variables_initializer()
 bcast_op = hvd.broadcast_global_variables(0)

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -215,3 +215,19 @@ class HorovodBasics(object):
           A boolean value indicating whether oneCCL support was compiled.
         """
         return bool(self.MPI_LIB_CTYPES.horovod_ccl_built())
+
+    def cuda_built(self):
+        """Returns True if Horovod was compiled with CUDA support.
+
+        Returns:
+          A boolean value indicating whether CUDA support was compiled.
+        """
+        return bool(self.MPI_LIB_CTYPES.horovod_cuda_built())
+
+    def rocm_built(self):
+        """Returns True if Horovod was compiled with ROCm support.
+
+        Returns:
+          A boolean value indicating whether ROCm support was compiled.
+        """
+        return bool(self.MPI_LIB_CTYPES.horovod_rocm_built())

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -452,7 +452,7 @@ Response Controller::ConstructResponse(std::string& name, int joined_size) {
   }
 
   // If we are doing an allreduce, check that prescaling and postscaling factors
-  // are identical.
+  // are identical across ranks.
   double prescale_factor;
   double postscale_factor;
   if (message_type == Request::ALLREDUCE ||

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -451,6 +451,36 @@ Response Controller::ConstructResponse(std::string& name, int joined_size) {
     }
   }
 
+  // If we are doing an allreduce, check that prescaling and postscaling factors
+  // are identical.
+  double prescale_factor;
+  double postscale_factor;
+  if (message_type == Request::ALLREDUCE ||
+      message_type == Request::ADASUM) {
+    prescale_factor = requests[0].prescale_factor();
+    postscale_factor = requests[0].postscale_factor();
+
+    for (unsigned int i = 1; i < requests.size(); ++i) {
+      if (error) {
+        break;
+      }
+      double request_prescale_factor = requests[i].prescale_factor();
+      double request_postscale_factor = requests[i].postscale_factor();
+
+      if (prescale_factor != request_prescale_factor ||
+          postscale_factor != request_postscale_factor) {
+        error = true;
+        error_message_stream
+            << "Mismatched prescale and/or postscale factors: "
+            << "One rank sent factors (" << prescale_factor
+            << ", " << postscale_factor << "), but another rank "
+            << "sent factors (" << request_prescale_factor
+            << ", " << request_postscale_factor << ").";
+        break;
+      }
+    }
+  }
+
   std::vector<int64_t> tensor_sizes;
   if (message_type == Request::ALLGATHER ||
       message_type == Request::ALLTOALL) {
@@ -601,6 +631,8 @@ Response Controller::ConstructResponse(std::string& name, int joined_size) {
       response.add_tensor_size(dim);
     }
     response.set_tensor_type(data_type);
+    response.set_prescale_factor(prescale_factor);
+    response.set_postscale_factor(postscale_factor);
   } else if (message_type == Request::BROADCAST) {
     response.set_response_type(Response::BROADCAST);
   } else if (message_type == Request::ALLTOALL) {
@@ -611,6 +643,8 @@ Response Controller::ConstructResponse(std::string& name, int joined_size) {
       response.add_tensor_size(dim);
     }
     response.set_tensor_type(data_type);
+    response.set_prescale_factor(prescale_factor);
+    response.set_postscale_factor(postscale_factor);
   }
   response.set_devices(devices);
 
@@ -675,7 +709,9 @@ ResponseList Controller::FuseResponses(std::deque<Response>& responses) {
         if (response.response_type() == new_response.response_type() &&
             response.devices() == new_response.devices() &&
             response.tensor_type() == new_response.tensor_type() &&
-            tensor_size + new_tensor_size <= TensorFusionThresholdBytes()) {
+            tensor_size + new_tensor_size <= TensorFusionThresholdBytes() &&
+            response.prescale_factor() == new_response.prescale_factor() &&
+            response.postscale_factor() == new_response.postscale_factor()) {
           // These tensors will fuse together well.
           tensor_size += new_tensor_size;
           response.add_tensor_name(std::move(new_response.tensor_names()[0]));

--- a/horovod/common/half.cc
+++ b/horovod/common/half.cc
@@ -39,6 +39,7 @@ bool is_avx_and_f16c() {
 }
 #endif
 
+#if HAVE_MPI
 // float16 custom data type summation operation.
 void float16_sum(void* invec, void* inoutvec, int* len,
                  MPI_Datatype* datatype) {
@@ -73,6 +74,7 @@ void float16_sum(void* invec, void* inoutvec, int* len,
     Float2HalfBits(&inout_float, inout + i);
   }
 }
+#endif
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/half.h
+++ b/horovod/common/half.h
@@ -28,8 +28,10 @@
 
 #include <stdint.h>
 
+#if HAVE_MPI
 #define OMPI_SKIP_MPICXX
 #include "mpi.h"
+#endif
 
 namespace horovod {
 namespace common {
@@ -136,7 +138,9 @@ inline void Float2HalfBits(const float* src, unsigned short* dest) {
   *dest = u;
 }
 
+#if HAVE_MPI
 void float16_sum(void* invec, void* inoutvec, int* len, MPI_Datatype* datatype);
+#endif
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/half.h
+++ b/horovod/common/half.h
@@ -34,7 +34,11 @@
 namespace horovod {
 namespace common {
 
-inline void HalfBits2Float(unsigned short* src, float* res) {
+#if __AVX__ && __F16C__
+bool is_avx_and_f16c();
+#endif
+
+inline void HalfBits2Float(const unsigned short* src, float* res) {
   unsigned h = *src;
   int sign = ((h >> 15) & 1);
   int exp = ((h >> 10) & 0x1f);
@@ -70,7 +74,7 @@ inline void HalfBits2Float(unsigned short* src, float* res) {
   *res = *reinterpret_cast<float const*>(&f);
 }
 
-inline void Float2HalfBits(float* src, unsigned short* dest) {
+inline void Float2HalfBits(const float* src, unsigned short* dest) {
   // software implementation rounds toward nearest even
   unsigned const& s = *reinterpret_cast<unsigned const*>(src);
   uint16_t sign = uint16_t((s >> 16) & 0x8000);

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -145,6 +145,14 @@ int32_t Request::device() const { return device_; }
 
 void Request::set_device(int32_t value) { device_ = value; }
 
+double Request::prescale_factor() const { return prescale_factor_; };
+
+double Request::postscale_factor() const { return postscale_factor_; };
+
+void Request::set_prescale_factor(const double prescale_factor) { prescale_factor_ = prescale_factor; };
+
+void Request::set_postscale_factor(const double postscale_factor) { postscale_factor_ = postscale_factor; };
+
 const std::vector<int64_t>& Request::tensor_shape() const {
   return tensor_shape_;
 }
@@ -169,6 +177,8 @@ void Request_ParseFromWire(Request& request,
   request.set_device(obj->device());
   request.set_tensor_shape(std::vector<int64_t>(obj->tensor_shape()->begin(),
                                                 obj->tensor_shape()->end()));
+  request.set_prescale_factor(obj->prescale_factor());
+  request.set_postscale_factor(obj->postscale_factor());
 }
 
 void Request_SerializeToWire(const Request& request,
@@ -187,6 +197,8 @@ void Request_SerializeToWire(const Request& request,
   request_builder.add_root_rank(request.root_rank());
   request_builder.add_device(request.device());
   request_builder.add_tensor_shape(tensor_shape_wire);
+  request_builder.add_prescale_factor(request.prescale_factor());
+  request_builder.add_postscale_factor(request.postscale_factor());
   obj = request_builder.Finish();
 }
 
@@ -371,6 +383,14 @@ void Response::add_allgather_response(const Response& response) {
   }
 }
 
+double Response::prescale_factor() const { return prescale_factor_; };
+
+double Response::postscale_factor() const { return postscale_factor_; };
+
+void Response::set_prescale_factor(const double prescale_factor) { prescale_factor_ = prescale_factor; };
+
+void Response::set_postscale_factor(const double postscale_factor) { postscale_factor_ = postscale_factor; };
+
 void Response_ParseFromWire(Response& response,
                             const wire::Response* obj) {
   response.set_response_type((Response::ResponseType) obj->response_type());
@@ -383,6 +403,8 @@ void Response_ParseFromWire(Response& response,
       std::vector<int32_t>(obj->devices()->begin(), obj->devices()->end()));
   response.set_tensor_sizes(std::vector<int64_t>(obj->tensor_sizes()->begin(),
                                                  obj->tensor_sizes()->end()));
+  response.set_prescale_factor(obj->prescale_factor());
+  response.set_postscale_factor(obj->postscale_factor());
 }
 
 void Response::ParseFromBytes(Response& response, const uint8_t* input) {
@@ -409,6 +431,8 @@ void Response_SerializeToWire(const Response& response,
   response_builder.add_error_message(error_message_wire);
   response_builder.add_devices(devices_wire);
   response_builder.add_tensor_sizes(tensor_sizes_wire);
+  response_builder.add_prescale_factor(response.prescale_factor());
+  response_builder.add_postscale_factor(response.postscale_factor());
   obj = response_builder.Finish();
 }
 

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -51,6 +51,7 @@ public:
     ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL = 5
   };
 
+
   static const std::string& RequestType_Name(RequestType value);
 
   // The request rank is necessary to create a consistent ordering of results,
@@ -86,9 +87,18 @@ public:
 
   void add_tensor_shape(int64_t value);
 
+  double prescale_factor() const;
+
+  double postscale_factor() const;
+
+  void set_prescale_factor(const double prescale_factor);
+
+  void set_postscale_factor(const double postscale_factor);
+
   static void ParseFromBytes(Request& request, const uint8_t* input);
 
   static void SerializeToString(const Request& request, std::string& output);
+
 
 private:
   int32_t request_rank_ = 0;
@@ -98,6 +108,8 @@ private:
   int32_t device_ = 0;
   std::string tensor_name_;
   std::vector<int64_t> tensor_shape_;
+  double prescale_factor_ = 1.0;
+  double postscale_factor_ = 1.0;
 };
 
 class RequestList {
@@ -180,6 +192,14 @@ public:
   // To fuse multiple allgather responses
   void add_allgather_response(const Response& response);
 
+  double prescale_factor() const;
+
+  double postscale_factor() const;
+
+  void set_prescale_factor(const double prescale_factor);
+
+  void set_postscale_factor(const double postscale_factor);
+
   static void ParseFromBytes(Response& response, const uint8_t* input);
 
   static void SerializeToString(const Response& response,
@@ -192,6 +212,8 @@ private:
   std::string error_message_;
   std::vector<int32_t> devices_;
   std::vector<int64_t> tensor_sizes_;
+  double prescale_factor_ = 1.0;
+  double postscale_factor_ = 1.0;
 };
 
 class ResponseList {

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -805,6 +805,22 @@ bool horovod_ccl_built() {
 #endif
 }
 
+bool horovod_cuda_built() {
+#if HAVE_CUDA
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool horovod_rocm_built() {
+#if HAVE_ROCM
+  return true;
+#else
+  return false;
+#endif
+}
+
 int horovod_reduce_op_average() {
   return ReduceOp::AVERAGE;
 }
@@ -827,7 +843,9 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string name, const int device,
                               StatusCallback callback,
-                              ReduceOp reduce_op) {
+                              ReduceOp reduce_op,
+                              const double prescale_factor,
+                              const double postscale_factor) {
   Status status;
 
   // AVERAGE should be taken care of in the framework layer. Equeuing it here directly is not allowed.
@@ -843,6 +861,8 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
   message.set_tensor_name(name);
   message.set_tensor_type(tensor->dtype());
   message.set_device(device);
+  message.set_prescale_factor(prescale_factor);
+  message.set_postscale_factor(postscale_factor);
   
   if (reduce_op == ReduceOp::ADASUM) {
     message.set_request_type(Request::ADASUM);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -856,6 +856,13 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
     LOG(ERROR, horovod_global.controller->GetRank()) << "Enqueuing AVERAGE allreduce is not allowed.";
     return status.Aborted("AVERAGE not allowed.");
 #endif
+  } else if (reduce_op == ReduceOp::ADASUM) {
+#if HAVE_NCCL
+    if (device != CPU_DEVICE_ID) {
+      // Averaging by local size happens via postscale_factor
+      postscale_factor /= horovod_global.controller->GetLocalSize();
+    }
+#endif
   }
   Request message;
   message.set_request_rank(horovod_global.controller->GetRank());

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -857,7 +857,7 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
     return status.Aborted("AVERAGE not allowed.");
 #endif
   } else if (reduce_op == ReduceOp::ADASUM) {
-#if HAVE_NCCL
+#if HAVE_NCCL && !HAVE_ROCM
     if (device != CPU_DEVICE_ID) {
       // Averaging by local size happens via postscale_factor
       postscale_factor /= horovod_global.controller->GetLocalSize();

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -94,6 +94,12 @@ bool horovod_ddl_built();
 // C interface to return flag indicating whether Horovod was compiled with CCL support.
 bool horovod_ccl_built();
 
+// C interface to return flag indicating whether Horovod was compiled with CUDA support.
+bool horovod_cuda_built();
+
+// C interface to return flag indicating whether Horovod was compiled with ROCm support.
+bool horovod_rocm_built();
+
 // C interface to return value of the ReduceOp::AVERAGE enum field.
 int horovod_reduce_op_average();
 
@@ -111,7 +117,9 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string name, const int device,
                               StatusCallback callback,
-                              ReduceOp reduce_op = ReduceOp::SUM);
+                              ReduceOp reduce_op = ReduceOp::SUM,
+                              const double prescale_factor = 1.0,
+                              const double postscale_factor = 1.0);
 
 Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -118,8 +118,8 @@ Status EnqueueTensorAllreduce(std::shared_ptr<OpContext> context,
                               const std::string name, const int device,
                               StatusCallback callback,
                               ReduceOp reduce_op = ReduceOp::SUM,
-                              const double prescale_factor = 1.0,
-                              const double postscale_factor = 1.0);
+                              double prescale_factor = 1.0,
+                              double postscale_factor = 1.0);
 
 Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,

--- a/horovod/common/ops/ccl_operations.cc
+++ b/horovod/common/ops/ccl_operations.cc
@@ -95,7 +95,7 @@ Status CCLAllreduce::Execute(std::vector<TensorTableEntry>& entries, const Respo
   // Do allreduce.
   timeline.ActivityStartAll(entries, CCL_ALLREDUCE);
   const void* sendbuf = entries.size() > 1 || fused_input_data == buffer_data
-                        ? MPI_IN_PLACE : fused_input_data;
+                        ? buffer_data : fused_input_data;
   ccl_request_t ccl_req;
   CCL_CALL(ccl_allreduce((void*)sendbuf, buffer_data, num_elements, GetCCLDataType(first_entry.tensor),
                          ccl_reduction_sum, nullptr /*attr*/, nullptr /*comm*/, nullptr /*stream*/, &ccl_req));

--- a/horovod/common/ops/ccl_operations.cc
+++ b/horovod/common/ops/ccl_operations.cc
@@ -69,6 +69,7 @@ CCLAllreduce::CCLAllreduce(CCLContext* ccl_context, HorovodGlobalState* global_s
 Status CCLAllreduce::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
   auto& first_entry = entries[0];
 
+  const void* fused_input_data;
   void* buffer_data;
   size_t buffer_len;
   int64_t num_elements = NumElements(entries);
@@ -77,23 +78,34 @@ Status CCLAllreduce::Execute(std::vector<TensorTableEntry>& entries, const Respo
   auto& timeline = global_state_->timeline;
   if (entries.size() > 1) {
     timeline.ActivityStartAll(entries, MEMCPY_IN_FUSION_BUFFER);
-    const void* fused_input_data;
     MemcpyInFusionBuffer(entries, fused_input_data, buffer_data, buffer_len);
     timeline.ActivityEndAll(entries);
   } else {
+    fused_input_data = first_entry.tensor->data();
     buffer_data = (void*) first_entry.output->data();
     buffer_len = (size_t) first_entry.output->size();
   }
 
+  if (response.prescale_factor() != 1.0) {
+    // Execute prescaling op
+    ScaleBuffer(response.prescale_factor(), entries, fused_input_data, buffer_data, num_elements);
+    fused_input_data = buffer_data; // for unfused, scale is done out of place
+  }
+
   // Do allreduce.
   timeline.ActivityStartAll(entries, CCL_ALLREDUCE);
-  const void* sendbuf = entries.size() > 1 || first_entry.tensor->data() == first_entry.output->data()
-                        ? buffer_data : first_entry.tensor->data();
+  const void* sendbuf = entries.size() > 1 || fused_input_data == buffer_data
+                        ? MPI_IN_PLACE : fused_input_data;
   ccl_request_t ccl_req;
   CCL_CALL(ccl_allreduce((void*)sendbuf, buffer_data, num_elements, GetCCLDataType(first_entry.tensor),
                          ccl_reduction_sum, nullptr /*attr*/, nullptr /*comm*/, nullptr /*stream*/, &ccl_req));
   CCL_CALL(ccl_wait(ccl_req));
   timeline.ActivityEndAll(entries);
+
+  if (response.postscale_factor() != 1.0) {
+    // Execute postscaling op
+    ScaleBuffer(response.postscale_factor(), entries, buffer_data, buffer_data, num_elements);
+  }
 
   // Copy memory out of the fusion buffer.
   if (entries.size() > 1) {

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(CUDA)
 # Remove C++ std flags (--std=c++11 included in CUDA_NVCC_FLAGS)
 string(REGEX REPLACE  "-std=[^ ]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+# Set ar
+if(DEFINED ENV{AR})
+  set(CMAKE_AR $ENV{AR})
+endif()
+
 MESSAGE(STATUS "HVD_NVCC_COMPILE_FLAGS = ${HVD_NVCC_COMPILE_FLAGS}")
 
 list(APPEND CUDA_NVCC_FLAGS ${HVD_NVCC_COMPILE_FLAGS})

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -4,6 +4,9 @@ project(horovod_cuda_kernels)
 
 find_package(CUDA)
 
+# Remove C++ std flags (--std=c++11 included in CUDA_NVCC_FLAGS)
+string(REGEX REPLACE  "-std=[^ ]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 MESSAGE(STATUS "HVD_NVCC_COMPILE_FLAGS = ${HVD_NVCC_COMPILE_FLAGS}")
 
 list(APPEND CUDA_NVCC_FLAGS ${HVD_NVCC_COMPILE_FLAGS})

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_VERBOSE_MAKEFILE ON)
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
+project(horovod_cuda_kernels)
+
+find_package(CUDA)
+
+MESSAGE(STATUS "HVD_NVCC_COMPILE_FLAGS = ${HVD_NVCC_COMPILE_FLAGS}")
+
+list(APPEND CUDA_NVCC_FLAGS ${HVD_NVCC_COMPILE_FLAGS})
+
+cuda_add_library(horovod_cuda_kernels
+    cuda_kernels.cu
+)

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(CMAKE_VERBOSE_MAKEFILE ON)
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(horovod_cuda_kernels)
@@ -12,3 +11,5 @@ list(APPEND CUDA_NVCC_FLAGS ${HVD_NVCC_COMPILE_FLAGS})
 cuda_add_library(horovod_cuda_kernels
     cuda_kernels.cu
 )
+
+set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/horovod/common/ops/cuda/cuda_kernels.cu
+++ b/horovod/common/ops/cuda/cuda_kernels.cu
@@ -1,0 +1,124 @@
+// Copyright (C) 2020 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#include "cuda_kernels.h"
+
+#include <stdexcept>
+#include <cuda_fp16.h>
+
+namespace horovod {
+namespace common {
+
+template<typename T, typename TS>
+__global__ void scale_buffer_k(const T* input, T* output, int64_t num_elements, const TS scale_factor) {
+
+  const size_t idx = static_cast<size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+
+  for (size_t i = idx; i < num_elements; i += gridDim.x * blockDim.x) {
+    output[i] = scale_factor * input[i];
+  }
+}
+
+// Specialization for half2
+__global__ void scale_buffer_half2_k(const __half* input, __half* output, int64_t num_elements, const __half scale_factor) {
+
+#if __CUDA_ARCH__ >= 530
+  const size_t idx = static_cast<size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  const __half2* input_h2 = reinterpret_cast<const __half2 *>(input);
+  __half2* output_h2 = reinterpret_cast<__half2 *>(output);
+  const __half2 scale_factor_h2 = __halves2half2(scale_factor, scale_factor);
+
+  for (size_t i = idx; i < num_elements / 2; i += gridDim.x * blockDim.x) {
+    output_h2[i] = __hmul2(scale_factor_h2, input_h2[i]);
+  }
+
+  // Deal with last element if num_elements is odd
+  if (idx == 0 && num_elements % 2) {
+    output[num_elements - 1] = __hmul(scale_factor, input[num_elements - 1]);
+  }
+#endif
+}
+
+#if __CUDA_ARCH__ <= 530
+// Specialization for architectures without __half compute
+template<>
+__global__ void scale_buffer_k(const __half* input, __half* output, int64_t num_elements, const __half scale_factor) {
+
+  const size_t idx = static_cast<size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+
+  for (size_t i = idx; i < num_elements; i += gridDim.x * blockDim.x) {
+    output[i] = __float2half(__half2float(scale_factor) * __half2float(input[i]));
+  }
+}
+#endif
+
+#define NTHREADS_SCALE_BUFFER_KERNEL 512
+void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const int64_t num_elements, double scale_factor,
+                         DataType dtype, cudaStream_t stream) {
+  const int64_t blocks = (num_elements + NTHREADS_SCALE_BUFFER_KERNEL - 1) / NTHREADS_SCALE_BUFFER_KERNEL;
+  const int threads = NTHREADS_SCALE_BUFFER_KERNEL;
+  switch (dtype) {
+    case HOROVOD_UINT8:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const uint8_t*) fused_input_data, (uint8_t*) buffer_data,
+                                                     num_elements, scale_factor);
+      break;
+    case HOROVOD_INT8:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const int8_t*) fused_input_data, (int8_t*) buffer_data,
+                                                     num_elements, scale_factor);
+      break;
+    case HOROVOD_INT32:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const int32_t*) fused_input_data, (int32_t*) buffer_data,
+                                                     num_elements, scale_factor);
+      break;
+    case HOROVOD_INT64:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const int64_t*) fused_input_data, (int64_t*) buffer_data,
+                                                     num_elements, scale_factor);
+      break;
+    case HOROVOD_FLOAT16:
+    {
+      __half scale_factor_half = __float2half((float) scale_factor);
+#if __CUDA_ARCH__ >= 530
+      if ((size_t) fused_input_data % 4 == 0 && (size_t) buffer_data % 4 == 0) {
+        // If alignment allows, use half2 specialized kernel
+        int64_t blocks_h2 = (num_elements / 2 + NTHREADS_SCALE_BUFFER_KERNEL - 1) / NTHREADS_SCALE_BUFFER_KERNEL;
+        scale_buffer_half2_k<<<blocks_h2, threads, 0, stream>>>((const __half*) fused_input_data, (__half*) buffer_data,
+                                                          num_elements, scale_factor_half);
+      } else {
+        scale_buffer_k<<<blocks, threads, 0, stream>>>((const __half*) fused_input_data, (__half*) buffer_data,
+                                                       num_elements, scale_factor_half);
+     }
+#else
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const __half*) fused_input_data, (__half*) buffer_data,
+                                                     num_elements, scale_factor_half);
+#endif
+      break;
+    }
+    case HOROVOD_FLOAT32:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const float*) fused_input_data, (float*) buffer_data,
+                                                     num_elements, (float) scale_factor);
+      break;
+    case HOROVOD_FLOAT64:
+      scale_buffer_k<<<blocks, threads, 0, stream>>>((const double*) fused_input_data, (double*) buffer_data,
+                                                     num_elements, scale_factor);
+      break;
+    default:
+      throw std::logic_error("Type " + DataType_Name(dtype) +
+                             " not supported by ScaleBufferCudaImpl.");
+  }
+}
+
+} // namespace common
+} // namespace horovod
+

--- a/horovod/common/ops/cuda/cuda_kernels.cu
+++ b/horovod/common/ops/cuda/cuda_kernels.cu
@@ -34,8 +34,9 @@ __global__ void scale_buffer_k(const T* input, T* output, int64_t num_elements, 
 // Specialization for half2
 __global__ void scale_buffer_half2_k(const __half* input, __half* output, int64_t num_elements, const __half scale_factor) {
 
-#if __CUDA_ARCH__ >= 530
   const size_t idx = static_cast<size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+
+#if __CUDA_ARCH__ > 530
   const __half2* input_h2 = reinterpret_cast<const __half2 *>(input);
   __half2* output_h2 = reinterpret_cast<__half2 *>(output);
   const __half2 scale_factor_h2 = __halves2half2(scale_factor, scale_factor);
@@ -48,21 +49,29 @@ __global__ void scale_buffer_half2_k(const __half* input, __half* output, int64_
   if (idx == 0 && num_elements % 2) {
     output[num_elements - 1] = __hmul(scale_factor, input[num_elements - 1]);
   }
+#else
+  for (size_t i = idx; i < num_elements; i += gridDim.x * blockDim.x) {
+    output[i] = __float2half(__half2float(scale_factor) * __half2float(input[i]));
+  }
 #endif
 }
 
-#if __CUDA_ARCH__ <= 530
 // Specialization for architectures without __half compute
 template<>
 __global__ void scale_buffer_k(const __half* input, __half* output, int64_t num_elements, const __half scale_factor) {
 
   const size_t idx = static_cast<size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
 
+#if __CUDA_ARCH__ > 530
+  for (size_t i = idx; i < num_elements; i += gridDim.x * blockDim.x) {
+    output[i] = scale_factor * input[i];
+  }
+#else
   for (size_t i = idx; i < num_elements; i += gridDim.x * blockDim.x) {
     output[i] = __float2half(__half2float(scale_factor) * __half2float(input[i]));
   }
-}
 #endif
+}
 
 #define NTHREADS_SCALE_BUFFER_KERNEL 512
 void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const int64_t num_elements, double scale_factor,
@@ -89,7 +98,6 @@ void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const 
     case HOROVOD_FLOAT16:
     {
       __half scale_factor_half = __float2half((float) scale_factor);
-#if __CUDA_ARCH__ >= 530
       if ((size_t) fused_input_data % 4 == 0 && (size_t) buffer_data % 4 == 0) {
         // If alignment allows, use half2 specialized kernel
         int64_t blocks_h2 = (num_elements / 2 + NTHREADS_SCALE_BUFFER_KERNEL - 1) / NTHREADS_SCALE_BUFFER_KERNEL;
@@ -99,10 +107,6 @@ void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const 
         scale_buffer_k<<<blocks, threads, 0, stream>>>((const __half*) fused_input_data, (__half*) buffer_data,
                                                        num_elements, scale_factor_half);
      }
-#else
-      scale_buffer_k<<<blocks, threads, 0, stream>>>((const __half*) fused_input_data, (__half*) buffer_data,
-                                                     num_elements, scale_factor_half);
-#endif
       break;
     }
     case HOROVOD_FLOAT32:

--- a/horovod/common/ops/cuda/cuda_kernels.h
+++ b/horovod/common/ops/cuda/cuda_kernels.h
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+#ifndef CUDA_KERNELS_H
+#define CUDA_KERNELS_H
+
+#include "../../message.h"
+
+namespace horovod {
+namespace common {
+
+void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const int64_t num_elements,
+                         double scale_factor, DataType dtype, cudaStream_t stream);
+
+} // namespace common
+} // namespace horovod
+
+#endif // CUDA_KERNELS_H

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -15,6 +15,8 @@
 // =============================================================================
 
 #include "gpu_operations.h"
+#include "cuda/cuda_kernels.h"
+#include "../message.h"
 
 #include <thread>
 
@@ -143,6 +145,12 @@ public:
 
   void MemcpyAsyncD2H(void* dst, const void* src, size_t count, cudaStream_t stream) {
     ErrorCheck("cudaMemcpyAsync", cudaMemcpyAsync(dst, src, count, cudaMemcpyDeviceToHost, stream));
+  }
+
+  void ScaleBufferImpl(const void* fused_input_data, void* buffer_data, int64_t num_elements,
+                       double scale_factor, DataType dtype, cudaStream_t stream) {
+    ScaleBufferCudaImpl(fused_input_data, buffer_data, num_elements, scale_factor, dtype, stream);
+    ErrorCheck("ScaleBufferCudaImpl", cudaGetLastError());
   }
 
 private:

--- a/horovod/common/ops/gpu_context_impl.cc
+++ b/horovod/common/ops/gpu_context_impl.cc
@@ -45,3 +45,8 @@ void GPUContext::MemcpyAsyncD2H(void* dst, const void* src, size_t count, gpuStr
   pimpl->MemcpyAsyncD2H(dst, src, count, stream);
 }
 
+void GPUContext::ScaleBufferImpl(const void* fused_input_data, void* buffer_data, int64_t num_elements,
+                                 double scale_factor, DataType dtype, gpuStream_t stream) {
+  pimpl->ScaleBufferImpl(fused_input_data, buffer_data, num_elements, scale_factor, dtype, stream);
+}
+

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -109,6 +109,13 @@ void GPUAllreduce::MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry
                                gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
 }
 
+void GPUAllreduce::ScaleBuffer(double scale_factor, const std::vector<TensorTableEntry>& entries,
+                               const void* fused_input_data, void* buffer_data, int64_t num_elements) {
+  gpu_context_->ScaleBufferImpl(fused_input_data, buffer_data, num_elements, scale_factor, entries[0].tensor->dtype(),
+                                gpu_context_->streams[global_state_->current_nccl_stream][entries[0].device]);
+
+}
+
 GPUAllgather::GPUAllgather(GPUContext* context, HorovodGlobalState* global_state)
     : AllgatherOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
 

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #if HAVE_CUDA
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 using gpuError_t = cudaError_t;
 using gpuEvent_t = cudaEvent_t;
@@ -83,6 +84,9 @@ public:
   void MemcpyAsyncH2D(void* dst, const void* src, size_t count, gpuStream_t stream);
   void MemcpyAsyncD2H(void* dst, const void* src, size_t count, gpuStream_t stream);
 
+  void ScaleBufferImpl(const void* fused_input_data, void* buffer_data, int64_t num_elements,
+                       double scale_factor, DataType dtype, gpuStream_t stream);
+
   // Thread pool for finalizer threads
   ThreadPool finalizer_thread_pool;
 
@@ -138,8 +142,12 @@ protected:
   void MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
                                   const void* buffer_data_at_offset, TensorTableEntry& e) override;
 
+  void ScaleBuffer(double scale_factor, const std::vector<TensorTableEntry>& entries,
+                   const void* fused_input_data, void* buffer_data, int64_t num_elements);
+
   GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;
+
 };
 
 class GPUAllgather : public AllgatherOp {

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -15,6 +15,7 @@
 // =============================================================================
 
 #include "gpu_operations.h"
+#include "../message.h"
 
 #include <thread>
 
@@ -143,6 +144,11 @@ public:
 
   void MemcpyAsyncD2H(void* dst, const void* src, size_t count, hipStream_t stream) {
     ErrorCheck("hipMemcpyAsync", hipMemcpyAsync(dst, src, count, hipMemcpyDeviceToHost, stream));
+  }
+
+  void ScaleBufferImpl(const void* fused_input_data, void* buffer_data, int64_t num_elements,
+                   double scale_factor, DataType dtype, hipStream_t stream) {
+    throw std::logic_error("ScaleBuffer not implemented for AMD GPUs.");
   }
 
 private:

--- a/horovod/common/wire/message.fbs
+++ b/horovod/common/wire/message.fbs
@@ -58,6 +58,11 @@ table Request {
     // We use a repeated integer instead of a TensorShapeProto because linking directly
     // to TensorFlow protos causes issues. See the comment for DataType.
     tensor_shape:[long];
+
+    // Prescale and postscale factors
+    prescale_factor:double;
+    postscale_factor:double;
+
 }
 table RequestList {
     requests:[Request];
@@ -101,6 +106,10 @@ table Response {
     // Empty unless response_type is ALLREDUCE and there is at least one rank
     // that requested Join.
     tensor_type:DataType;
+
+    // Prescale and postscale factors
+    prescale_factor:double;
+    postscale_factor:double;
 }
 table ResponseList {
     responses:[Response];

--- a/horovod/common/wire/message_generated.h
+++ b/horovod/common/wire/message_generated.h
@@ -66,7 +66,7 @@ inline const DataType (&EnumValuesDataType())[10] {
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[] = {
+  static const char * const names[11] = {
     "HOROVOD_UINT8",
     "HOROVOD_INT8",
     "HOROVOD_UINT16",
@@ -108,7 +108,7 @@ inline const RequestType (&EnumValuesRequestType())[4] {
 }
 
 inline const char * const *EnumNamesRequestType() {
-  static const char * const names[] = {
+  static const char * const names[5] = {
     "ALLREDUCE",
     "ALLGATHER",
     "BROADCAST",
@@ -148,7 +148,7 @@ inline const ResponseType (&EnumValuesResponseType())[6] {
 }
 
 inline const char * const *EnumNamesResponseType() {
-  static const char * const names[] = {
+  static const char * const names[7] = {
     "ALLREDUCE",
     "ALLGATHER",
     "BROADCAST",
@@ -174,16 +174,18 @@ struct Request FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_TENSOR_NAME = 10,
     VT_ROOT_RANK = 12,
     VT_DEVICE = 14,
-    VT_TENSOR_SHAPE = 16
+    VT_TENSOR_SHAPE = 16,
+    VT_PRESCALE_FACTOR = 18,
+    VT_POSTSCALE_FACTOR = 20
   };
   int32_t request_rank() const {
     return GetField<int32_t>(VT_REQUEST_RANK, 0);
   }
-  RequestType request_type() const {
-    return static_cast<RequestType>(GetField<int8_t>(VT_REQUEST_TYPE, 0));
+  horovod::common::wire::RequestType request_type() const {
+    return static_cast<horovod::common::wire::RequestType>(GetField<int8_t>(VT_REQUEST_TYPE, 0));
   }
-  DataType tensor_type() const {
-    return static_cast<DataType>(GetField<int8_t>(VT_TENSOR_TYPE, 0));
+  horovod::common::wire::DataType tensor_type() const {
+    return static_cast<horovod::common::wire::DataType>(GetField<int8_t>(VT_TENSOR_TYPE, 0));
   }
   const flatbuffers::String *tensor_name() const {
     return GetPointer<const flatbuffers::String *>(VT_TENSOR_NAME);
@@ -197,6 +199,12 @@ struct Request FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<int64_t> *tensor_shape() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_TENSOR_SHAPE);
   }
+  double prescale_factor() const {
+    return GetField<double>(VT_PRESCALE_FACTOR, 0.0);
+  }
+  double postscale_factor() const {
+    return GetField<double>(VT_POSTSCALE_FACTOR, 0.0);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int32_t>(verifier, VT_REQUEST_RANK) &&
@@ -208,6 +216,8 @@ struct Request FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int32_t>(verifier, VT_DEVICE) &&
            VerifyOffset(verifier, VT_TENSOR_SHAPE) &&
            verifier.VerifyVector(tensor_shape()) &&
+           VerifyField<double>(verifier, VT_PRESCALE_FACTOR) &&
+           VerifyField<double>(verifier, VT_POSTSCALE_FACTOR) &&
            verifier.EndTable();
   }
 };
@@ -218,10 +228,10 @@ struct RequestBuilder {
   void add_request_rank(int32_t request_rank) {
     fbb_.AddElement<int32_t>(Request::VT_REQUEST_RANK, request_rank, 0);
   }
-  void add_request_type(RequestType request_type) {
+  void add_request_type(horovod::common::wire::RequestType request_type) {
     fbb_.AddElement<int8_t>(Request::VT_REQUEST_TYPE, static_cast<int8_t>(request_type), 0);
   }
-  void add_tensor_type(DataType tensor_type) {
+  void add_tensor_type(horovod::common::wire::DataType tensor_type) {
     fbb_.AddElement<int8_t>(Request::VT_TENSOR_TYPE, static_cast<int8_t>(tensor_type), 0);
   }
   void add_tensor_name(flatbuffers::Offset<flatbuffers::String> tensor_name) {
@@ -235,6 +245,12 @@ struct RequestBuilder {
   }
   void add_tensor_shape(flatbuffers::Offset<flatbuffers::Vector<int64_t>> tensor_shape) {
     fbb_.AddOffset(Request::VT_TENSOR_SHAPE, tensor_shape);
+  }
+  void add_prescale_factor(double prescale_factor) {
+    fbb_.AddElement<double>(Request::VT_PRESCALE_FACTOR, prescale_factor, 0.0);
+  }
+  void add_postscale_factor(double postscale_factor) {
+    fbb_.AddElement<double>(Request::VT_POSTSCALE_FACTOR, postscale_factor, 0.0);
   }
   explicit RequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -251,13 +267,17 @@ struct RequestBuilder {
 inline flatbuffers::Offset<Request> CreateRequest(
     flatbuffers::FlatBufferBuilder &_fbb,
     int32_t request_rank = 0,
-    RequestType request_type = RequestType_ALLREDUCE,
-    DataType tensor_type = DataType_HOROVOD_UINT8,
+    horovod::common::wire::RequestType request_type = horovod::common::wire::RequestType_ALLREDUCE,
+    horovod::common::wire::DataType tensor_type = horovod::common::wire::DataType_HOROVOD_UINT8,
     flatbuffers::Offset<flatbuffers::String> tensor_name = 0,
     int32_t root_rank = 0,
     int32_t device = 0,
-    flatbuffers::Offset<flatbuffers::Vector<int64_t>> tensor_shape = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<int64_t>> tensor_shape = 0,
+    double prescale_factor = 0.0,
+    double postscale_factor = 0.0) {
   RequestBuilder builder_(_fbb);
+  builder_.add_postscale_factor(postscale_factor);
+  builder_.add_prescale_factor(prescale_factor);
   builder_.add_tensor_shape(tensor_shape);
   builder_.add_device(device);
   builder_.add_root_rank(root_rank);
@@ -271,12 +291,14 @@ inline flatbuffers::Offset<Request> CreateRequest(
 inline flatbuffers::Offset<Request> CreateRequestDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     int32_t request_rank = 0,
-    RequestType request_type = RequestType_ALLREDUCE,
-    DataType tensor_type = DataType_HOROVOD_UINT8,
+    horovod::common::wire::RequestType request_type = horovod::common::wire::RequestType_ALLREDUCE,
+    horovod::common::wire::DataType tensor_type = horovod::common::wire::DataType_HOROVOD_UINT8,
     const char *tensor_name = nullptr,
     int32_t root_rank = 0,
     int32_t device = 0,
-    const std::vector<int64_t> *tensor_shape = nullptr) {
+    const std::vector<int64_t> *tensor_shape = nullptr,
+    double prescale_factor = 0.0,
+    double postscale_factor = 0.0) {
   auto tensor_name__ = tensor_name ? _fbb.CreateString(tensor_name) : 0;
   auto tensor_shape__ = tensor_shape ? _fbb.CreateVector<int64_t>(*tensor_shape) : 0;
   return horovod::common::wire::CreateRequest(
@@ -287,7 +309,9 @@ inline flatbuffers::Offset<Request> CreateRequestDirect(
       tensor_name__,
       root_rank,
       device,
-      tensor_shape__);
+      tensor_shape__,
+      prescale_factor,
+      postscale_factor);
 }
 
 struct RequestList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -295,8 +319,8 @@ struct RequestList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_REQUESTS = 4,
     VT_SHUTDOWN = 6
   };
-  const flatbuffers::Vector<flatbuffers::Offset<Request>> *requests() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Request>> *>(VT_REQUESTS);
+  const flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Request>> *requests() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Request>> *>(VT_REQUESTS);
   }
   bool shutdown() const {
     return GetField<uint8_t>(VT_SHUTDOWN, 0) != 0;
@@ -314,7 +338,7 @@ struct RequestList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct RequestListBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_requests(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Request>>> requests) {
+  void add_requests(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Request>>> requests) {
     fbb_.AddOffset(RequestList::VT_REQUESTS, requests);
   }
   void add_shutdown(bool shutdown) {
@@ -334,7 +358,7 @@ struct RequestListBuilder {
 
 inline flatbuffers::Offset<RequestList> CreateRequestList(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Request>>> requests = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Request>>> requests = 0,
     bool shutdown = false) {
   RequestListBuilder builder_(_fbb);
   builder_.add_requests(requests);
@@ -344,9 +368,9 @@ inline flatbuffers::Offset<RequestList> CreateRequestList(
 
 inline flatbuffers::Offset<RequestList> CreateRequestListDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<Request>> *requests = nullptr,
+    const std::vector<flatbuffers::Offset<horovod::common::wire::Request>> *requests = nullptr,
     bool shutdown = false) {
-  auto requests__ = requests ? _fbb.CreateVector<flatbuffers::Offset<Request>>(*requests) : 0;
+  auto requests__ = requests ? _fbb.CreateVector<flatbuffers::Offset<horovod::common::wire::Request>>(*requests) : 0;
   return horovod::common::wire::CreateRequestList(
       _fbb,
       requests__,
@@ -360,10 +384,12 @@ struct Response FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_ERROR_MESSAGE = 8,
     VT_DEVICES = 10,
     VT_TENSOR_SIZES = 12,
-    VT_TENSOR_TYPE = 14
+    VT_TENSOR_TYPE = 14,
+    VT_PRESCALE_FACTOR = 16,
+    VT_POSTSCALE_FACTOR = 18
   };
-  ResponseType response_type() const {
-    return static_cast<ResponseType>(GetField<int8_t>(VT_RESPONSE_TYPE, 0));
+  horovod::common::wire::ResponseType response_type() const {
+    return static_cast<horovod::common::wire::ResponseType>(GetField<int8_t>(VT_RESPONSE_TYPE, 0));
   }
   const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *tensor_names() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_TENSOR_NAMES);
@@ -377,8 +403,14 @@ struct Response FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<int64_t> *tensor_sizes() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_TENSOR_SIZES);
   }
-  DataType tensor_type() const {
-    return static_cast<DataType>(GetField<int8_t>(VT_TENSOR_TYPE, 0));
+  horovod::common::wire::DataType tensor_type() const {
+    return static_cast<horovod::common::wire::DataType>(GetField<int8_t>(VT_TENSOR_TYPE, 0));
+  }
+  double prescale_factor() const {
+    return GetField<double>(VT_PRESCALE_FACTOR, 0.0);
+  }
+  double postscale_factor() const {
+    return GetField<double>(VT_POSTSCALE_FACTOR, 0.0);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -393,6 +425,8 @@ struct Response FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyOffset(verifier, VT_TENSOR_SIZES) &&
            verifier.VerifyVector(tensor_sizes()) &&
            VerifyField<int8_t>(verifier, VT_TENSOR_TYPE) &&
+           VerifyField<double>(verifier, VT_PRESCALE_FACTOR) &&
+           VerifyField<double>(verifier, VT_POSTSCALE_FACTOR) &&
            verifier.EndTable();
   }
 };
@@ -400,7 +434,7 @@ struct Response FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct ResponseBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_response_type(ResponseType response_type) {
+  void add_response_type(horovod::common::wire::ResponseType response_type) {
     fbb_.AddElement<int8_t>(Response::VT_RESPONSE_TYPE, static_cast<int8_t>(response_type), 0);
   }
   void add_tensor_names(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> tensor_names) {
@@ -415,8 +449,14 @@ struct ResponseBuilder {
   void add_tensor_sizes(flatbuffers::Offset<flatbuffers::Vector<int64_t>> tensor_sizes) {
     fbb_.AddOffset(Response::VT_TENSOR_SIZES, tensor_sizes);
   }
-  void add_tensor_type(DataType tensor_type) {
+  void add_tensor_type(horovod::common::wire::DataType tensor_type) {
     fbb_.AddElement<int8_t>(Response::VT_TENSOR_TYPE, static_cast<int8_t>(tensor_type), 0);
+  }
+  void add_prescale_factor(double prescale_factor) {
+    fbb_.AddElement<double>(Response::VT_PRESCALE_FACTOR, prescale_factor, 0.0);
+  }
+  void add_postscale_factor(double postscale_factor) {
+    fbb_.AddElement<double>(Response::VT_POSTSCALE_FACTOR, postscale_factor, 0.0);
   }
   explicit ResponseBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -432,13 +472,17 @@ struct ResponseBuilder {
 
 inline flatbuffers::Offset<Response> CreateResponse(
     flatbuffers::FlatBufferBuilder &_fbb,
-    ResponseType response_type = ResponseType_ALLREDUCE,
+    horovod::common::wire::ResponseType response_type = horovod::common::wire::ResponseType_ALLREDUCE,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> tensor_names = 0,
     flatbuffers::Offset<flatbuffers::String> error_message = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> devices = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> tensor_sizes = 0,
-    DataType tensor_type = DataType_HOROVOD_UINT8) {
+    horovod::common::wire::DataType tensor_type = horovod::common::wire::DataType_HOROVOD_UINT8,
+    double prescale_factor = 0.0,
+    double postscale_factor = 0.0) {
   ResponseBuilder builder_(_fbb);
+  builder_.add_postscale_factor(postscale_factor);
+  builder_.add_prescale_factor(prescale_factor);
   builder_.add_tensor_sizes(tensor_sizes);
   builder_.add_devices(devices);
   builder_.add_error_message(error_message);
@@ -450,12 +494,14 @@ inline flatbuffers::Offset<Response> CreateResponse(
 
 inline flatbuffers::Offset<Response> CreateResponseDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    ResponseType response_type = ResponseType_ALLREDUCE,
+    horovod::common::wire::ResponseType response_type = horovod::common::wire::ResponseType_ALLREDUCE,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *tensor_names = nullptr,
     const char *error_message = nullptr,
     const std::vector<int32_t> *devices = nullptr,
     const std::vector<int64_t> *tensor_sizes = nullptr,
-    DataType tensor_type = DataType_HOROVOD_UINT8) {
+    horovod::common::wire::DataType tensor_type = horovod::common::wire::DataType_HOROVOD_UINT8,
+    double prescale_factor = 0.0,
+    double postscale_factor = 0.0) {
   auto tensor_names__ = tensor_names ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*tensor_names) : 0;
   auto error_message__ = error_message ? _fbb.CreateString(error_message) : 0;
   auto devices__ = devices ? _fbb.CreateVector<int32_t>(*devices) : 0;
@@ -467,7 +513,9 @@ inline flatbuffers::Offset<Response> CreateResponseDirect(
       error_message__,
       devices__,
       tensor_sizes__,
-      tensor_type);
+      tensor_type,
+      prescale_factor,
+      postscale_factor);
 }
 
 struct ResponseList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -475,8 +523,8 @@ struct ResponseList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_RESPONSES = 4,
     VT_SHUTDOWN = 6
   };
-  const flatbuffers::Vector<flatbuffers::Offset<Response>> *responses() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Response>> *>(VT_RESPONSES);
+  const flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Response>> *responses() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Response>> *>(VT_RESPONSES);
   }
   bool shutdown() const {
     return GetField<uint8_t>(VT_SHUTDOWN, 0) != 0;
@@ -494,7 +542,7 @@ struct ResponseList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct ResponseListBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_responses(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Response>>> responses) {
+  void add_responses(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Response>>> responses) {
     fbb_.AddOffset(ResponseList::VT_RESPONSES, responses);
   }
   void add_shutdown(bool shutdown) {
@@ -514,7 +562,7 @@ struct ResponseListBuilder {
 
 inline flatbuffers::Offset<ResponseList> CreateResponseList(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Response>>> responses = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<horovod::common::wire::Response>>> responses = 0,
     bool shutdown = false) {
   ResponseListBuilder builder_(_fbb);
   builder_.add_responses(responses);
@@ -524,9 +572,9 @@ inline flatbuffers::Offset<ResponseList> CreateResponseList(
 
 inline flatbuffers::Offset<ResponseList> CreateResponseListDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<Response>> *responses = nullptr,
+    const std::vector<flatbuffers::Offset<horovod::common::wire::Response>> *responses = nullptr,
     bool shutdown = false) {
-  auto responses__ = responses ? _fbb.CreateVector<flatbuffers::Offset<Response>>(*responses) : 0;
+  auto responses__ = responses ? _fbb.CreateVector<flatbuffers::Offset<horovod::common::wire::Response>>(*responses) : 0;
   return horovod::common::wire::CreateResponseList(
       _fbb,
       responses__,

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -24,7 +24,7 @@ from horovod.tensorflow import rank
 from horovod.tensorflow import local_rank
 from horovod.tensorflow import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.tensorflow import gloo_enabled, gloo_built
-from horovod.tensorflow import nccl_built, ddl_built, ccl_built
+from horovod.tensorflow import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
 from horovod.tensorflow import Compression
 
 from horovod.keras import callbacks, elastic
@@ -34,7 +34,8 @@ import horovod._keras as _impl
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
                          compression=Compression.none,
-                         sparse_as_dense=False):
+                         sparse_as_dense=False,
+                         gradient_predivide_factor=1.0):
     """
     An optimizer that wraps another keras.optimizers.Optimizer, using an allreduce to
     average gradient values before applying gradients to model weights.
@@ -55,10 +56,17 @@ def DistributedOptimizer(optimizer, name=None,
                          help improve performance and memory utilization if
                          the original sparse gradient has high density.
                          Defaults to false.
+        gradient_predivide_factor: gradient_predivide_factor splits the averaging
+                                   before and after the sum. Gradients are scaled by
+                                   1.0 / gradient_predivide_factor before the sum and
+                                   gradient_predivide_factor / size after the sum.
     """
+    if gradient_predivide_factor != 1.0 and rocm_built():
+            raise ValueError('gradient_predivide_factor not supported yet with ROCm')
+
     return _impl.create_distributed_optimizer(keras, optimizer, name,
                                               device_dense, device_sparse, compression,
-                                              sparse_as_dense)
+                                              sparse_as_dense, gradient_predivide_factor)
 
 
 def broadcast_global_variables(root_rank):
@@ -71,7 +79,7 @@ def broadcast_global_variables(root_rank):
     return _impl.broadcast_global_variables(K, root_rank)
 
 
-def allreduce(value, name=None, average=True):
+def allreduce(value, name=None, average=True, prescale_factor=1.0, postscale_factor=1.0):
     """
     Perform an allreduce on a tensor-compatible value.
 
@@ -81,8 +89,10 @@ def allreduce(value, name=None, average=True):
         name: Optional name for the constants created by this operation.
         average: If True, computes the average over all ranks.
                  Otherwise, computes the sum over all ranks.
+        prescale_factor: Multiplicative factor to scale tensor before allreduce.
+        postscale_factor: Multiplicative factor to scale tensor after allreduce.
     """
-    return _impl.allreduce(K, value, name, average)
+    return _impl.allreduce(K, value, name, average, prescale_factor, postscale_factor)
 
 
 def allgather(value, name=None):

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -81,6 +81,8 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
   auto output_tensor = ops_param->output_tensor.get();
   auto output = ops_param->output;
   auto name = ops_param->op_name;
+  auto prescale_factor = ops_param->prescale_factor;
+  auto postscale_factor = ops_param->postscale_factor;
   auto device = TensorUtil::GetDevice(input_tensor);
 
   auto hvd_tensor = std::make_shared<MXTensor>(input_tensor);
@@ -95,7 +97,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
           hvd_context, hvd_tensor, hvd_output, nullptr, name, device,
           [on_complete](const Status& status) {
             InvokeCompleteCallback(on_complete, status);
-      });
+      }, ReduceOp::SUM, prescale_factor, postscale_factor);
       break;
     case OperationType::ALLGATHER:
       enqueue_result = EnqueueTensorAllgather(
@@ -136,7 +138,9 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 inline void PushHorovodOperation(OperationType op_type, NDArray* input,
                                  NDArray* output, const char* name,
                                  int priority, int root_rank = -1,
-                                 NDArray* splits = nullptr) {
+                                 NDArray* splits = nullptr,
+                                 double prescale_factor = 1.0,
+                                 double postscale_factor = 1.0) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
 
@@ -162,7 +166,7 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   }
   auto ops_param = CreateMpiOpsParam(input_copy, output_copy, output,
     nullptr /* cpu_input_tensor */, nullptr /* cpu_output_tensor */,
-    op_type, op_name, root_rank, splits_tensor);
+    op_type, op_name, root_rank, splits_tensor, prescale_factor, postscale_factor);
 
   // Not in-place
   auto input_var = input->var();
@@ -198,6 +202,8 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   auto hvd_cpu_buffer = std::make_shared<MXTensor>(ops_param->cpu_input_tensor.get());
   auto hvd_context = std::make_shared<MXOpContext>(
     CPU_DEVICE_ID, ops_param->cpu_output_tensor.get());
+  auto prescale_factor = ops_param->prescale_factor;
+  auto postscale_factor = ops_param->postscale_factor;
 
   Status enqueue_result;
   switch (ops_param->op_type) {
@@ -206,7 +212,7 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
           hvd_context, hvd_cpu_buffer, hvd_cpu_buffer, nullptr, name, CPU_DEVICE_ID,
           [on_complete](const Status& status) {
             InvokeCompleteCallback(on_complete, status);
-      });
+      }, ReduceOp::SUM, prescale_factor, postscale_factor);
       break;
     case OperationType::ALLGATHER:
       enqueue_result = EnqueueTensorAllgather(
@@ -243,7 +249,9 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
 inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
                                           NDArray* output, const char* name,
                                           int priority, int root_rank = -1,
-                                          NDArray* splits = nullptr) {
+                                          NDArray* splits = nullptr,
+                                          double prescale_factor = 1.0,
+                                          double postscale_factor = 1.0) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
 
@@ -269,7 +277,7 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
 
   auto ops_param = CreateMpiOpsParam(nullptr, nullptr, output, cpu_input_tensor,
                                      cpu_output_tensor, op_type, op_name, root_rank,
-                                     splits_tensor);
+                                     splits_tensor, prescale_factor, postscale_factor);
 
   auto input_var = input->var();
   auto output_var = output->var();
@@ -308,25 +316,38 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
 
 extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
                                              const char* name, bool average,
-                                             int priority) {
+                                             int priority,
+                                             double prescale_factor,
+                                             double postscale_factor) {
   MX_API_BEGIN();
+
+#if !HAVE_ROCM
+  if (average) {
+    // Averaging done via postscale_factor.
+    postscale_factor /= horovod_size();
+  }
+#endif
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLREDUCE
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLREDUCE, input, output,
-                         name, priority);
+                         name, priority, 0, nullptr, prescale_factor, postscale_factor);
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLREDUCE, input, output,
-                                  name, priority);
+                                  name, priority, nullptr, prescale_factor, postscale_factor);
   }
 #else
   PushHorovodOperation(OperationType::ALLREDUCE, input, output,
-                       name, priority);
+                       name, priority, 0, nullptr, prescale_factor, postscale_factor);
 #endif
 
+#if HAVE_ROCM
+  // Averaging left at framework level for ROCm until ScaleBuffer implementation
+  // added.
   if (average) {
     *output /= horovod_size();
   }
+#endif
 
   MX_API_END();
 }

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -139,8 +139,8 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 inline void PushHorovodOperation(OperationType op_type, NDArray* input,
                                  NDArray* output, const char* name,
                                  int priority, int root_rank = -1,
-                                 NDArray* splits = nullptr,
                                  bool average = true,
+                                 NDArray* splits = nullptr,
                                  double prescale_factor = 1.0,
                                  double postscale_factor = 1.0) {
   auto op_type_name = GetOpTypeName(op_type);
@@ -252,8 +252,8 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
 inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
                                           NDArray* output, const char* name,
                                           int priority, int root_rank = -1,
-                                          NDArray* splits = nullptr,
                                           bool average = true,
+                                          NDArray* splits = nullptr,
                                           double prescale_factor = 1.0,
                                           double postscale_factor = 1.0) {
   auto op_type_name = GetOpTypeName(op_type);
@@ -408,15 +408,15 @@ extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
 #if HAVE_CUDA && !HOROVOD_GPU_ALLTOALL
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLTOALL, input, output,
-                         name, priority, -1, splits);
+                         name, priority, -1, false, splits);
 
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLTOALL, input, output,
-                                  name, priority, -1, splits);
+                                  name, priority, -1, false, splits);
   }
 #else
   PushHorovodOperation(OperationType::ALLTOALL, input, output,
-                       name, priority, -1, splits);
+                       name, priority, -1, false, splits);
 #endif
 
   MX_API_END();

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -331,14 +331,14 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
 #if HAVE_CUDA && !HOROVOD_GPU_ALLREDUCE
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLREDUCE, input, output,
-                         name, priority, 0, nullptr, prescale_factor, postscale_factor);
+                         name, priority, -1, nullptr, prescale_factor, postscale_factor);
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLREDUCE, input, output,
-                                  name, priority, nullptr, prescale_factor, postscale_factor);
+                                  name, priority, -1, nullptr, prescale_factor, postscale_factor);
   }
 #else
   PushHorovodOperation(OperationType::ALLREDUCE, input, output,
-                       name, priority, 0, nullptr, prescale_factor, postscale_factor);
+                       name, priority, -1, nullptr, prescale_factor, postscale_factor);
 #endif
 
 #if HAVE_ROCM

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -47,6 +47,8 @@ struct MpiOpsParam {
   std::string op_name;
   int root_rank;
   NDArraySharedPtr splits_tensor;
+  double prescale_factor;
+  double postscale_factor;
 
   MpiOpsParam(NDArraySharedPtr input_tensor,
               NDArraySharedPtr output_tensor,
@@ -55,7 +57,9 @@ struct MpiOpsParam {
               NDArraySharedPtr cpu_output_tensor,
               const OperationType& op_type, const std::string& op_name,
               int root_rank,
-              NDArraySharedPtr splits_tensor)
+              NDArraySharedPtr splits_tensor,
+              double prescale_factor,
+              double postscale_factor)
       : input_tensor(input_tensor),
         output_tensor(output_tensor),
         output(output),
@@ -64,7 +68,9 @@ struct MpiOpsParam {
         op_type(op_type),
         op_name(op_name),
         root_rank(root_rank),
-        splits_tensor(splits_tensor) {
+        splits_tensor(splits_tensor),
+        prescale_factor(prescale_factor),
+        postscale_factor(postscale_factor) {
   }
 };
 
@@ -76,9 +82,12 @@ inline MpiOpsParam* CreateMpiOpsParam(NDArraySharedPtr input_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
                                       int root_rank,
-                                      NDArraySharedPtr splits_tensor) {
+                                      NDArraySharedPtr splits_tensor,
+                                       double prescale_factor,
+                                      double postscale_factor) {
   return new MpiOpsParam(input_tensor, output_tensor, output, cpu_input_tensor,
-    cpu_output_tensor, op_type, op_name, root_rank, splits_tensor);
+    cpu_output_tensor, op_type, op_name, root_rank, splits_tensor, prescale_factor,
+    postscale_factor);
 }
 
 void DeleteMpiOpsParam(void* param) {
@@ -89,7 +98,9 @@ void DeleteMpiOpsParam(void* param) {
 extern "C" int horovod_mxnet_allreduce_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, bool average,
-                                             int priority);
+                                             int priority,
+                                             double prescale_factor,
+                                             double postscale_factor);
 extern "C" int horovod_mxnet_allgather_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, int priority);

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -47,6 +47,7 @@ struct MpiOpsParam {
   std::string op_name;
   int root_rank;
   NDArraySharedPtr splits_tensor;
+  bool average;
   double prescale_factor;
   double postscale_factor;
 
@@ -56,7 +57,7 @@ struct MpiOpsParam {
               NDArraySharedPtr cpu_input_tensor,
               NDArraySharedPtr cpu_output_tensor,
               const OperationType& op_type, const std::string& op_name,
-              int root_rank,
+              int root_rank, bool average,
               NDArraySharedPtr splits_tensor,
               double prescale_factor,
               double postscale_factor)
@@ -69,6 +70,7 @@ struct MpiOpsParam {
         op_name(op_name),
         root_rank(root_rank),
         splits_tensor(splits_tensor),
+        average(average),
         prescale_factor(prescale_factor),
         postscale_factor(postscale_factor) {
   }
@@ -81,12 +83,12 @@ inline MpiOpsParam* CreateMpiOpsParam(NDArraySharedPtr input_tensor,
                                       NDArraySharedPtr cpu_output_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
-                                      int root_rank,
+                                      int root_rank, bool average,
                                       NDArraySharedPtr splits_tensor,
-                                       double prescale_factor,
+                                      double prescale_factor,
                                       double postscale_factor) {
   return new MpiOpsParam(input_tensor, output_tensor, output, cpu_input_tensor,
-    cpu_output_tensor, op_type, op_name, root_rank, splits_tensor, prescale_factor,
+    cpu_output_tensor, op_type, op_name, root_rank, average, splits_tensor, prescale_factor,
     postscale_factor);
 }
 

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -40,13 +40,16 @@ gloo_built = _basics.gloo_built
 nccl_built = _basics.nccl_built
 ddl_built = _basics.ddl_built
 ccl_built = _basics.ccl_built
+cuda_built = _basics.cuda_built
+rocm_built = _basics.rocm_built
 
 dll_path = os.path.join(os.path.dirname(__file__),
                         'mpi_lib' + get_ext_suffix())
 MPI_MXNET_LIB_CTYPES = ctypes.CDLL(dll_path, ctypes.RTLD_GLOBAL)
 
 
-def allreduce(tensor, average=True, name=None, priority=0):
+def allreduce(tensor, average=True, name=None, priority=0, prescale_factor=1.0,
+              postscale_factor=1.0):
     """
     A function that performs averaging or summation of the input tensor over
     all the Horovod processes. The input tensor is not modified.
@@ -67,6 +70,8 @@ def allreduce(tensor, average=True, name=None, priority=0):
         name: A name of the reduction operation.
         priority: The priority of this operation. Higher priority operations
                   are likely to be executed before other operations.
+        prescale_factor: Multiplicative factor to scale tensor before allreduce
+        postscale_factor: Multiplicative factor to scale tensor after allreduce
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -79,16 +84,21 @@ def allreduce(tensor, average=True, name=None, priority=0):
     if isinstance(name, string_types):
         check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
             c_in, c_out, c_str(name), ctypes.c_bool(average),
-            ctypes.c_int(priority)))
+            ctypes.c_int(priority),
+            ctypes.c_double(prescale_factor),
+            ctypes.c_double(postscale_factor)))
     else:
         check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
             c_in, c_out, name, ctypes.c_bool(average),
-            ctypes.c_int(priority)))
+            ctypes.c_int(priority),
+            ctypes.c_double(prescale_factor),
+            ctypes.c_double(postscale_factor)))
 
     return output
 
 
-def allreduce_(tensor, average=True, name=None, priority=0):
+def allreduce_(tensor, average=True, name=None, priority=0, prescale_factor=1.0,
+              postscale_factor=1.0):
     """
     A function that performs in-place averaging or summation of the input
     tensor over all the Horovod processes.
@@ -105,6 +115,8 @@ def allreduce_(tensor, average=True, name=None, priority=0):
         name: A name of the reduction operation.
         priority: The priority of this operation. Higher priority operations
                   are likely to be executed before other operations.
+        prescale_factor: Multiplicative factor to scale tensor before allreduce
+        postscale_factor: Multiplicative factor to scale tensor after allreduce
 
     Returns:
         A tensor of the same shape and type as `tensor`, averaged or summed
@@ -115,11 +127,15 @@ def allreduce_(tensor, average=True, name=None, priority=0):
     if isinstance(name, string_types):
         check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
             c_in, c_out, c_str(name), ctypes.c_bool(average),
-            ctypes.c_int(priority)))
+            ctypes.c_int(priority),
+            ctypes.c_double(prescale_factor),
+            ctypes.c_double(postscale_factor)))
     else:
         check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_allreduce_async(
             c_in, c_out, name, ctypes.c_bool(average),
-            ctypes.c_int(priority)))
+            ctypes.c_int(priority),
+            ctypes.c_double(prescale_factor),
+            ctypes.c_double(postscale_factor)))
     return tensor
 
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -246,7 +246,7 @@ def _make_allreduce_grads_fn(name, device_dense, device_sparse,
         # Perform averaging via pre/postscaling factors.
         # Split average operation across pre/postscale factors
         prescale_factor = 1.0 / gradient_predivide_factor
-        postscale_factor = gradient_predivide_factor / size()
+        postscale_factor = gradient_predivide_factor / tf.cast(size_op(), dtype=tf.float64)
         true_op = Sum
     else:
         prescale_factor = 1.0

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -479,8 +479,6 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
         gradient_predivide_factor / size after the sum.
     """
     if gradient_predivide_factor != 1.0:
-        if op == Adasum:
-            raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
         if rocm_built():
             raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 
@@ -500,11 +498,9 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             raise ValueError('op == Adasum is not supported yet with Keras')
         if backward_passes_per_step > 1:
             raise ValueError('backward_passes_per_step > 1 is not supported yet with Keras')
-        if gradient_predivide_factor != 1.0:
-            raise ValueError('gradient_predivide_factor not supported yet with Keras')
         import horovod.tensorflow.keras as hvd_k
         return hvd_k.DistributedOptimizer(optimizer, name, device_dense, device_sparse,
-                                          compression, sparse_as_dense)
+                                          compression, sparse_as_dense, gradient_predivide_factor)
     else:
         raise ValueError('Provided optimizer doesn\'t inherit from either legacy '
                          'TensorFlow or Keras optimizer: %s' % optimizer)
@@ -562,8 +558,6 @@ if hasattr(tf, 'GradientTape'):
             gradient_predivide_factor / size after the sum.
         """
         if gradient_predivide_factor != 1.0:
-            if op == Adasum:
-                raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
             if rocm_built():
                 raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -246,7 +246,7 @@ def _make_allreduce_grads_fn(name, device_dense, device_sparse,
         # Perform averaging via pre/postscaling factors.
         # Split average operation across pre/postscale factors
         prescale_factor = 1.0 / gradient_predivide_factor
-        postscale_factor = gradient_predivide_factor / tf.cast(size_op(), dtype=tf.float64)
+        postscale_factor = gradient_predivide_factor / size()
         true_op = Sum
     else:
         prescale_factor = 1.0

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -32,7 +32,7 @@ from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank, is_ho
 from horovod.tensorflow.mpi_ops import rank_op, local_rank_op, size_op, local_size_op
 from horovod.tensorflow.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.tensorflow.mpi_ops import gloo_enabled, gloo_built
-from horovod.tensorflow.mpi_ops import nccl_built, ddl_built, ccl_built
+from horovod.tensorflow.mpi_ops import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
 from horovod.tensorflow.mpi_ops import Average, Sum, Adasum
 from horovod.tensorflow.mpi_ops import handle_average_backwards_compatibility, check_num_rank_power_of_2
 from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache
@@ -50,7 +50,8 @@ if tf.__version__.startswith('2.2.'):
 
 
 def allreduce(tensor, average=None, device_dense='', device_sparse='',
-              compression=Compression.none, op=None):
+              compression=Compression.none, op=None,
+              prescale_factor=1.0, postscale_factor=1.0):
     """Perform an allreduce on a tf.Tensor or tf.IndexedSlices.
 
     This function performs a bandwidth-optimal ring allreduce on the input
@@ -75,14 +76,21 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
                      using compression.
         op: The reduction operation to combine tensors across different ranks.
             Defaults to Average if None is given.
+        prescale_factor: Multiplicative factor to scale tensor before allreduce.
+        postscale_factor: Multiplicative factor to scale tensor after allreduce.
 
     Returns:
         A tensor of the same shape and type as `tensor`, summed across all
         processes.
     """
     op = handle_average_backwards_compatibility(op, average)
-    # Averaging happens in framework code, so translate that to Sum for the actual call
+
     true_op = Sum if op == Average else op
+    if not rocm_built():
+      if (op == Average):
+        # Averaging happens via postscale_factor.
+        postscale_factor /= size()
+
 
     if isinstance(tensor, tf.IndexedSlices):
         # TODO: Need to fix this to actuall call Adasum
@@ -106,7 +114,9 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
             horovod_size = tf.cast(size_op() if int(os.environ.get("HOROVOD_ELASTIC", 0)) else size(),
                                    dtype=tensor.dtype)
             tensor_compressed, ctx = compression.compress(tensor)
-            summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op)
+            summed_tensor_compressed = _allreduce(tensor_compressed, op=true_op,
+                                                  prescale_factor=prescale_factor,
+                                                  postscale_factor=postscale_factor)
             summed_tensor = compression.decompress(summed_tensor_compressed, ctx)
             if op == Adasum:
                 if 'CPU' not in tensor.device and gpu_available('tensorflow'):
@@ -130,7 +140,10 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
                         raise NotImplementedError('Running Adasum with non-power of 2 ranks is not supported yet.')
                     new_tensor = summed_tensor
             else:
-                new_tensor = (summed_tensor / horovod_size) if op == Average else summed_tensor
+                if rocm_built():
+                    new_tensor = (summed_tensor / horovod_size) if op == Average else summed_tensor
+                else:
+                  new_tensor = summed_tensor
         return new_tensor
 
 
@@ -226,7 +239,17 @@ if _SessionRunHook is not None and _get_default_graph is not None:
 
 @_cache
 def _make_allreduce_grads_fn(name, device_dense, device_sparse,
-                             compression, sparse_as_dense, op):
+                             compression, sparse_as_dense, op, gradient_predivide_factor):
+    if op == Average and gradient_predivide_factor != 1.0:
+        # Split average operation across pre/postscale factors
+        prescale_factor = 1.0 / gradient_predivide_factor
+        postscale_factor = gradient_predivide_factor / size()
+        true_op = Sum
+    else:
+        prescale_factor = 1.0
+        postscale_factor = 1.0
+        true_op = op
+
     def allreduce_grads(grads):
         with tf.name_scope(name + "_Allreduce"):
             if sparse_as_dense:
@@ -235,10 +258,12 @@ def _make_allreduce_grads_fn(name, device_dense, device_sparse,
                          else grad for grad in grads]
 
             return [_allreduce_cond(grad,
-                                    device_dense=device_dense,
-                                    device_sparse=device_sparse,
-                                    compression=compression,
-                                    op=op)
+                              device_dense=device_dense,
+                              device_sparse=device_sparse,
+                              compression=compression,
+                              op=true_op,
+                              prescale_factor=prescale_factor,
+                              postscale_factor=postscale_factor)
                     if grad is not None else grad
                     for grad in grads]
 
@@ -266,14 +291,15 @@ if _LegacyOptimizer is not None:
 
         def __init__(self, optimizer, name=None, use_locking=False, device_dense='',
                     device_sparse='', compression=Compression.none,
-                    sparse_as_dense=False, op=Average):
+                    sparse_as_dense=False, op=Average, gradient_predivide_factor=1.0):
             if name is None:
                 name = "Distributed{}".format(type(optimizer).__name__)
             super(_DistributedOptimizer, self).__init__(name=name, use_locking=use_locking)
 
             self._optimizer = optimizer
             self._allreduce_grads = _make_allreduce_grads_fn(
-                name, device_dense, device_sparse, compression, sparse_as_dense, op)
+                name, device_dense, device_sparse, compression, sparse_as_dense, op,
+                gradient_predivide_factor)
 
         def compute_gradients(self, *args, **kwargs):
             """Compute gradients of all trainable variables.
@@ -404,7 +430,7 @@ if _LegacyOptimizer is not None:
 def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='',
                          device_sparse='', compression=Compression.none,
                          sparse_as_dense=False, backward_passes_per_step=1,
-                         op=Average):
+                         op=Average, gradient_predivide_factor=1.0):
     """Construct a new DistributedOptimizer, which uses another optimizer
     under the hood for computing single-process gradient values and
     applying gradient updates after the gradient values have been combined
@@ -441,7 +467,18 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
       op:
         The reduction operation to use when combining gradients across
         different ranks.
+      gradient_predivide_factor:
+        If op == Average, gradient_predivide_factor splits the averaging
+        before and after the sum. Gradients are scaled by
+        1.0 / gradient_predivide_factor before the sum and
+        gradient_predivide_factor / size after the sum.
     """
+    if gradient_predivide_factor != 1.0:
+        if op == Adasum:
+            raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
+        if rocm_built():
+            raise ValueError('gradient_predivide_factor not supported yet with ROCm')
+
     if isinstance(optimizer, _LegacyOptimizer):
         if op == Adasum:
             return _DistributedAdasumOptimizer(optimizer, name, use_locking, device_dense,
@@ -451,12 +488,15 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
                 raise ValueError('backward_passes_per_step>1 is not supported yet with '
                                  'op != Adasum')
             return _DistributedOptimizer(optimizer, name, use_locking, device_dense,
-                                        device_sparse, compression, sparse_as_dense, op)
+                                        device_sparse, compression, sparse_as_dense, op,
+                                        gradient_predivide_factor)
     elif isinstance(optimizer, tf.keras.optimizers.Optimizer):
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
         if backward_passes_per_step > 1:
             raise ValueError('backward_passes_per_step > 1 is not supported yet with Keras')
+        if gradient_predivide_factor != 1.0:
+            raise ValueError('gradient_predivide_factor not supported yet with Keras')
         import horovod.tensorflow.keras as hvd_k
         return hvd_k.DistributedOptimizer(optimizer, name, device_dense, device_sparse,
                                           compression, sparse_as_dense)
@@ -468,7 +508,7 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
 if hasattr(tf, 'GradientTape'):
     class _DistributedGradientTape(tf.GradientTape):
         def __init__(self, tape, device_dense, device_sparse, compression, sparse_as_dense, op,
-                     persistent=False, watch_accessed_variables=True):
+                     gradient_predivide_factor, persistent=False, watch_accessed_variables=True):
             if hasattr(tape, '_watch_accessed_variables'):
                 super(self.__class__, self).__init__(persistent, watch_accessed_variables)
             else:
@@ -477,7 +517,7 @@ if hasattr(tf, 'GradientTape'):
             self._tape = tape
             self._allreduce_grads = _make_allreduce_grads_fn(
                 'DistributedGradientTape', device_dense, device_sparse, compression,
-                sparse_as_dense, op)
+                sparse_as_dense, op, gradient_predivide_factor)
 
         def gradient(self, target, sources, output_gradients=None):
             gradients = super(self.__class__, self).gradient(target, sources, output_gradients)
@@ -486,7 +526,7 @@ if hasattr(tf, 'GradientTape'):
 
     def DistributedGradientTape(gradtape, device_dense='', device_sparse='',
                                 compression=Compression.none, sparse_as_dense=False,
-                                op=Average):
+                                op=Average, gradient_predivide_factor=1.0):
         """A tape that wraps another tf.GradientTape, using an allreduce to
         combine gradient values before applying gradients to model weights.
 
@@ -510,13 +550,24 @@ if hasattr(tf, 'GradientTape'):
           op:
             The reduction operation to use when combining gradients across
             different ranks.
+          gradient_predivide_factor:
+            If op == Average, gradient_predivide_factor splits the averaging
+            before and after the sum. Gradients are scaled by
+            1.0 / gradient_predivide_factor before the sum and
+            gradient_predivide_factor / size after the sum.
         """
+        if gradient_predivide_factor != 1.0:
+            if op == Adasum:
+                raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
+            if rocm_built():
+                raise ValueError('gradient_predivide_factor not supported yet with ROCm')
+
         cls = type(gradtape.__class__.__name__, (gradtape.__class__,),
                    dict(_DistributedGradientTape.__dict__))
         if hasattr(gradtape, '_watch_accessed_variables'):
             return cls(gradtape._tape, device_dense, device_sparse, compression,
-                       sparse_as_dense, op, gradtape._persistent,
+                       sparse_as_dense, op, gradient_predivide_factor, gradtape._persistent,
                        gradtape._watch_accessed_variables)
         else:
             return cls(gradtape._tape, device_dense, device_sparse, compression,
-                       sparse_as_dense, op, gradtape._persistent)
+                       sparse_as_dense, op, gradient_predivide_factor, gradtape._persistent)

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -373,6 +373,8 @@ public:
   explicit HorovodAllreduceOp(OpKernelConstruction* context)
       : AsyncOpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("reduce_op", &reduce_op_));
+    OP_REQUIRES_OK(context, context->GetAttr("prescale_factor", &prescale_factor_));
+    OP_REQUIRES_OK(context, context->GetAttr("postscale_factor", &postscale_factor_));
   }
 
   void ComputeAsync(OpKernelContext* context, DoneCallback done) override {
@@ -382,14 +384,6 @@ public:
     auto node_name = name();
     auto device = GetDeviceID(context);
     auto tensor = context->input(0);
-    auto prescale_factor = context->input(1);
-    auto postscale_factor = context->input(2);
-    OP_REQUIRES(context, TensorShapeUtils::IsScalar(prescale_factor.shape()),
-                errors::InvalidArgument("prescale_factor should be a scalar tensor."));
-    OP_REQUIRES(context, TensorShapeUtils::IsScalar(postscale_factor.shape()),
-                errors::InvalidArgument("postscale_factor should be a scalar tensor."));
-    double prescale_factor_ = *reinterpret_cast<const double *>(prescale_factor.tensor_data().data());
-    double postscale_factor_ = *reinterpret_cast<const double *>(postscale_factor.tensor_data().data());
     horovod::common::ReduceOp reduce_op = static_cast<horovod::common::ReduceOp>(reduce_op_);
     Tensor* output;
     OP_REQUIRES_OK_ASYNC(
@@ -404,29 +398,30 @@ public:
         [context, done](const common::Status& status) {
           context->SetStatus(ConvertStatus(status));
           done();
-        }, reduce_op, prescale_factor_, postscale_factor_);
+        }, reduce_op, (double) prescale_factor_, (double) postscale_factor_);
     OP_REQUIRES_OK_ASYNC(context, ConvertStatus(enqueue_result), done);
   }
 
 private:
   int reduce_op_;
+  // Using float since TF does not support double OP attributes
+  float prescale_factor_;
+  float postscale_factor_;
 };
 
 REGISTER_KERNEL_BUILDER(Name("HorovodAllreduce").Device(DEVICE_CPU),
                         HorovodAllreduceOp);
 #if HOROVOD_GPU_ALLREDUCE
-REGISTER_KERNEL_BUILDER(Name("HorovodAllreduce").Device(DEVICE_GPU)
-                        .HostMemory("prescale_factor")
-                        .HostMemory("postscale_factor"),
+REGISTER_KERNEL_BUILDER(Name("HorovodAllreduce").Device(DEVICE_GPU),
                         HorovodAllreduceOp);
 #endif
 
 REGISTER_OP("HorovodAllreduce")
     .Attr("T: {int32, int64, float16, float32, float64}")
     .Attr("reduce_op: int")
+    .Attr("prescale_factor: float")
+    .Attr("postscale_factor: float")
     .Input("tensor: T")
-    .Input("prescale_factor: double")
-    .Input("postscale_factor: double")
     .Output("sum: T")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->input(0));

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -120,7 +120,10 @@ def _allreduce_grad(op, grad):
       The gradient with respect to the input of the op.
     """
     reduce_op = op.get_attr('reduce_op')
-    return _allreduce(grad, op=reduce_op)
+    prescale_factor = op.get_attr('prescale_factor')
+    postscale_factor = op.get_attr('postscale_factor')
+    return _allreduce(grad, op=reduce_op, prescale_factor=prescale_factor,
+                      postscale_factor=postscale_factor)
 
 
 def allgather(tensor, name=None):

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -62,6 +62,8 @@ gloo_built = _basics.gloo_built
 nccl_built = _basics.nccl_built
 ddl_built = _basics.ddl_built
 ccl_built = _basics.ccl_built
+cuda_built = _basics.cuda_built
+rocm_built = _basics.rocm_built
 
 # import reduction op values
 Average = _basics.Average
@@ -87,7 +89,7 @@ def _normalize_name(name):
     return re.sub('[^a-zA-Z0-9_]', '_', name)
 
 
-def _allreduce(tensor, name=None, op=Sum):
+def _allreduce(tensor, name=None, op=Sum, prescale_factor=1.0, postscale_factor=1.0):
     """An op which reduces an input tensor over all the Horovod processes. The
     default reduction is a sum.
 
@@ -101,7 +103,9 @@ def _allreduce(tensor, name=None, op=Sum):
     """
     if name is None and not _executing_eagerly():
         name = 'HorovodAllreduce_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op)
+    return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op,
+                                     prescale_factor=prescale_factor,
+                                     postscale_factor=postscale_factor)
 
 
 @ops.RegisterGradient('HorovodAllreduce')

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -101,8 +101,6 @@ def _allreduce(tensor, name=None, op=Sum, prescale_factor=1.0, postscale_factor=
       A tensor of the same shape and type as `tensor`, summed across all
       processes.
     """
-    prescale_factor = tf.convert_to_tensor(prescale_factor, dtype=tf.float64)
-    postscale_factor = tf.convert_to_tensor(postscale_factor, dtype=tf.float64)
     if name is None and not _executing_eagerly():
         name = 'HorovodAllreduce_%s' % _normalize_name(tensor.name)
     return MPI_LIB.horovod_allreduce(tensor, name=name, reduce_op=op,
@@ -122,8 +120,10 @@ def _allreduce_grad(op, grad):
       The gradient with respect to the input of the op.
     """
     reduce_op = op.get_attr('reduce_op')
-    return [_allreduce(grad, op=reduce_op, prescale_factor=op.inputs[1],
-                      postscale_factor=op.inputs[2]), None, None]
+    prescale_factor = op.get_attr('prescale_factor')
+    postscale_factor = op.get_attr('postscale_factor')
+    return _allreduce(grad, op=reduce_op, prescale_factor=prescale_factor,
+                      postscale_factor=postscale_factor)
 
 
 def allgather(tensor, name=None):

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -36,7 +36,7 @@ from horovod.torch.mpi_ops import init, shutdown, is_initialized
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank
 from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built
-from horovod.torch.mpi_ops import nccl_built, ddl_built, ccl_built
+from horovod.torch.mpi_ops import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
 from horovod.torch.mpi_ops import Average, Sum, Adasum
 from horovod.torch.optimizer import DistributedOptimizer
 from horovod.torch.sync_batch_norm import SyncBatchNorm

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -62,7 +62,8 @@ void DivideInPlace(::torch::Tensor& tensor, int divisor) {
 }
 
 int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
-                const std::string& name, int reduce_op_int) {
+                const std::string& name, int reduce_op_int,
+                double prescale_factor, double postscale_factor) {
   ThrowIfError(common::CheckInitialized());
 
   auto handle = handle_manager.AllocateHandle();
@@ -83,14 +84,15 @@ int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
           DivideInPlace(output, divisor);
         }
         handle_manager.MarkDone(handle, status);
-      }, reduce_op);
+      }, reduce_op, prescale_factor, postscale_factor);
   ThrowIfError(enqueue_result);
 
   return handle;
 }
 
 int DoAllreduceCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
-                         const std::string& name, int reduce_op_int) {
+                         const std::string& name, int reduce_op_int,
+                         double prescale_factor, double postscale_factor) {
   ThrowIfError(common::CheckInitialized());
 
   // Make async copy of input tensor to CPU tensor and record completion event.
@@ -118,7 +120,7 @@ int DoAllreduceCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int div
           DivideInPlace(output, divisor);
         }
         handle_manager.MarkDone(handle, status);
-      }, reduce_op);
+      }, reduce_op, prescale_factor, postscale_factor);
   ThrowIfError(enqueue_result);
 
   return handle;

--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -429,10 +429,10 @@ def DistributedOptimizer(optimizer, named_parameters=None,
     # We dynamically create a new class that inherits from the optimizer that was passed in.
     # The goal is to override the `step()` method with an allreduce implementation.
     if gradient_predivide_factor != 1.0:
-        if op == Adasum:
-            raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
         if rocm_built():
             raise ValueError('gradient_predivide_factor not supported yet with ROCm')
+        if op != Average:
+            raise ValueError('gradient_predivide_factor not supported with op != Average')
 
     if op != Adasum or size() == 1:
         cls = type(optimizer.__class__.__name__, (optimizer.__class__,),

--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -26,11 +26,13 @@ from horovod.torch.mpi_ops import allreduce_async_
 from horovod.torch.mpi_ops import synchronize
 from horovod.torch.mpi_ops import size
 from horovod.torch.mpi_ops import Average, Adasum
+from horovod.torch.mpi_ops import rocm_built
 
 
 class _DistributedOptimizer(torch.optim.Optimizer):
     def __init__(self, params, named_parameters, compression,
-                 backward_passes_per_step=1, op=Average):
+                 backward_passes_per_step=1, op=Average,
+                 gradient_predivide_factor=1.0):
         super(self.__class__, self).__init__(params)
         self._compression = compression
 
@@ -66,6 +68,7 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         self._allreduce_delay = {v: self.backward_passes_per_step
                                  for _, v in sorted(named_parameters)}
         self.op = op
+        self.gradient_predivide_factor = gradient_predivide_factor
         self._handles = {}
         self._grad_accs = []
         self._requires_update = set()
@@ -113,7 +116,18 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         tensor = p.grad
         tensor_compressed, ctx = self._compression.compress(tensor)
 
-        handle = allreduce_async_(tensor_compressed, name=name, op=self.op)
+        if self.op == Average and self.gradient_predivide_factor != 1.0:
+            prescale_factor = 1.0 / gradient_predivide_factor
+            postscale_factor = gradient_predivide_factor / size()
+            true_op = Sum
+        else:
+            prescale_factor = 1.0
+            postscale_factor = 1.0
+            true_op = self.op
+
+        handle = allreduce_async_(tensor_compressed, name=name, op=true_op,
+                                  prescale_factor=prescale_factor,
+                                  postscale_factor=postscale_factor)
         return handle, ctx
 
     def _make_hook(self, p):
@@ -367,7 +381,8 @@ class _DistributedAdasumOptimizer(torch.optim.Optimizer):
 def DistributedOptimizer(optimizer, named_parameters=None,
                          compression=Compression.none,
                          backward_passes_per_step=1,
-                         op=Average):
+                         op=Average,
+                         gradient_predivide_factor=1.0):
     """
     An optimizer that wraps another torch.optim.Optimizer, using an allreduce to
     combine gradient values before applying gradients to model weights.
@@ -406,14 +421,24 @@ def DistributedOptimizer(optimizer, named_parameters=None,
                                   allows accumulating gradients over multiple
                                   mini-batches before reducing and applying them.
         op: The reduction operation to use when combining gradients across different ranks.
+        gradient_predivide_factor: If op == Average, gradient_predivide_factor splits the averaging
+                                   before and after the sum. Gradients are scaled by
+                                   1.0 / gradient_predivide_factor before the sum and
+                                   gradient_predivide_factor / size after the sum.
     """
     # We dynamically create a new class that inherits from the optimizer that was passed in.
     # The goal is to override the `step()` method with an allreduce implementation.
+    if gradient_predivide_factor != 1.0:
+        if op == Adasum:
+            raise ValueError('gradient_predivide_factor not supported yet with op == Adasum')
+        if rocm_built():
+            raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 
     if op != Adasum or size() == 1:
         cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                    dict(_DistributedOptimizer.__dict__))
-        return cls(optimizer.param_groups, named_parameters, compression, backward_passes_per_step, op)
+        return cls(optimizer.param_groups, named_parameters, compression, backward_passes_per_step, op,
+                   gradient_predivide_factor)
     else:
         cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                    dict(_DistributedAdasumOptimizer.__dict__))

--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -116,16 +116,16 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         tensor = p.grad
         tensor_compressed, ctx = self._compression.compress(tensor)
 
-        if self.op == Average and self.gradient_predivide_factor != 1.0:
+        if self.op == Average:
+           # Split average operation across pre/postscale factors
+           # C++ backend will apply additional 1 / size() factor to postscale_factor for op == Average.
             prescale_factor = 1.0 / self.gradient_predivide_factor
-            postscale_factor = self.gradient_predivide_factor / size()
-            true_op = Sum
+            postscale_factor = self.gradient_predivide_factor
         else:
             prescale_factor = 1.0
             postscale_factor = 1.0
-            true_op = self.op
 
-        handle = allreduce_async_(tensor_compressed, name=name, op=true_op,
+        handle = allreduce_async_(tensor_compressed, name=name, op=self.op,
                                   prescale_factor=prescale_factor,
                                   postscale_factor=postscale_factor)
         return handle, ctx

--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -25,7 +25,7 @@ from horovod.torch.compression import Compression
 from horovod.torch.mpi_ops import allreduce_async_
 from horovod.torch.mpi_ops import synchronize
 from horovod.torch.mpi_ops import size
-from horovod.torch.mpi_ops import Average, Adasum
+from horovod.torch.mpi_ops import Average, Adasum, Sum
 from horovod.torch.mpi_ops import rocm_built
 
 
@@ -117,8 +117,8 @@ class _DistributedOptimizer(torch.optim.Optimizer):
         tensor_compressed, ctx = self._compression.compress(tensor)
 
         if self.op == Average and self.gradient_predivide_factor != 1.0:
-            prescale_factor = 1.0 / gradient_predivide_factor
-            postscale_factor = gradient_predivide_factor / size()
+            prescale_factor = 1.0 / self.gradient_predivide_factor
+            postscale_factor = self.gradient_predivide_factor / size()
             true_op = Sum
         else:
             prescale_factor = 1.0

--- a/setup.py
+++ b/setup.py
@@ -1574,7 +1574,7 @@ setup(name='horovod',
           'Topic :: Scientific/Engineering :: Artificial Intelligence',
       ],
       ext_modules=[tensorflow_mpi_lib, torch_mpi_lib, torch_mpi_lib_impl,
-                   torch_mpi_lib_v2, mxnet_mpi_lib, gloo_lib],
+                   torch_mpi_lib_v2, mxnet_mpi_lib, gloo_lib, horovod_cuda_lib],
       cmdclass={'build_ext': custom_build_ext},
       # cffi is required for PyTorch
       # If cffi is specified in setup_requires, it will need libffi to be installed on the machine,

--- a/setup.py
+++ b/setup.py
@@ -743,6 +743,7 @@ def get_common_options(build_ext):
     SOURCES = ['horovod/common/common.cc',
                'horovod/common/controller.cc',
                'horovod/common/fusion_buffer_manager.cc',
+               'horovod/common/half.cc',
                'horovod/common/logging.cc',
                'horovod/common/message.cc',
                'horovod/common/operations.cc',
@@ -788,8 +789,7 @@ def get_common_options(build_ext):
 
     if have_mpi:
         MACROS += [('HAVE_MPI', '1')]
-        SOURCES += ['horovod/common/half.cc',
-                    'horovod/common/mpi/mpi_context.cc',
+        SOURCES += ['horovod/common/mpi/mpi_context.cc',
                     'horovod/common/mpi/mpi_controller.cc',
                     'horovod/common/ops/mpi_operations.cc',
                     'horovod/common/ops/adasum/adasum_mpi.cc',

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,8 @@ def get_nvcc_flags():
     cc_list_env = os.environ.get('HOROVOD_BUILD_CUDA_CC_LIST')
 
     # Invoke nvcc and extract all supported compute capabilities for CUDA toolkit version
-    full_cc_list = subprocess.check_output("nvcc --help  | grep -i sm_ | grep -Eo 'sm_[0-9]+' | sed -e s/sm_//g | sort -g -u | tr '\n' ' '",
+    full_cc_list = subprocess.check_output("nvcc --help | sed -n -e '/gpu-architecture <arch>/,/gpu-code <code>/ p' | sed -n -e '/Allowed values/,/gpu-code <code>/ p' | "
+                                           "grep -i sm_ | grep -Eo 'sm_[0-9]+' | sed -e s/sm_//g | sort -g -u | tr '\n' ' '",
                                            shell=True).strip().split()
     full_cc_list = [int(i) for i in full_cc_list]
 

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -154,6 +154,42 @@ class MXTests(unittest.TestCase):
             assert almost_equal(tensor.asnumpy(), multiplied.asnumpy(), atol=threshold), \
                 f'hvd.allreduce produces incorrect results for self: {hvd.rank()} {count} {dtype} {dim}'
 
+    def test_horovod_allreduce_scale(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors with pre and post scaling."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types(['int32',   'int64',
+                                              'float16', 'float32', 'float64'])
+        dims = [1, 2, 3]
+        ctx = self._current_context()
+        count = 1
+        shapes = [(), (17), (17, 17), (17, 17, 17)]
+        for dtype, dim in itertools.product(dtypes, dims):
+            mx.random.seed(1234, ctx=ctx)
+            tensor = mx.nd.random.uniform(-100, 100, shape=shapes[dim],
+                                          ctx=ctx)
+            tensor = tensor.astype(dtype)
+            scaled = hvd.allreduce(tensor, average=False, name=str(count),
+                                   prescale_factor=4.0, postscale_factor=0.5)
+            tensor *= size
+            tensor *= 2.0
+            max_difference = mx.nd.max(mx.nd.abs(mx.nd.subtract(scaled, tensor)))
+            count += 1
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in ['int32', 'int64']:
+                threshold = 1
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert almost_equal(tensor.asnumpy(), scaled.asnumpy(), atol=threshold), \
+                f'hvd.allreduce produces incorrect results for pre/post scaling: {hvd.rank()} {count} {dtype} {dim}'
+
     def test_horovod_allreduce_error(self):
         """Test that the allreduce raises an error if different ranks try to
            send tensors of different rank or dimension."""

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -171,22 +171,21 @@ class MXTests(unittest.TestCase):
             tensor = mx.nd.random.uniform(-100, 100, shape=shapes[dim],
                                           ctx=ctx)
             tensor = tensor.astype(dtype)
-            tensor_np = tensor.asnumpy()
             factor = np.random.uniform()
             scaled = hvd.allreduce(tensor, average=False, name=str(count),
                                    prescale_factor=factor)
 
             factor = mx.nd.array([factor], dtype='float64', ctx=ctx)
-            if ctx != mx.cpu():
+            if ctx != mx.cpu() and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
                 # For integer types, scaling done in FP64
-                factor = factor.astype(dtype if dtype not in int_types else 'float64')
-                tensor = tensor.astype(dtype if dtype not in int_types else 'float64')
+                factor = factor.astype('float64' if dtype in int_types else dtype)
+                tensor = tensor.astype('float64' if dtype in int_types else dtype)
             else:
                 # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
-                factor = factor.astype(dtype if dtype not in int_types else
-                                       'float32' if dtype == 'float16' else 'float64')
-                tensor = tensor.astype(dtype if dtype not in int_types else
-                                       'float32' if dtype == 'float16' else 'float64')
+                factor = factor.astype('float32' if dtype == 'float16' else
+                                       'float64' if dtype in int_types else dtype)
+                tensor = tensor.astype('float32' if dtype == 'float16' else
+                                       'float64' if dtype in int_types else dtype)
 
             expected = factor * tensor
             expected = expected.astype(dtype)
@@ -229,16 +228,16 @@ class MXTests(unittest.TestCase):
                                    postscale_factor=factor)
 
             factor = mx.nd.array([factor], dtype='float64', ctx=ctx)
-            if ctx != mx.cpu():
+            if ctx != mx.cpu() and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
                 # For integer types, scaling done in FP64
-                factor = factor.astype(dtype if dtype not in int_types else 'float64')
-                tensor = tensor.astype(dtype if dtype not in int_types else 'float64')
+                factor = factor.astype('float64' if dtype in int_types else dtype)
+                tensor = tensor.astype('float64' if dtype in int_types else dtype)
             else:
                 # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
-                factor = factor.astype(dtype if dtype not in int_types else
-                                       'float32' if dtype == 'float16' else 'float64')
-                tensor = tensor.astype(dtype if dtype not in int_types else
-                                       'float32' if dtype == 'float16' else 'float64')
+                factor = factor.astype('float32' if dtype == 'float16' else
+                                       'float64' if dtype in int_types else dtype)
+                tensor = tensor.astype('float32' if dtype == 'float16' else
+                                       'float64' if dtype in int_types else dtype)
 
             expected = tensor * size
             expected *= factor

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -247,12 +247,15 @@ class TensorFlowTests(tf.test.TestCase):
         self.assertTrue(self.evaluate(tf.reduce_all(tests)),
                         "hvd.allreduce produces incorrect results")
 
+    # Note: TF does not support FP64 op attributes so scaling factor is cast to FP32
+    # by op and loses precision. We skip FP64 version of pre/postscale tests for this reason.
+    # See https://github.com/tensorflow/tensorflow/pull/39452 for PR to resolve this limitation.
     def test_horovod_allreduce_cpu_prescale(self):
         """Test on CPU that the allreduce correctly sums 1D, 2D, 3D tensors
            with prescaling"""
         hvd.init()
         size = hvd.size()
-        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32])
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/cpu:0"):
@@ -291,7 +294,7 @@ class TensorFlowTests(tf.test.TestCase):
            with postscaling"""
         hvd.init()
         size = hvd.size()
-        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32])
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/cpu:0"):
@@ -511,7 +514,7 @@ class TensorFlowTests(tf.test.TestCase):
         hvd.init()
         size = hvd.size()
         local_rank = hvd.local_rank()
-        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32])
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/gpu:%s" % local_rank):
@@ -560,8 +563,7 @@ class TensorFlowTests(tf.test.TestCase):
         hvd.init()
         size = hvd.size()
         local_rank = hvd.local_rank()
-        # TODO: Skip tf.float64 as op attributes can be single precision only. To fix.
-        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32])
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/gpu:%s" % local_rank):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -328,14 +328,11 @@ class TorchTests(unittest.TestCase):
         hvd.init()
         size = hvd.size()
         dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
-                  torch.FloatTensor, torch.DoubleTensor])
-        if _fp16_supported:
-            dtypes += self.filter_supported_types([torch.HalfTensor])
+                  torch.FloatTensor, torch.DoubleTensor, torch.HalfTensor])
         if torch.cuda.is_available():
             dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
-                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor]
-            if _fp16_supported:
-                dtypes += [torch.cuda.HalfTensor]
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
 
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -348,8 +348,8 @@ class TorchTests(unittest.TestCase):
                                    prescale_factor=factor)
 
             factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
             if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
-              factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64
               factor = factor.type(torch.float64 if dtype in int_types else dtype)
               tensor = tensor.type(torch.float64 if dtype in int_types else dtype)
@@ -402,8 +402,8 @@ class TorchTests(unittest.TestCase):
                                    postscale_factor=factor)
 
             factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
             if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
-              factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64
               factor = factor.type(torch.float64 if dtype in int_types else dtype)
               tensor = tensor.type(torch.float64 if dtype in int_types else dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -56,7 +56,7 @@ class TorchTests(unittest.TestCase):
         # In case we need to do ops, we will convert tensor to FP32 here.
         result = []
         for value in values:
-            if value.dtype in [torch.float16, torch.HalfTensor]:
+            if value.dtype in [torch.float16, torch.HalfTensor] and not value.is_cuda:
                 result.append(value.float())
             else:
                 result.append(value)
@@ -323,33 +323,44 @@ class TorchTests(unittest.TestCase):
 
             assert torch.allclose(tensor, multiplied, threshold), 'hvd.allreduce produces incorrect results'
 
-    def test_horovod_allreduce_scale(self):
-        """Test that the allreduce correctly sums 1D, 2D, 3D tensors with pre and post scaling."""
+    def test_horovod_allreduce_prescale(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors with prescaling."""
         hvd.init()
         size = hvd.size()
         dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
-                  torch.FloatTensor, torch.DoubleTensor, torch.HalfTensor])
+                 torch.FloatTensor, torch.DoubleTensor, torch.HalfTensor])
         if torch.cuda.is_available():
             dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
                        torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
                        torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+
 
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             torch.manual_seed(1234)
+            np.random.seed(1234)
+            factor = np.random.uniform()
             tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
             tensor = self.cast_and_place(tensor, dtype)
             summed = hvd.allreduce(tensor, average=False,
-                                   prescale_factor=4.0, postscale_factor=0.5)
-            tensor, summed = self.convert_cpu_fp16_to_fp32(tensor, summed)
-            multiplied = tensor * size * 2.0
-            max_difference = summed.data.sub(multiplied).abs().max()
+                                   prescale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.double)
+            if dtype.is_cuda: factor = factor.cuda(hvd.local_rank())
+            # For integer types, scaling done in FP64
+            factor.type(dtype if dtype not in int_types else torch.DoubleTensor)
+            tensor, summed, factor = self.convert_cpu_fp16_to_fp32(tensor, summed, factor)
+            multiplied = factor * tensor
+            multiplied = multiplied.type(dtype)
+            multiplied = self.convert_cpu_fp16_to_fp32(multiplied)[0]
+            multiplied *= size
 
             # Threshold for floating point equality depends on number of
             # ranks, since we're comparing against precise multiplication.
-            if size <= 3 or dtype in [torch.IntTensor, torch.LongTensor,
-                                      torch.cuda.IntTensor, torch.cuda.LongTensor]:
-                threshold = 1
+            if size <= 3 or dtype in int_types:
+                threshold = 0
             elif size < 10:
                 threshold = 1e-4
             elif size < 15:
@@ -357,7 +368,54 @@ class TorchTests(unittest.TestCase):
             else:
                 break
 
-            assert max_difference <= threshold, 'hvd.allreduce produces incorrect results'
+            assert torch.allclose(summed, multiplied, threshold), 'hvd.allreduce produces incorrect results'
+
+    def test_horovod_allreduce_postscale(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors with postscaling."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
+                 torch.FloatTensor, torch.DoubleTensor, torch.HalfTensor])
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+
+
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            np.random.seed(1234)
+            factor = np.random.uniform()
+            tensor = torch.FloatTensor(*([17] * dim)).random_(-100, 100)
+            tensor = self.cast_and_place(tensor, dtype)
+            summed = hvd.allreduce(tensor, average=False,
+                                   postscale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.double)
+            if dtype.is_cuda: factor = factor.cuda(hvd.local_rank())
+            # For integer types, scaling done in FP64
+            factor.type(dtype if dtype not in int_types else torch.DoubleTensor)
+            tensor, summed, factor = self.convert_cpu_fp16_to_fp32(tensor, summed, factor)
+            multiplied = size * tensor
+            multiplied = multiplied * factor
+            multiplied = multiplied.type(dtype)
+            multiplied = self.convert_cpu_fp16_to_fp32(multiplied)[0]
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in int_types:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert torch.allclose(summed, multiplied, threshold), 'hvd.allreduce produces incorrect results'
 
     def test_horovod_allreduce_error(self):
         """Test that the allreduce raises an error if different ranks try to

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -347,7 +347,7 @@ class TorchTests(unittest.TestCase):
             summed = hvd.allreduce(tensor, average=False,
                                    prescale_factor=factor)
 
-            factor = torch.tensor(factor, dtype=torch.double)
+            factor = torch.tensor(factor, dtype=torch.float64)
             if dtype.is_cuda:
               factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64
@@ -401,7 +401,7 @@ class TorchTests(unittest.TestCase):
             summed = hvd.allreduce(tensor, average=False,
                                    postscale_factor=factor)
 
-            factor = torch.tensor(factor, dtype=torch.double)
+            factor = torch.tensor(factor, dtype=torch.float64)
             if dtype.is_cuda:
               factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -348,17 +348,17 @@ class TorchTests(unittest.TestCase):
                                    prescale_factor=factor)
 
             factor = torch.tensor(factor, dtype=torch.float64)
-            if dtype.is_cuda:
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
               factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64
-              factor = factor.type(dtype if dtype not in int_types else torch.float64)
-              tensor = tensor.type(dtype if dtype not in int_types else torch.float64)
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float64 if dtype in int_types else dtype)
             else:
               # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
-              factor = factor.type(dtype if dtype not in int_types + half_types else
-                                   torch.float32 if dtype in half_types else torch.float64)
-              tensor = tensor.type(dtype if dtype not in int_types + half_types else
-                                   torch.float32 if dtype in half_types else torch.float64)
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
             multiplied = factor * tensor
             multiplied = multiplied.type(dtype)
             summed, multiplied = self.convert_cpu_fp16_to_fp32(summed, multiplied)
@@ -402,17 +402,17 @@ class TorchTests(unittest.TestCase):
                                    postscale_factor=factor)
 
             factor = torch.tensor(factor, dtype=torch.float64)
-            if dtype.is_cuda:
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
               factor = factor.cuda(hvd.local_rank())
               # For integer types, scaling done in FP64
-              factor.type(dtype if dtype not in int_types else torch.float64)
-              tensor.type(dtype if dtype not in int_types else torch.float64)
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float64 if dtype in int_types else dtype)
             else:
               # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
-              factor = factor.type(dtype if dtype not in int_types + half_types else
-                                   torch.float32 if dtype in half_types else torch.float64)
-              tensor = tensor.type(dtype if dtype not in int_types + half_types else
-                                   torch.float32 if dtype in half_types else torch.float64)
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
             multiplied = size * tensor
             multiplied = multiplied * factor
             multiplied = multiplied.type(dtype)


### PR DESCRIPTION
This PR implements support for `gradient_predivide_factor` in the `DistributedOptimizer`, similar to that available in [APEX DDP](https://nvidia.github.io/apex/parallel.html#apex.parallel.DistributedDataParallel). The purpose of this is to enable splitting the averaging before and after the allreduce, which can be useful in managing the numerical range for mixed precision computations (see #1699). The `gradient_predivide_factor` is applied as follows: 
```
        If op == Average, gradient_predivide_factor splits the averaging
        before and after the sum. Gradients are scaled by
        1.0 / gradient_predivide_factor before the sum and
        gradient_predivide_factor / size after the sum. 
```
To facilitate this, additional arguments, `prescale_factor` and `postscale_factor`, have been added to the basic `hvd.allreduce` functions, enabling the definition of multiplicative factors to scale the tensors before and after the allreduce respectively. For efficiency, the pre and post-scaling is implemented in the Horovod backend on the fused tensor buffer, rather than through framework level operations. For GPU, this required a CUDA kernel implementation to scale the GPU buffer which in turn, required adding compilation of CUDA code to the current build infrastructure. The changes to the build are a more general version of build code changes to enable CUDA compilation proposed in #1760. 

As an additional general benefit from these changes, gradient averaging in the optimizer can now be carried out within the Horovod backend on the fused tensor buffer using the `postscale_factor` argument, rather than on a tensor by tensor basis at the framework level. This should, in general, be more efficient.

Marking the current PR as WIP, but would appreciate feedback to finish up. The implementation is complete, but there are still a few details that need to be worked out (adding support for Keras, if/how to add this to the adasum path), as well as some additional testing. 