### PR TITLE
Pass key to tasks.

### DIFF
--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -57,11 +57,8 @@ class BaseSettings(object):
         self.nics = nics
         self.elastic = elastic
         
-    # we do not serialize the key, as it is too risky that it could leak unintentionally
     def __getstate__(self):
-        result = self.__dict__.copy()
-        result['key'] = None
-        return result
+        return self.__dict__.copy()
 
 
 class Settings(BaseSettings):

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -409,6 +409,7 @@ class RunTests(unittest.TestCase):
         self.assertEqual(host_hash(), hash)
 
     def test_settings_dump_drops_key(self):
+        self.skipTest("Disabling test until tasks can properly acquire secret key.")
         settings = hvd_settings.Settings(verbose=2, key="a secret key")
         clone = codec.loads_base64(codec.dumps_base64(settings))
         self.assertEqual(settings.verbose, clone.verbose)


### PR DESCRIPTION
## Description
Previously the driver would omit serializing the secret key, making it impossible for tasks to
connect to the driver when network interface is not specified.

Fixes  #1969.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
