### PR TITLE
Don't serialize the key in settings with Spark

### DIFF
--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -56,12 +56,6 @@ class BaseSettings(object):
         self.run_func_mode = run_func_mode
         self.nics = nics
         self.elastic = elastic
-        
-    # we do not serialize the key, as it is too risky that it could leak unintentionally
-    def __getstate__(self):
-        result = self.__dict__.copy()
-        result['key'] = None
-        return result
 
 
 class Settings(BaseSettings):

--- a/horovod/spark/driver/mpirun_rsh.py
+++ b/horovod/spark/driver/mpirun_rsh.py
@@ -49,4 +49,4 @@ if __name__ == '__main__':
 
     # Since tasks with the same host hash have shared memory,
     # we will run only one orted process on the first task.
-    rsh(addresses, key, settings, host_hash, command, env, 0)
+    rsh(addresses, key, host_hash, command, env, 0, settings.verbose)

--- a/horovod/spark/driver/rsh.py
+++ b/horovod/spark/driver/rsh.py
@@ -21,7 +21,7 @@ from horovod.spark.task import task_service
 from horovod.spark.driver import driver_service
 
 
-def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank,
+def rsh(driver_addresses, key, host_hash, command, env, local_rank, verbose,
         background=True, events=None):
     """
     Method to run a command remotely given a host hash, local rank and driver addresses.
@@ -37,24 +37,22 @@ def rsh(driver_addresses, key, settings, host_hash, command, env, local_rank,
 
     :param driver_addresses: driver's addresses
     :param key: used for encryption of parameters passed across the hosts
-    :param settings: settings
     :param host_hash: host hash to connect to
     :param command: command and arguments to invoke
     :param env: environment to use
     :param local_rank: local rank on the host of task to run the command in
+    :param verbose: verbosity level
     :param background: run command in background if True, returns command result otherwise
     :param events: events to abort the command, only if background is True
     """
     if ':' in host_hash:
         raise Exception('Illegal host hash provided. Are you using Open MPI 4.0.0+?')
 
-    driver_client = driver_service.SparkDriverClient(driver_addresses, key,
-                                                     verbose=settings.verbose)
+    driver_client = driver_service.SparkDriverClient(driver_addresses, key, verbose=verbose)
     task_indices = driver_client.task_host_hash_indices(host_hash)
     task_index = task_indices[local_rank]
     task_addresses = driver_client.all_task_addresses(task_index)
-    task_client = task_service.SparkTaskClient(task_index, task_addresses,
-                                               key, verbose=settings.verbose)
+    task_client = task_service.SparkTaskClient(task_index, task_addresses, key, verbose=verbose)
     task_client.run_command(command, env)
 
     if not background:

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -25,7 +25,8 @@ def _exec_command_fn(driver_addresses, key, settings, env):
     def _exec_command(command, slot_info, events):
         host = slot_info.hostname
         local_rank = slot_info.local_rank
-        result = rsh(driver_addresses, key, settings, host, command, env, local_rank, False, events)
+        verbose = settings.verbose
+        result = rsh(driver_addresses, key, host, command, env, local_rank, verbose, False, events)
         return result, time.time()
     return _exec_command
 
@@ -43,6 +44,10 @@ def gloo_run(settings, nics, driver, env):
     if env is None:
         env = {}
 
+    # we don't want the key to be serialized along with settings from here on
+    key = settings.key
+    settings.key = None
+
     # Each thread will use SparkTaskClient to launch the job on each remote host. If an
     # error occurs in one thread, entire process will be terminated. Otherwise,
     # threads will keep running and ssh session.
@@ -53,5 +58,5 @@ def gloo_run(settings, nics, driver, env):
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))
 
-    exec_command = _exec_command_fn(driver.addresses(), settings.key, settings, env)
+    exec_command = _exec_command_fn(driver.addresses(), key, settings, env)
     launch_gloo(command, exec_command, settings, nics, {}, server_ip)

--- a/horovod/spark/mpi_run.py
+++ b/horovod/spark/mpi_run.py
@@ -38,6 +38,8 @@ def mpi_run(settings, nics, driver, env, stdout=None, stderr=None):
 
     # Pass secret key through the environment variables.
     env[secret.HOROVOD_SECRET_KEY] = codec.dumps_base64(settings.key)
+    # we don't want the key to be serialized along with settings from here on
+    settings.key = None
 
     rsh_agent = (sys.executable,
                  '-m', 'horovod.spark.driver.mpirun_rsh',

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -408,13 +408,6 @@ class RunTests(unittest.TestCase):
             self.assertNotEqual(host_hash(), hash)
         self.assertEqual(host_hash(), hash)
 
-    def test_settings_dump_drops_key(self):
-        settings = hvd_settings.Settings(verbose=2, key="a secret key")
-        clone = codec.loads_base64(codec.dumps_base64(settings))
-        self.assertEqual(settings.verbose, clone.verbose)
-        self.assertIsNotNone(settings.key)
-        self.assertIsNone(clone.key)
-
     def test_get_mpi_implementation(self):
         def test(output, expected, exit_code=0):
             ret = (output, exit_code) if output is not None else None


### PR DESCRIPTION
Fixes #1969 **and** keeps key away from serialized `settings` when running on Spark.

Signed-off-by: Enrico Minack <github@enrico.minack.dev>