### PR TITLE
Limit response cache bit assignment updates for better performance.

### DIFF
--- a/horovod/common/response_cache.cc
+++ b/horovod/common/response_cache.cc
@@ -149,8 +149,6 @@ void ResponseCache::put_(const Response& response, TensorParams& params, bool jo
   cache_iters_[cache_bit] = cache_.begin();
   tensor_name_to_bit_[response.tensor_names()[0]] = cache_bit;
 
-  // Cache is mutated, mark that bit assignments are stale.
-  bits_outdated_ = true;
 }
 
 void ResponseCache::put(const Response& response, TensorQueue& tensor_queue, bool joined) {
@@ -213,9 +211,6 @@ const Response& ResponseCache::get_response(uint32_t cache_bit) {
   cache_.erase(it);
   cache_iters_[cache_bit] = cache_.begin();
 
-  // Cache is mutated, mark that bit assignments are stale.
-  bits_outdated_ = true;
-
   return cache_.front().first;
 }
 
@@ -256,14 +251,14 @@ void ResponseCache::erase_response(uint32_t cache_bit) {
 
   cache_iters_[cache_bit] = cache_.end();
 
-  // Cache is mutated, mark that bit assignments are stale.
+  // Set flag to trigger update_cache_bits to remove empty
+  // positions in cache_iters_ vector
   bits_outdated_ = true;
 }
 
 void ResponseCache::update_cache_bits() {
   // Note: This method invalidates all previously returned cache bit positions.
 
-  // If bit assignments are not stale, do nothing.
   if (!bits_outdated_) {
     return;
   }


### PR DESCRIPTION
Signed-off-by: Josh Romero <joshr@nvidia.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
It was brought to my attention that in cases with sync BN, the current process of reassigning response cache bits to align with the current cache order in `update_cache_bits` every cycle an operation is performed can lead to highly inefficient performance. The reason for this is that when using sync BN, additional Horovod operations are performed within the forward/backward path which dramatically increases the number of cycles where operations are performed per iteration.  As a result, this update occurs many more times per training step which can be a performance bottleneck. Outside of the sync BN case, this performance issue could also arise in other similar situations where Horovod operations are inserted within the main forward/backward pass of the training graph. 

The proposed solution in this PR is to limit the operation of `update_cache_bits` to situations where responses in the cache are erased to reclaim some space in the cache data structures, but otherwise, leave the bit assignments unchanged. This will remove the 1 to 1 correspondence between the cache bit assignments and the location of the cached entries in the actual response cache (i.e. linked list), as those will still be moved around in the cache on access to maintain LRU behavior. 

This may impact the scheduling priority of some operations. As the cache bit assignments are no longer updated to match the LRU ordering of the cache, in places where the response priority is determined by the cache bit values (responses corresponding to lower bit values are carried out first), rather than giving higher priority to the least recently used responses, the priorities will remain constant and highest priority will be given to responses seen first during training.  


