### PR TITLE
Blacklist hosts on failure, not _on_workers_recorded

### DIFF
--- a/horovod/run/elastic/discovery.py
+++ b/horovod/run/elastic/discovery.py
@@ -83,12 +83,13 @@ class HostManager(object):
         self._discovery = discovery
 
     def update_available_hosts(self):
-        # TODO(travis): also check for hosts removed from the blacklist in the future
         prev_host_slots = self._current_hosts.host_slots
         prev_host_assignment_order = self._current_hosts.host_assignment_order
-        host_slots = self._discovery.find_available_hosts_and_slots()
+        discovered_hosts_slots = self._discovery.find_available_hosts_and_slots()
+        host_slots = {host: slots for host, slots in discovered_hosts_slots.items()
+                      if not self._hosts_state[host].is_blacklisted()}
         if prev_host_slots != host_slots:
-            available_hosts = set([host for host in host_slots.keys() if not self._hosts_state[host].is_blacklisted()])
+            available_hosts = host_slots.keys()
             host_assignment_order = HostManager.order_available_hosts(available_hosts, prev_host_assignment_order)
             self._current_hosts = DiscoveredHosts(host_slots=host_slots,
                                                   host_assignment_order=host_assignment_order)

--- a/horovod/run/elastic/registration.py
+++ b/horovod/run/elastic/registration.py
@@ -66,6 +66,7 @@ class WorkerStateRegistry(object):
         return self._record_state(host, slot, SUCCESS)
 
     def record_failure(self, host, slot):
+        self._host_manager.blacklist(host)
         return self._record_state(host, slot, FAILURE)
 
     def _record_state(self, host, slot, state):
@@ -130,11 +131,6 @@ class WorkerStateRegistry(object):
             logging.error('failure count == {} -> stop running'.format(self._size))
             self._driver.stop()
             return
-
-        # Check for failures, and add them to the blacklisted hosts list
-        failures = self.get(FAILURE)
-        for host, slot in failures:
-            self._host_manager.blacklist(host)
 
         # If every active host is blacklisted, then treat this as job failure
         if all([self._host_manager.is_blacklisted(host) for host, slot in self.get_recorded_slots()]):


### PR DESCRIPTION
Removes hosts from discovery as soon as worker fails. Allows for worker notification about scale-down through `HostsUpdatedInterrupt` in addition to existing `HorovodInternalError`.

Signed-off-by: Enrico Minack <github@enrico.minack.dev>