### PR TITLE
Dropped support for Python 2

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -8,14 +8,11 @@ repository=823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
 
 # list of all the tests
 tests=( \
-       test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
        test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2 \
-       test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-gloo-py3_8-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0 \
-       test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
        test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0 \
        test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0 \
@@ -103,11 +100,6 @@ run_mpi_pytest() {
     exclude_keras="| sed 's/[a-z_]*tensorflow2[a-z_.]*//g'"
   fi
 
-  local exclude_elastic=""
-  if [[ ${test} == *"py2_"* ]]; then
-    exclude_elastic="| sed 's/test_elastic[a-z_.]*//g'"
-  fi
-
   local excluded_tests="| sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g'"
 
   # Spark and Run test does not need to be executed with horovodrun, but we still run it below.
@@ -123,7 +115,7 @@ run_mpi_pytest() {
   # pytests have 4x GPU use cases and require a separate queue
   run_test "${test}" "${queue}" \
     ":pytest: Run PyTests (${test})" \
-    "bash -c \"${oneccl_env} cd /horovod/test && (echo test_*.py ${exclude_keras} ${exclude_elastic} ${excluded_tests} ${exclude_standalone_test} | xargs -n 1 \\\$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no ${standalone_tests}\""
+    "bash -c \"${oneccl_env} cd /horovod/test && (echo test_*.py ${exclude_keras} ${excluded_tests} ${exclude_standalone_test} | xargs -n 1 \\\$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no ${standalone_tests}\""
 }
 
 run_mpi_integration() {
@@ -216,11 +208,6 @@ run_gloo_pytest() {
     exclude_keras="| sed 's/[a-z_]*tensorflow2[a-z_.]*//g'"
   fi
 
-  local exclude_elastic=""
-  if [[ ${test} == *"py2_"* ]]; then
-    exclude_elastic="| sed 's/test_elastic[a-z_.]*//g'"
-  fi
-
   # These are tested as integration style tests.
   local excluded_tests="| sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g'"
 
@@ -236,7 +223,7 @@ run_gloo_pytest() {
 
   run_test "${test}" "${queue}" \
     ":pytest: Run PyTests (${test})" \
-    "bash -c \"cd /horovod/test && (echo test_*.py ${exclude_keras} ${exclude_elastic} ${excluded_tests} ${exclude_standalone_test} | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no ${standalone_tests}\""
+    "bash -c \"cd /horovod/test && (echo test_*.py ${exclude_keras} ${excluded_tests} ${exclude_standalone_test} | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no ${standalone_tests}\""
 }
 
 run_gloo_integration() {
@@ -298,7 +285,7 @@ run_spark_integration() {
   # Horovod Spark Estimator tests
   if [[ ${test} != *"tf1_1_0"* && ${test} != *"tf1_6_0"* && ${test} != *"torch0_"* && ${test} != *"mpich"* && ${test} != *"oneccl"* ]]; then
     if [[ ${test} != *"tf2"* && ${test} != *"tfhead"* ]]; then
-      if [[ ! (  ${test} == *"py2"* && ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+      if [[ ! (  ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
         run_test "${test}" "${queue}" \
           ":spark: Spark Keras Rossmann Run (${test})" \
           "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01\""
@@ -319,7 +306,7 @@ run_spark_integration() {
       fi
     fi
 
-    if [[ ! (  ${test} == *"py2"* && ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+    if [[ ! (  ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
       run_test "${test}" "${queue}" \
         ":spark: Spark Torch MNIST (${test})" \
         "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -285,7 +285,7 @@ run_spark_integration() {
   # Horovod Spark Estimator tests
   if [[ ${test} != *"tf1_1_0"* && ${test} != *"tf1_6_0"* && ${test} != *"torch0_"* && ${test} != *"mpich"* && ${test} != *"oneccl"* ]]; then
     if [[ ${test} != *"tf2"* && ${test} != *"tfhead"* ]]; then
-      if [[ ! (  ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+      if [[ ${test} != *"gloo"* || ${test} == *"openmpi-gloo"* ]]; then
         run_test "${test}" "${queue}" \
           ":spark: Spark Keras Rossmann Run (${test})" \
           "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01\""
@@ -306,7 +306,7 @@ run_spark_integration() {
       fi
     fi
 
-    if [[ ! (  ${test} == *"gloo"* && ${test} != *"openmpi-gloo"* ) ]]; then
+    if [[ ${test} != *"gloo"* || ${test} == *"openmpi-gloo"* ]]; then
       run_test "${test}" "${queue}" \
         ":spark: Spark Torch MNIST (${test})" \
         "bash -c \"OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3\""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Dropped support for Python 2. ([#1954](https://github.com/horovod/horovod/pull/1954))
+
 ### Fixed

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -5,8 +5,8 @@ ENV PYTORCH_VERSION=1.4.0
 ENV TORCHVISION_VERSION=0.5.0
 ENV MXNET_VERSION=1.6.0
 
-# Python 2.7 or 3.6 is supported by Ubuntu Bionic out of the box
-ARG python=2.7
+# Python 3.6 is supported by Ubuntu Bionic out of the box
+ARG python=3.6
 ENV PYTHON_VERSION=${python}
 
 # Set default shell to /bin/bash
@@ -25,13 +25,11 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         libpng-dev \
         python${PYTHON_VERSION} \
         python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
         librdmacm1 \
         libibverbs1 \
         ibverbs-providers
 
-RUN if [[ "${PYTHON_VERSION}" == "3.6" ]]; then \
-        apt-get install -y python${PYTHON_VERSION}-distutils; \
-    fi
 RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -8,8 +8,8 @@ ENV CUDNN_VERSION=7.6.5.32-1+cuda10.1
 ENV NCCL_VERSION=2.4.8-1+cuda10.1
 ENV MXNET_VERSION=1.6.0
 
-# Python 2.7 or 3.6 is supported by Ubuntu Bionic out of the box
-ARG python=2.7
+# Python 3.6 is supported by Ubuntu Bionic out of the box
+ARG python=3.6
 ENV PYTHON_VERSION=${python}
 
 # Set default shell to /bin/bash
@@ -31,13 +31,11 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         libpng-dev \
         python${PYTHON_VERSION} \
         python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
         librdmacm1 \
         libibverbs1 \
         ibverbs-providers
 
-RUN if [[ "${PYTHON_VERSION}" == "3.6" ]]; then \
-        apt-get install -y python${PYTHON_VERSION}-distutils; \
-    fi
 RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -5,7 +5,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 # the first usage only applies to the FROM tag.
 ARG UBUNTU_VERSION=16.04
 ARG MPI_KIND=OpenMPI
-ARG PYTHON_VERSION=2.7
+ARG PYTHON_VERSION=3.6
 ARG TENSORFLOW_PACKAGE=tensorflow==1.14.0
 ARG KERAS_PACKAGE=keras==2.2.4
 ARG PYTORCH_PACKAGE=torch==1.2.0+cpu
@@ -32,10 +32,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update -qq && apt-get install -y --no-install-recommends g++-7
 
 # Install Python.
-RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev
-RUN if [[ "${PYTHON_VERSION}" == "3."* ]]; then \
-        apt-get install -y python${PYTHON_VERSION}-distutils; \
-    fi
+RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip install -U --force pip 'setuptools<46.0.0' requests pytest mock pytest-forked
@@ -43,9 +40,6 @@ RUN pip install -U --force pip 'setuptools<46.0.0' requests pytest mock pytest-f
 # Install PySpark.
 RUN apt-get update -qq && apt install -y openjdk-8-jdk-headless
 RUN pip install ${PYSPARK_PACKAGE}
-RUN if [[ "${PYTHON_VERSION}" == "2."* ]]; then \
-    pip install 'pyarrow<0.16.0'; \
-fi
 
 # Install MPI.
 RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
@@ -121,7 +115,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; then \
+RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
         pip install --pre mxnet-mkl -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -7,7 +7,7 @@ ARG CUDA_DOCKER_VERSION=10.0-devel-ubuntu16.04
 ARG CUDNN_VERSION=7.6.0.64-1+cuda10.0
 ARG NCCL_VERSION_OVERRIDE=2.4.7-1+cuda10.0
 ARG MPI_KIND=OpenMPI
-ARG PYTHON_VERSION=2.7
+ARG PYTHON_VERSION=3.6
 ARG TENSORFLOW_PACKAGE=tensorflow-gpu==1.14.0
 ARG KERAS_PACKAGE=keras==2.2.4
 ARG PYTORCH_PACKAGE=torch==1.2.0
@@ -39,10 +39,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update -qq && apt-get install -y --no-install-recommends g++-7
 
 # Install Python.
-RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev
-RUN if [[ "${PYTHON_VERSION}" == "3."* ]]; then \
-        apt-get install -y python${PYTHON_VERSION}-distutils; \
-    fi
+RUN apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip install -U --force pip 'setuptools<46.0.0' requests pytest mock pytest-forked
@@ -95,7 +92,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" && ${PYTHON_VERSION} != "2.7" ]]; then \
+RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
         pip install --pre mxnet-cu101mkl -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -28,7 +28,7 @@ function build_one()
 docker rmi $(cat Dockerfile.gpu | grep FROM | awk '{print $2}') || true
 docker rmi $(cat Dockerfile.cpu | grep FROM | awk '{print $2}') || true
 
-# build for py2 and py3, cpu and gpu
+# build for cpu and gpu
 build_one 3.6 gpu
 build_one 3.6 cpu
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,18 +6,6 @@ services:
       dockerfile: Dockerfile.test.cpu
     privileged: true
     shm_size: 8gb
-  test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2:
-    extends: test-cpu-base
-    build:
-      args:
-        MPI_KIND: OpenMPI
-        PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==1.6.0
-        KERAS_PACKAGE: keras==2.1.2
-        PYTORCH_PACKAGE: torch==0.4.1
-        TORCHVISION_PACKAGE: torchvision==0.2.2.post3
-        MXNET_PACKAGE: mxnet==1.4.1
-        PYSPARK_PACKAGE: pyspark==2.3.2
   test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2:
     extends: test-cpu-base
     build:
@@ -31,18 +19,6 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.2.2.post3
         MXNET_PACKAGE: mxnet==1.4.1
         PYSPARK_PACKAGE: pyspark==2.3.2
-  test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0:
-    extends: test-cpu-base
-    build:
-      args:
-        MPI_KIND: None
-        PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow-cpu==1.15.0
-        KERAS_PACKAGE: keras==2.3.1
-        PYTORCH_PACKAGE: torch==1.4.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.5.0+cpu
-        MXNET_PACKAGE: mxnet==1.5.0
-        PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base
     build:
@@ -94,18 +70,6 @@ services:
         PYTORCH_PACKAGE: torch==1.2.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
         MXNET_PACKAGE: mxnet==1.4.1
-        PYSPARK_PACKAGE: pyspark==2.4.0
-  test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
-    extends: test-cpu-base
-    build:
-      args:
-        MPI_KIND: OpenMPI
-        PYTHON_VERSION: 2.7
-        TENSORFLOW_PACKAGE: tensorflow==2.0.0
-        KERAS_PACKAGE: keras==2.3.1
-        PYTORCH_PACKAGE: torch==1.3.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.4.1+cpu
-        MXNET_PACKAGE: mxnet==1.5.0
         PYSPARK_PACKAGE: pyspark==2.4.0
   test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:
     extends: test-cpu-base

--- a/docs/elastic.rst
+++ b/docs/elastic.rst
@@ -20,7 +20,6 @@ When to use elastic training
 Requirements
 ~~~~~~~~~~~~
 
-- Python >= 3.6
 - TensorFlow >= 1.15 or PyTorch >= 1.0
 - Horovod >= 0.20.0 with Gloo support (install Horovod using ``HOROVOD_WITH_GLOO=1`` to ensure it is installed)
 - A way to discover available hosts at runtime

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,6 +3,17 @@
 Horovod Installation Guide
 ==========================
 
+Requirements
+------------
+
+- Python >= 3.6
+- MPI or CMake
+- TensorFlow, PyTorch, or MXNet
+
+For best performance on GPU:
+
+- `NCCL 2 <https://developer.nvidia.com/nccl>`__
+
 Frameworks
 ----------
 

--- a/examples/elastic/pytorch_mnist_elastic.py
+++ b/examples/elastic/pytorch_mnist_elastic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import torch.nn as nn
 import torch.nn.functional as F

--- a/examples/elastic/pytorch_synthetic_benchmark_elastic.py
+++ b/examples/elastic/pytorch_synthetic_benchmark_elastic.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import torch.backends.cudnn as cudnn
 import torch.nn.functional as F

--- a/examples/elastic/tensorflow2_synthetic_benchmark_elastic.py
+++ b/examples/elastic/tensorflow2_synthetic_benchmark_elastic.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import numpy as np

--- a/examples/elastic/tensorflow_keras_mnist_elastic.py
+++ b/examples/elastic/tensorflow_keras_mnist_elastic.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras.models import Sequential

--- a/examples/keras_imagenet_resnet50.py
+++ b/examples/keras_imagenet_resnet50.py
@@ -11,8 +11,6 @@
 # increase in the top-1 validation error compared to the single-crop top-1 validation error from
 # https://github.com/KaimingHe/deep-residual-networks.
 #
-from __future__ import print_function
-
 import argparse
 import keras
 from keras import backend as K

--- a/examples/keras_mnist.py
+++ b/examples/keras_mnist.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import keras
 from keras.datasets import mnist
 from keras.models import Sequential

--- a/examples/keras_mnist_advanced.py
+++ b/examples/keras_mnist_advanced.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 
 import keras

--- a/examples/keras_spark_mnist.py
+++ b/examples/keras_spark_mnist.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import os
 import subprocess

--- a/examples/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch_imagenet_resnet50.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import torch
 import argparse
 import torch.backends.cudnn as cudnn

--- a/examples/pytorch_mnist.py
+++ b/examples/pytorch_mnist.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import torch.multiprocessing as mp
 import torch.nn as nn

--- a/examples/pytorch_spark_mnist.py
+++ b/examples/pytorch_spark_mnist.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import os
 import subprocess

--- a/examples/pytorch_synthetic_benchmark.py
+++ b/examples/pytorch_synthetic_benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import torch.backends.cudnn as cudnn
 import torch.nn.functional as F

--- a/examples/tensorflow2_synthetic_benchmark.py
+++ b/examples/tensorflow2_synthetic_benchmark.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import numpy as np

--- a/examples/tensorflow_keras_mnist.py
+++ b/examples/tensorflow_keras_mnist.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import math
 
 import tensorflow as tf

--- a/examples/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow_mnist_estimator.py
@@ -14,10 +14,6 @@
 #  limitations under the License.
 """Convolutional Neural Network Estimator for MNIST, built with tf.layers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import errno
 import numpy as np

--- a/examples/tensorflow_synthetic_benchmark.py
+++ b/examples/tensorflow_synthetic_benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import numpy as np

--- a/examples/tensorflow_word2vec.py
+++ b/examples/tensorflow_word2vec.py
@@ -23,11 +23,10 @@ import collections
 import math
 import os
 import random
+import urllib
 import zipfile
 
 import numpy as np
-from six.moves import urllib
-from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 import horovod.tensorflow as hvd
 
@@ -215,7 +214,7 @@ with tf.Session(graph=graph, config=config) as session:
     print('Initialized')
 
     average_loss = 0
-    for step in xrange(num_steps):
+    for step in range(num_steps):
         # simulate various sentence length by randomization
         batch_size = random.randint(max_batch_size // 2, max_batch_size)
         batch_inputs, batch_labels = generate_batch(
@@ -238,12 +237,12 @@ with tf.Session(graph=graph, config=config) as session:
     # Evaluate similarity in the end on worker 0.
     if hvd.rank() == 0:
         sim = similarity.eval()
-        for i in xrange(valid_size):
+        for i in range(valid_size):
             valid_word = reverse_dictionary[valid_examples[i]]
             top_k = 8  # number of nearest neighbors
             nearest = (-sim[i, :]).argsort()[1:top_k + 1]
             log_str = 'Nearest to %s:' % valid_word
-            for k in xrange(top_k):
+            for k in range(top_k):
                 close_word = reverse_dictionary[nearest[k]]
                 log_str = '%s %s,' % (log_str, close_word)
             print(log_str)

--- a/examples/tensorflow_word2vec.py
+++ b/examples/tensorflow_word2vec.py
@@ -15,10 +15,6 @@
 # ==============================================================================
 """Basic word2vec example."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import math
 import os

--- a/horovod/common/elastic.py
+++ b/horovod/common/elastic.py
@@ -16,8 +16,7 @@
 from __future__ import absolute_import
 
 import functools
-
-from six.moves import queue
+import queue
 
 from horovod.common.exceptions import HorovodInternalError, HostsUpdatedInterrupt
 from horovod.run.elastic.worker import WorkerNotificationManager

--- a/horovod/common/elastic.py
+++ b/horovod/common/elastic.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import functools
 import queue
 

--- a/horovod/common/exceptions.py
+++ b/horovod/common/exceptions.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 
 class HorovodInternalError(RuntimeError):
     """Internal error raised when a Horovod collective operation (e.g., allreduce) fails.

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -24,7 +24,6 @@ import warnings
 from contextlib import contextmanager
 
 
-_PY3 = sys.version_info[0] == 3
 EXTENSIONS = ['tensorflow', 'torch', 'mxnet']
 
 
@@ -89,7 +88,7 @@ def _check_extension_lambda(ext_base_name, fn, fn_desc, verbose):
         queue.put(result)
 
     # 'fork' is required because horovodrun is a frozen executable
-    ctx = multiprocessing.get_context('fork') if _PY3 else multiprocessing
+    ctx = multiprocessing.get_context('fork')
     queue = ctx.Queue()
     p = ctx.Process(target=_target_fn,
                     args=(ext_base_name, fn, fn_desc, queue, verbose))

--- a/horovod/keras/elastic.py
+++ b/horovod/keras/elastic.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import keras
 
 from horovod._keras import elastic as _impl

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from horovod.common.util import check_extension
 
 check_extension('horovod.mxnet', 'HOROVOD_WITH_MXNET',

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 # Load all the necessary MXNet C types.
 import ctypes
 import os

--- a/horovod/run/common/util/hosts.py
+++ b/horovod/run/common/util/hosts.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import collections
 
 

--- a/horovod/run/common/util/network.py
+++ b/horovod/run/common/util/network.py
@@ -14,13 +14,12 @@
 # ==============================================================================
 
 import psutil
+import queue
 import socket
+import socketserver
 import struct
-import threading
 
 import cloudpickle
-
-from six.moves import queue, socketserver
 
 from horovod.run.util.threads import in_thread
 from horovod.run.common.util import secret

--- a/horovod/run/common/util/safe_shell_exec.py
+++ b/horovod/run/common/util/safe_shell_exec.py
@@ -25,7 +25,6 @@ import time
 
 from horovod.run.util.threads import in_thread, on_event
 
-_PY3 = sys.version_info[0] == 3
 GRACEFUL_TERMINATION_TIME_S = 5
 
 
@@ -159,7 +158,7 @@ def _create_event(ctx):
 
 
 def execute(command, env=None, stdout=None, stderr=None, index=None, events=None):
-    ctx = multiprocessing.get_context('spawn') if _PY3 else multiprocessing
+    ctx = multiprocessing.get_context('spawn')
 
     # When this event is set, signal to middleman to terminate its children and exit.
     exit_event = _create_event(ctx)

--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 
 class BaseSettings(object):
     def __init__(self, num_proc=None, verbose=0, ssh_port=None, extra_mpi_args=None, tcp_flag=None,

--- a/horovod/run/common/util/tiny_shell_exec.py
+++ b/horovod/run/common/util/tiny_shell_exec.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
-
 import io
 import sys
 import traceback

--- a/horovod/run/common/util/tiny_shell_exec.py
+++ b/horovod/run/common/util/tiny_shell_exec.py
@@ -15,7 +15,7 @@
 
 from __future__ import print_function
 
-import six
+import io
 import sys
 import traceback
 
@@ -28,7 +28,7 @@ def execute(command):
     :param command: command to execute
     :return: (output, exit code) or None on failure
     """
-    output = six.StringIO()
+    output = io.StringIO()
     try:
         exit_code = safe_shell_exec.execute(command, stdout=output, stderr=output)
         output_msg = output.getvalue()

--- a/horovod/run/driver/driver_service.py
+++ b/horovod/run/driver/driver_service.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import io
 import os
-import six
 import sys
 
 from socket import AF_INET
@@ -73,7 +73,7 @@ def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
     """
 
     def _exec_command(command):
-        host_output = six.StringIO()
+        host_output = io.StringIO()
         try:
             exit_code = safe_shell_exec.execute(command,
                                                 stdout=host_output,

--- a/horovod/run/elastic/discovery.py
+++ b/horovod/run/elastic/discovery.py
@@ -19,7 +19,6 @@ import logging
 import threading
 
 from collections import defaultdict
-
 import six
 
 from horovod.run.common.util import safe_shell_exec

--- a/horovod/run/elastic/discovery.py
+++ b/horovod/run/elastic/discovery.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import io
 import logging
 import threading

--- a/horovod/run/elastic/discovery.py
+++ b/horovod/run/elastic/discovery.py
@@ -15,11 +15,11 @@
 
 from __future__ import absolute_import
 
+import io
 import logging
 import threading
 
 from collections import defaultdict
-import six
 
 from horovod.run.common.util import safe_shell_exec
 
@@ -136,7 +136,7 @@ class HostDiscoveryScript(HostDiscovery):
         super(HostDiscoveryScript, self).__init__()
 
     def find_available_hosts_and_slots(self):
-        stdout = six.StringIO()
+        stdout = io.StringIO()
         exit_code = safe_shell_exec.execute(self._discovery_script, stdout=stdout)
         if exit_code != 0:
             raise RuntimeError('Failed to execute discovery script: {}. Exit code: {}'

--- a/horovod/run/elastic/driver.py
+++ b/horovod/run/elastic/driver.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import logging
 import os
 import queue

--- a/horovod/run/elastic/driver.py
+++ b/horovod/run/elastic/driver.py
@@ -17,12 +17,11 @@ from __future__ import absolute_import
 
 import logging
 import os
+import queue
 import threading
 import time
 
 from collections import defaultdict
-
-from six.moves import queue
 
 from horovod.run.common.util import hosts, timeout
 from horovod.run.elastic.discovery import HostManager

--- a/horovod/run/elastic/registration.py
+++ b/horovod/run/elastic/registration.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import logging
 import threading
 

--- a/horovod/run/elastic/rendezvous.py
+++ b/horovod/run/elastic/rendezvous.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # =============================================================================
 
-from __future__ import absolute_import
-
 import logging
 
 from horovod.run.common.util import codec

--- a/horovod/run/elastic/settings.py
+++ b/horovod/run/elastic/settings.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 from horovod.run.common.util.settings import BaseSettings
 
 

--- a/horovod/run/elastic/worker.py
+++ b/horovod/run/elastic/worker.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import os
 import threading
 

--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import collections
 import copy
 import errno
 import math
@@ -23,10 +22,7 @@ import sys
 import threading
 import time
 
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
+from shlex import quote
 
 from horovod.run.common.util import env as env_util, safe_shell_exec
 from horovod.run.common.util.hosts import get_host_assignments, parse_hosts

--- a/horovod/run/http/http_server.py
+++ b/horovod/run/http/http_server.py
@@ -16,9 +16,10 @@
 import collections
 import logging
 import socket
+import socketserver
 import threading
 
-from six.moves import socketserver, BaseHTTPServer, SimpleHTTPServer
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 
 from horovod.run.util.network import find_port
 from horovod.run.util.threads import in_thread
@@ -31,7 +32,7 @@ TIMEOUT = 408
 OK = 200
 
 
-class KVStoreHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+class KVStoreHandler(SimpleHTTPRequestHandler):
     # Set timeout
     timeout = SINGLE_REQUEST_TIMEOUT
 
@@ -130,7 +131,7 @@ class RendezvousHandler(KVStoreHandler):
         self.send_status_code(OK)
 
 
-class RendezvousHTTPServer(socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServer, object):
+class RendezvousHTTPServer(socketserver.ThreadingMixIn, HTTPServer, object):
     def __init__(self, addr, handler, verbose):
         # This class has to inherit from object since HTTPServer is an old-style
         # class that does not inherit from object.
@@ -197,7 +198,7 @@ class RendezvousServer:
         self.listen_thread.join()
 
 
-class KVStoreHTTPServer(BaseHTTPServer.HTTPServer, object):
+class KVStoreHTTPServer(HTTPServer, object):
     def __init__(self, addr, handler, verbose):
         super(KVStoreHTTPServer, self).__init__(addr, handler)
 

--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -15,15 +15,13 @@
 
 import os
 import tempfile
+
+from shlex import quote
+
 from horovod.run.common.util import safe_shell_exec
 from horovod.run.util import lsf
 from distutils.spawn import find_executable
 from horovod.run.mpi_run import _get_mpi_implementation_flags, _MPI_NOT_FOUND_ERROR_MSG
-
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
 
 
 def is_jsrun_installed():

--- a/horovod/run/js_run.py
+++ b/horovod/run/js_run.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
 import os
 import tempfile
 from horovod.run.common.util import safe_shell_exec

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
-
 import copy
 import os
 import sys

--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -17,6 +17,8 @@ import copy
 import os
 import sys
 
+from shlex import quote
+
 from horovod.run.common.util import env as env_util, safe_shell_exec, tiny_shell_exec
 
 # MPI implementations
@@ -50,11 +52,6 @@ _MPI_NOT_FOUND_ERROR_MSG= ('horovod does not find an installed MPI.\n\n'
                            'training script using the standard way provided by your'
                            ' MPI distribution (usually mpirun, srun, or jsrun).\n'
                            '3. Use built-in gloo option (horovodrun --gloo ...).')
-
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
 
 
 def mpi_available():

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
-
 import argparse
 import hashlib
 import logging

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -22,10 +22,7 @@ import re
 import sys
 import textwrap
 
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
+from shlex import quote
 
 import yaml
 

--- a/horovod/run/runner.py
+++ b/horovod/run/runner.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import argparse
 import hashlib
 import logging
+import io
 import os
 import re
 import sys
@@ -28,7 +29,6 @@ try:
 except ImportError:
     from pipes import quote
 
-import six
 import yaml
 
 import horovod
@@ -76,7 +76,7 @@ def _check_all_hosts_ssh_successful(host_addresses, ssh_port=None):
 
         # Try ssh 5 times
         for i in range(SSH_ATTEMPTS):
-            output = six.StringIO()
+            output = io.StringIO()
             try:
                 exit_code = safe_shell_exec.execute(command,
                                                     stdout=output,
@@ -101,7 +101,7 @@ def _check_all_hosts_ssh_successful(host_addresses, ssh_port=None):
                                                args_list)
 
     ssh_successful_to_all_hosts = True
-    for index, ssh_status in six.iteritems(ssh_exit_codes):
+    for index, ssh_status in ssh_exit_codes.items():
         exit_code, output_msg = ssh_status[0], ssh_status[1]
         if exit_code != 0:
             print('ssh not successful for host {host}:\n{msg_output}'

--- a/horovod/run/util/lsf.py
+++ b/horovod/run/util/lsf.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
+import io
 import os
-import six
+
 import yaml
+
 from horovod.common.util import _cache
 from horovod.run.common.util import safe_shell_exec
+
 
 class LSFUtils:
     """LSF Utilities"""
@@ -37,7 +40,7 @@ class LSFUtils:
         """Returns and sets the static CSM allocation info."""
         if not LSFUtils._csm_allocation_info:
             lsf_allocation_id = os.environ["CSM_ALLOCATION_ID"].strip()
-            output = six.StringIO()
+            output = io.StringIO()
             exit_code = safe_shell_exec.execute("{cmd} -a {allocation}".format(
                 cmd=LSFUtils._CSM_ALLOCATION_QUERY, allocation=lsf_allocation_id),
                 stdout=output, stderr=output)
@@ -47,7 +50,7 @@ class LSFUtils:
                         cmd=LSFUtils._CSM_ALLOCATION_QUERY, exit_code=exit_code))
             LSFUtils._csm_allocation_info = yaml.safe_load(output.getvalue())
             # Fetch the total number of cores and gpus for the first host
-            output = six.StringIO()
+            output = io.StringIO()
             exit_code = safe_shell_exec.execute("{cmd} -n {node}".format(
                 cmd=LSFUtils._CSM_NODE_QUERY,
                 node=LSFUtils._csm_allocation_info["compute_nodes"][0]),
@@ -92,9 +95,9 @@ class LSFUtils:
         """Returns the number of hardware threads."""
         lscpu_cmd = 'ssh -o StrictHostKeyChecking=no {host} {cmd}'.format(
             host=LSFUtils.get_compute_hosts()[0],
-            cmd = LSFUtils._LSCPU_CMD
+            cmd=LSFUtils._LSCPU_CMD
         )
-        output = six.StringIO()
+        output = io.StringIO()
         exit_code = safe_shell_exec.execute(lscpu_cmd, stdout=output, stderr=output)
         if exit_code != 0:
             raise RuntimeError("{cmd} failed with exit code {exit_code}".format(

--- a/horovod/run/util/network.py
+++ b/horovod/run/util/network.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import psutil
 import random
 import socket

--- a/horovod/run/util/threads.py
+++ b/horovod/run/util/threads.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import queue
 import threading
-
-from six.moves import queue
 
 
 def execute_function_multithreaded(fn,

--- a/horovod/spark/common/_namedtuple_fix.py
+++ b/horovod/spark/common/_namedtuple_fix.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 # Workaround for https://issues.apache.org/jira/browse/SPARK-22674
 # This fix also requires the user to make this same change at the top of their
 # training script before importing pyspark (on serialization).

--- a/horovod/spark/common/backend.py
+++ b/horovod/spark/common/backend.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 import os

--- a/horovod/spark/common/cache.py
+++ b/horovod/spark/common/cache.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import collections
 import contextlib
 import threading

--- a/horovod/spark/common/constants.py
+++ b/horovod/spark/common/constants.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 PETASTORM_HDFS_DRIVER = 'libhdfs'
 METRIC_PRINT_FREQUENCY = 1000  # to print metric every 1000 steps in verbose mode
 

--- a/horovod/spark/common/estimator.py
+++ b/horovod/spark/common/estimator.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 from pyspark.ml import Estimator, Model

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 from pyspark import keyword_only

--- a/horovod/spark/common/serialization.py
+++ b/horovod/spark/common/serialization.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import json
 import os
 import time

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import contextlib
 import errno
 import os

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -187,11 +187,6 @@ def _get_col_info(df):
                 size = data_col.indices.shape[0]
             elif isinstance(data_col, list):
                 shape = size = len(data_col)
-            elif isinstance(data_col, type(None)):
-                # Python 2.7 compat: NoneType is not pickleable
-                # see: https://bugs.python.org/issue6477
-                dtype = NullType
-                shape = size = 1
             else:
                 shape = size = 1
             row_schema.append((col_name, ({dtype}, {shape}, {size})))

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 import contextlib

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -43,9 +43,6 @@ def gloo_run(settings, nics, driver, env):
     if env is None:
         env = {}
 
-    if sys.version_info < (3, 0, 0):
-        raise Exception('Horovod on Spark over Gloo only supported on Python3')
-
     # Each thread will use SparkTaskClient to launch the job on each remote host. If an
     # error occurs in one thread, entire process will be terminated. Otherwise,
     # threads will keep running and ssh session.

--- a/horovod/spark/keras/__init__.py
+++ b/horovod/spark/keras/__init__.py
@@ -13,7 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 from horovod.spark.keras.estimator import KerasEstimator
 from horovod.spark.keras.estimator import KerasModel

--- a/horovod/spark/keras/bare.py
+++ b/horovod/spark/keras/bare.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import json
 import warnings
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 import numbers

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -17,10 +17,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import copy
 import io
 
-import six
 import h5py
 
 from horovod.run.common.util import codec

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -70,22 +70,7 @@ def _serialize_keras_optimizer(opt, optimizer_class, save_optimizer_fn):
 
 
 def is_string(obj):
-    if six.PY3:
-        return isinstance(obj, str)
-    if six.PY2:
-        if not isinstance(obj, str):
-            return False
-
-        # Now we need to check if it is not byte array. Bytearrays in python 2 are essentially an
-        # instance of string. There is not a good way to distinguish between the two types other than
-        # trying to decode the object
-        # https://stackoverflow.com/questions/34869889/what-is-the-proper-way-to-determine-if-an-object-is-a-bytes-like-object-in-pytho
-        obj_copy = copy.copy(obj)
-        try:
-            obj_copy.decode('ascii')
-            return True
-        except (UnicodeDecodeError, AttributeError):
-            return False
+    return isinstance(obj, str)
 
 
 def _deserialize_keras_optimizer(serialized_opt, load_keras_optimizer_fn):

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import io
 
 import h5py

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import contextlib
 import io
 import math

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 
 import json
 
-from six.moves import zip
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import optimizers
 from tensorflow.python.platform import tf_logging as logging

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import json
 
 from tensorflow.python.keras import backend as K

--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import io
 
 import h5py

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -15,10 +15,10 @@
 
 import os
 import platform
+import queue
 import time
 
 import pyspark
-from six.moves import queue
 
 from horovod.run.util.threads import in_thread
 from horovod.spark.task import task_service

--- a/horovod/spark/task/mpirun_exec_fn.py
+++ b/horovod/spark/task/mpirun_exec_fn.py
@@ -16,11 +16,6 @@
 import os
 import sys
 
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
-
 from horovod.spark.task import task_exec
 from horovod.run.common.util import codec
 

--- a/horovod/spark/torch/__init__.py
+++ b/horovod/spark/torch/__init__.py
@@ -13,7 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 from horovod.spark.torch.estimator import TorchEstimator
 from horovod.spark.torch.estimator import TorchModel

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import horovod.spark.common._namedtuple_fix
 
 import copy

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import contextlib
 import io
 import math

--- a/horovod/spark/torch/util.py
+++ b/horovod/spark/torch/util.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import io
+import platform
 import sys
 
 from horovod.run.common.util import codec
@@ -26,11 +27,7 @@ def is_module_available(module_name):
 
 def is_module_available_fn():
     def _is_module_available(module_name):
-        if sys.version_info < (3, 0):
-            # python 2
-            import pkgutil
-            torch_loader = pkgutil.find_loader(module_name)
-        elif sys.version_info <= (3, 3):
+        if sys.version_info <= (3, 3):
             # python 3.0 to 3.3
             import pkgutil
             torch_loader = pkgutil.find_loader(module_name)
@@ -38,6 +35,8 @@ def is_module_available_fn():
             # python 3.4 and above
             import importlib
             torch_loader = importlib.util.find_spec(module_name)
+        else:
+            raise RuntimeError('Unsupported version of Python: {}'.format(platform.python_version()))
 
         return torch_loader is not None
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -16,10 +16,6 @@
 # ==============================================================================
 # pylint: disable=g-short-docstring-punctuation
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import warnings
 

--- a/horovod/tensorflow/elastic.py
+++ b/horovod/tensorflow/elastic.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 from distutils.version import LooseVersion
 
 import tensorflow as tf

--- a/horovod/tensorflow/functions.py
+++ b/horovod/tensorflow/functions.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import io
-
-from distutils.version import LooseVersion
 
 import cloudpickle
 import numpy as np

--- a/horovod/tensorflow/keras/elastic.py
+++ b/horovod/tensorflow/keras/elastic.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import tensorflow as tf
 
 from horovod._keras import elastic as _impl

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -16,10 +16,6 @@
 # =============================================================================
 """Inter-process communication using MPI."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import re
 import tensorflow as tf
 from tensorflow.python.framework import load_library

--- a/horovod/tensorflow/util.py
+++ b/horovod/tensorflow/util.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 from distutils.version import LooseVersion
 
 import tensorflow as tf

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from horovod.common.util import check_extension
 
 try:

--- a/horovod/torch/elastic.py
+++ b/horovod/torch/elastic.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import copy
 
 from horovod.common.elastic import run_fn, ObjectState

--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import collections
 import io
 

--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -16,6 +16,8 @@
 import collections
 import io
 
+from collections.abc import Iterable
+
 import cloudpickle
 import torch
 
@@ -23,11 +25,6 @@ from horovod.torch.mpi_ops import broadcast_, broadcast_async_
 from horovod.torch.mpi_ops import synchronize
 from horovod.torch.mpi_ops import rank
 from horovod.torch.optimizer import DistributedOptimizer
-
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 
 
 def broadcast_parameters(params, root_rank):

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from distutils.version import LooseVersion
 
 # Load all the necessary PyTorch C types.

--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import warnings
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
-
 import os
 import re
 import shlex

--- a/setup.py
+++ b/setup.py
@@ -1569,7 +1569,7 @@ class custom_build_ext(build_ext):
                 'None of TensorFlow, PyTorch, or MXNet plugins were built. See errors above.')
 
 
-require_list = ['cloudpickle', 'psutil', 'pyyaml', 'six']
+require_list = ['cloudpickle', 'psutil', 'pyyaml']
 test_require_list = ['mock', 'pytest', 'pytest-forked']
 
 # framework dependencies

--- a/setup.py
+++ b/setup.py
@@ -1627,5 +1627,6 @@ setup(name='horovod',
           'mxnet': mxnet_require_list,
           'spark': spark_require_list
       },
+      python_requires='>=3.6',
       zip_safe=False,
       scripts=['bin/horovodrun'])

--- a/test/common.py
+++ b/test/common.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 # =============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import contextlib
 import os
 import shutil

--- a/test/data/expected_buildkite_pipeline.yaml
+++ b/test/data/expected_buildkite_pipeline.yaml
@@ -1,40 +1,10 @@
 steps:
-- label: ':docker: Build test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2'
-  plugins:
-  - docker-compose#6b0df8a98ff97f42f4944dbb745b5b8cbf04b78c:
-      build: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
-      cache-from: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2:823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite:SLUG-test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2-latest
-      config: docker-compose.test.yml
-      push-retries: 5
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 30
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':docker: Build test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2'
   plugins:
   - docker-compose#6b0df8a98ff97f42f4944dbb745b5b8cbf04b78c:
       build: test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       cache-from: test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2:823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite:SLUG-test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2-latest
-      config: docker-compose.test.yml
-      push-retries: 5
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 30
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':docker: Build test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0'
-  plugins:
-  - docker-compose#6b0df8a98ff97f42f4944dbb745b5b8cbf04b78c:
-      build: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
-      cache-from: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0:823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite:SLUG-test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0-latest
       config: docker-compose.test.yml
       push-retries: 5
   - ecr#v1.2.0:
@@ -95,21 +65,6 @@ steps:
       build: test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       cache-from: test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite:SLUG-test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0-latest
-      config: docker-compose.test.yml
-      push-retries: 5
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 30
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':docker: Build test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0'
-  plugins:
-  - docker-compose#6b0df8a98ff97f42f4944dbb745b5b8cbf04b78c:
-      build: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
-      cache-from: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0:823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite:SLUG-test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0-latest
       config: docker-compose.test.yml
       push-retries: 5
   - ecr#v1.2.0:
@@ -295,134 +250,8 @@ steps:
   agents:
     queue: cpu
 - wait
-- label: ':pytest: Run PyTests (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_elastic[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':jupyter: Run PyTests test_interactiverun (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c "cd /horovod/test && pytest -v --capture=no test_interactiverun.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test TensorFlow MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test Keras MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " \$(cat /mpirun_command) python /horovod/examples/keras_mnist_advanced.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Test PyTorch MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Test MXNet MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Single Keras MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " python /horovod/examples/keras_mnist_advanced.py --epochs 3 --batch-size 64"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Single PyTorch MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " python /horovod/examples/pytorch_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Single MXNet MNIST (test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " python /horovod/examples/mxnet_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tf1_6_0-keras2_1_2-torch0_4_1-mxnet1_4_1-pyspark2_3_2
@@ -547,134 +376,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':pytest: Run PyTests (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_elastic[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test TensorFlow MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow_mnist.py
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test Keras MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras_mnist_advanced.py
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Test PyTorch MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch_mnist.py
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Test MXNet MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet_mnist.py
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Single Keras MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " python /horovod/examples/keras_mnist_advanced.py --epochs 3 --batch-size 64"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Single PyTorch MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " python /horovod/examples/pytorch_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Single MXNet MNIST (test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " python /horovod/examples/mxnet_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py2_7-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -757,64 +460,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Keras Rossmann Run (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Keras Rossmann Estimator (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Keras MNIST (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':spark: PyTests Spark Estimators (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
   command: bash -c "cd /horovod/test && pytest --forked -v --capture=no test_spark_keras.py test_spark_torch.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Torch MNIST (test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_4_0-mxnet1_5_0-pyspark2_4_0
@@ -870,7 +517,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0
@@ -953,20 +600,6 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':spark: Spark Torch MNIST (test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':fire: Single PyTorch MNIST (test-cpu-gloo-py3_7-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0)'
   command: bash -c " python /horovod/examples/pytorch_mnist.py --epochs 3"
   plugins:
@@ -996,7 +629,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-gloo-py3_8-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_run.py"
+  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-gloo-py3_8-tf2_2_0-keras2_3_1-torch1_5_0-mxnet1_5_0-pyspark2_4_0
@@ -1108,7 +741,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0
@@ -1317,134 +950,8 @@ steps:
     automatic: true
   agents:
     queue: cpu
-- label: ':pytest: Run PyTests (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_elastic[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':jupyter: Run PyTests test_interactiverun (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && pytest -v --capture=no test_interactiverun.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Test PyTorch MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Test MXNet MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test TensorFlow 2.0 MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "\$(cat /mpirun_command) python /horovod/examples/tensorflow2_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':tensorflow: Test TensorFlow 2.0 Keras MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "\$(cat /mpirun_command) python /horovod/examples/tensorflow2_keras_mnist.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':spark: Spark Torch MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':fire: Single PyTorch MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " python /horovod/examples/pytorch_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
-- label: ':muscle: Single MXNet MNIST (test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " python /horovod/examples/mxnet_mnist.py --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-cpu-openmpi-py2_7-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -1570,7 +1077,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0
@@ -1696,7 +1203,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-mpich-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -1836,7 +1343,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-oneccl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "\$(cat /oneccl_env) && echo '/mpirun_command_mpi' > /mpirun_command && cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "\$(cat /oneccl_env) && echo '/mpirun_command_mpi' > /mpirun_command && cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-oneccl-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -1976,7 +1483,7 @@ steps:
   agents:
     queue: cpu
 - label: ':pytest: Run PyTests (test-cpu-oneccl-ofi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c "\$(cat /oneccl_env) && echo '/mpirun_command_ofi' > /mpirun_command && cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "\$(cat /oneccl_env) && echo '/mpirun_command_ofi' > /mpirun_command && cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-cpu-oneccl-ofi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -2117,7 +1624,7 @@ steps:
     queue: cpu
 - wait
 - label: ':pytest: Run PyTests (test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
@@ -2131,7 +1638,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
@@ -2145,7 +1652,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c "cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
@@ -2159,7 +1666,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-openmpi-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
@@ -2173,7 +1680,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-openmpi-py3_6-tf2_0_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -2187,7 +1694,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/test_keras.py//g' | sed 's/test_tensorflow_keras.py//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-openmpi-py3_6-tfhead-kerashead-torchhead-mxnethead-pyspark2_4_0
@@ -2201,7 +1708,7 @@ steps:
   agents:
     queue: 4x-gpu-g4
 - label: ':pytest: Run PyTests (test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0)'
-  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g'  | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
+  command: bash -c " cd /horovod/test && (echo test_*.py | sed 's/[a-z_]*tensorflow2[a-z_.]*//g' | sed 's/test_interactiverun.py//g' | sed 's/test_spark_keras.py//g' | sed 's/test_spark_torch.py//g' | sed 's/test_spark.py//g' | sed 's/test_run.py//g' | xargs -n 1 \$(cat /mpirun_command) pytest -v --capture=no) && pytest --forked -v --capture=no test_spark.py test_run.py"
   plugins:
   - docker-compose#v2.6.0:
       run: test-mixed-openmpi-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_5_0-pyspark2_4_0
@@ -2455,62 +1962,6 @@ steps:
     queue: 2x-gpu-g4
 - label: ':factory: Elastic Tests (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
   command: bash -c "cd /horovod/test/integration && pytest -v --log-cli-level 10 --capture=no test_elastic_torch.py test_elastic_tensorflow.py"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-g4
-- label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-g4
-- label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.01"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-g4
-- label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
-  plugins:
-  - docker-compose#v2.6.0:
-      run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-g4
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0)'
-  command: bash -c "OMP_NUM_THREADS=1 python /horovod/examples/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   plugins:
   - docker-compose#v2.6.0:
       run: test-gpu-gloo-py3_6-tf1_15_0-keras2_3_1-torch1_3_0-mxnet1_4_1-pyspark2_4_0

--- a/test/integration/data/elastic_tensorflow2_main.py
+++ b/test/integration/data/elastic_tensorflow2_main.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import argparse
 import json
 import os

--- a/test/integration/data/elastic_tensorflow_main.py
+++ b/test/integration/data/elastic_tensorflow_main.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import argparse
 import json
 import os

--- a/test/integration/data/elastic_torch_main.py
+++ b/test/integration/data/elastic_torch_main.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import argparse
 import json
 import os

--- a/test/integration/elastic_common.py
+++ b/test/integration/elastic_common.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import contextlib
 import json
 import os

--- a/test/integration/test_elastic_tensorflow.py
+++ b/test/integration/test_elastic_tensorflow.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import unittest
 import warnings

--- a/test/integration/test_elastic_tensorflow2.py
+++ b/test/integration/test_elastic_tensorflow2.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import unittest
 import warnings

--- a/test/integration/test_elastic_torch.py
+++ b/test/integration/test_elastic_torch.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import unittest
 import warnings

--- a/test/spark_common.py
+++ b/test/spark_common.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import contextlib
 import os
 import platform

--- a/test/test_adasum_tensorflow.py
+++ b/test/test_adasum_tensorflow.py
@@ -13,22 +13,14 @@
 # limitations under the License.
 # =============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import itertools
 import numpy as np
-import os
 import tensorflow as tf
 from tensorflow.python.framework import ops
 from horovod.tensorflow.util import _executing_eagerly, _has_eager
 import warnings
-from datetime import datetime
 import horovod.tensorflow as hvd
 import math
 import copy
-import subprocess
 
 def adasum_reference_operation(a,b):
     assert a.size == b.size

--- a/test/test_buildkite.py
+++ b/test/test_buildkite.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import print_function
-
-import string
 import unittest
 import warnings
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import unittest
 import warnings

--- a/test/test_elastic_driver.py
+++ b/test/test_elastic_driver.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import time
 import unittest
 import warnings

--- a/test/test_interactiverun.py
+++ b/test/test_interactiverun.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import unittest
 import warnings
 

--- a/test/test_keras.py
+++ b/test/test_keras.py
@@ -15,10 +15,6 @@
 
 """Tests for horovod.keras."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from distutils.version import LooseVersion
 
 import keras

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import itertools
 import unittest

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 import io
 import itertools

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
+import io
 import itertools
 import os
 import subprocess
@@ -30,7 +31,6 @@ import warnings
 import psutil
 import pytest
 import mock
-import six
 
 from mock import MagicMock
 
@@ -392,8 +392,8 @@ class RunTests(unittest.TestCase):
             self.assertFalse(child.is_running())
 
     def do_test_safe_shell_exec(self, cmd, expected_exit_code, expected_stdout, expected_stderr, event=None):
-        stdout = six.StringIO()
-        stderr = six.StringIO()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
         res = safe_shell_exec.execute(cmd, stdout=stdout, stderr=stderr, events=[event])
         self.assertEqual(expected_exit_code, res)
         if expected_stdout is not None:

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -17,14 +17,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import unittest
+import queue
 import threading
 import time
-import sys
+import unittest
 import warnings
-
-from distutils.version import LooseVersion
-from six.moves import queue
 
 import pytest
 

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import queue
 import threading
 import time

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -89,8 +89,6 @@ class NetworkTests(unittest.TestCase):
         self.assertGreaterEqual(duration, sleep, 'sleep requests should have been completed')
         self.assertLess(duration, sleep + 1.0, 'sleep requests should have been concurrent')
 
-    @pytest.mark.skipif(sys.version_info < (3,0),
-                        reason='block on shutdown is supported in Spark 3.0 and above')
     def test_shutdown_during_request_basic(self):
         sleep = 2.0
         key = secret.make_secret_key()
@@ -110,8 +108,6 @@ class NetworkTests(unittest.TestCase):
             thread.join(0.1)
             self.assertFalse(thread.is_alive(), 'thread should have terminated by now')
 
-    @pytest.mark.skipif(sys.version_info < (3,0),
-                        reason='block on shutdown is supported in Spark 3.0 and above')
     def test_shutdown_during_request_basic_task(self):
         result_queue = queue.Queue(1)
 

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -755,8 +755,8 @@ class SparkTests(unittest.TestCase):
 
             expected = [
                 ('int', {int}, 1, 1),
-                ('float', {float, NullType}, 1, 1),
-                ('null', {NullType}, 1, 1),
+                ('float', {float, type(None)}, 1, 1),
+                ('null', {type(None)}, 1, 1),
                 ('array', {list}, 2, 2),
                 ('dense', {DenseVector}, 2, 2),
                 ('sparse', {SparseVector}, 2, 1),

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -82,14 +82,6 @@ class SparkTests(unittest.TestCase):
 
         super(SparkTests, self).run(result)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 0), reason='Skipped on Python 3')
-    def test_run_throws_on_python2(self):
-        if not gloo_built():
-            self.skipTest("Gloo is not available")
-
-        with pytest.raises(Exception, match='^Horovod on Spark over Gloo only supported on Python3$'):
-            self.do_test_happy_run(use_mpi=False, use_gloo=True)
-
     """
     Test that horovod.spark.run works properly in a simple setup using MPI.
     """
@@ -102,8 +94,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run works properly in a simple setup using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_happy_run_with_gloo(self):
         if not gloo_built():
             self.skipTest("Gloo is not available")
@@ -138,8 +128,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run times out when it does not start up fast enough using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_timeout_with_gloo(self):
         if not gloo_built():
             self.skipTest("Gloo is not available")
@@ -181,8 +169,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run uses Gloo properly.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_with_gloo(self):
         self.do_test_spark_run(use_mpi=False, use_gloo=True)
 
@@ -209,8 +195,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run does not default to spark parallelism given num_proc using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_num_proc_precedes_spark_cores_with_gloo(self):
         self.do_test_spark_run_num_proc_precedes_spark_cores(use_mpi=False, use_gloo=True)
 
@@ -244,8 +228,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run defaults num_proc to spark parallelism using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_defaults_num_proc_to_spark_cores_with_gloo(self):
         self.do_test_spark_run_defaults_num_proc_to_spark_cores(use_mpi=False, use_gloo=True)
 
@@ -266,8 +248,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run defaults env to the full system env using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_does_not_default_env_to_os_env_with_gloo(self):
         self.do_test_spark_run_does_not_default_env_to_os_env(use_mpi=False, use_gloo=True)
 
@@ -294,8 +274,6 @@ class SparkTests(unittest.TestCase):
     """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using Gloo.
     """
-    @pytest.mark.skipif(sys.version_info < (3, 0),
-                        reason='Horovod on Spark over Gloo only supported on Python3')
     def test_spark_run_with_non_zero_exit_with_gloo(self):
         expected = '^Horovod detected that one or more processes exited with non-zero ' \
                    'status, thus causing the job to be terminated. The first process ' \

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import copy
 import itertools
 import os

--- a/test/test_spark_keras.py
+++ b/test/test_spark_keras.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
 import collections
 import warnings
 
 import mock
 import numpy as np
-import sys
 import tensorflow as tf
 
 import pyspark.sql.types as T
 from pyspark.ml.linalg import DenseVector, SparseVector
 from pyspark.sql.functions import udf
 
-from horovod.run.runner import is_gloo_used
 import horovod.spark.keras as hvd
 from horovod.spark.common import constants, util
 from horovod.spark.keras import remote

--- a/test/test_spark_keras.py
+++ b/test/test_spark_keras.py
@@ -74,9 +74,6 @@ class SparkKerasTests(tf.test.TestCase):
         warnings.simplefilter('module')
 
     def test_fit_model(self):
-        if sys.version_info < (3, 0, 0) and is_gloo_used():
-            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
-
         model = create_xor_model()
         optimizer = tf.keras.optimizers.SGD(lr=0.1)
         loss = 'binary_crossentropy'
@@ -105,9 +102,6 @@ class SparkKerasTests(tf.test.TestCase):
                 assert pred.dtype == np.float32
 
     def test_fit_model_multiclass(self):
-        if sys.version_info < (3, 0, 0) and is_gloo_used():
-            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
-
         model = create_mnist_model()
         optimizer = tf.keras.optimizers.Adadelta(1.0)
         loss = tf.keras.losses.categorical_crossentropy

--- a/test/test_spark_torch.py
+++ b/test/test_spark_torch.py
@@ -64,9 +64,6 @@ class SparkTorchTests(unittest.TestCase):
         warnings.simplefilter('module')
 
     def test_fit_model(self):
-        if sys.version_info < (3, 0, 0) and is_gloo_used():
-            self.skipTest('Horovod on Spark over Gloo only supported on Python3')
-
         model = create_xor_model()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss = F.binary_cross_entropy

--- a/test/test_spark_torch.py
+++ b/test/test_spark_torch.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-
-import sys
 import unittest
 import warnings
 
@@ -30,7 +27,6 @@ import torch.nn as nn
 from torch.nn import functional as F
 import torch.optim as optim
 
-from horovod.run.runner import is_gloo_used
 import horovod.spark.torch as hvd
 from horovod.spark.common import constants, util
 from horovod.spark.torch import remote

--- a/test/test_stall.py
+++ b/test/test_stall.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import horovod.torch as hvd
 from horovod.common.util import env
 import torch

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -17,10 +17,6 @@
 
 """Tests for horovod.tensorflow.mpi_ops."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from distutils.version import LooseVersion
 
 import itertools

--- a/test/test_tensorflow2_keras.py
+++ b/test/test_tensorflow2_keras.py
@@ -15,10 +15,6 @@
 
 """Tests for horovod.tensorflow.keras."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import tensorflow as tf
 import numpy as np
 import warnings

--- a/test/test_tensorflow_keras.py
+++ b/test/test_tensorflow_keras.py
@@ -15,10 +15,6 @@
 
 """Tests for horovod.tensorflow.keras."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import pytest
 import tensorflow as tf

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import time
 import torch
 import unittest

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -23,6 +23,8 @@ import pytest
 import unittest
 import warnings
 
+from collections.abc import Iterable
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -31,11 +33,6 @@ import torch.nn.functional as F
 import horovod.torch as hvd
 
 from common import mpi_env_rank_and_size, temppath
-
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 
 _v2_api = LooseVersion(torch.__version__) >= LooseVersion('1.0.0')
 _fp16_supported = _v2_api

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -20,7 +20,6 @@ import inspect
 import itertools
 import os
 import pytest
-import sys
 import unittest
 import warnings
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1674,10 +1674,6 @@ class TorchTests(unittest.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("No GPUs available")
 
-        if sys.version_info < (3,):
-            # TODO: remove this check after Py2 deprecation
-            self.skipTest("Python 3 only feature")
-
         hvd.init()
 
         ts_list = [

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from distutils.version import LooseVersion
 
 import inspect


### PR DESCRIPTION
Fixes #1929.

- Removed Python 2 tests from Buildkite.
- Removed references to Python 2 in Docker images.
- Removed system version checks that perform different logic for Python 2 vs Python 3.
- Removed dependency on `six` and replaced all usages with native Python 3 equivalents.
- Removed doc references to Python 2 and added Python 3 to install requirements.
- Removed unit test exclusions for Python 2.
- Removed Python 2 from supported versions in setup.