### PR TITLE
Keras Mixed Precision Policy and Horovod are incompatible with Tensorflow 2.2

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -38,6 +38,13 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache
 
 import tensorflow as tf
 
+# @DEKHTIARJonathan: Do not remove, this fixes issues: 
+# - https://github.com/tensorflow/tensorflow/issues/38516
+# - https://github.com/tensorflow/tensorflow/issues/39894
+if tf.__version__.startswith('2.2.'):
+  from tensorflow.python.keras.mixed_precision.experimental import device_compatibility_check
+  device_compatibility_check.log_device_compatibility_check = lambda policy_name, skip_local: None
+
 
 def allreduce(tensor, average=None, device_dense='', device_sparse='',
               compression=Compression.none, op=None):


### PR DESCRIPTION
It seems that Mixed Precision Keras policy is currently in broken state when used combined with Horovod. If you use the test repository, you can reproduce the issue (you will need 2+ GPUs) https://github.com/DEKHTIARJonathan/TF_HVD_Stability_Test.

The issues comes by the sequence of operations:
1. set_visible_devices()
2. define Keras Policy

**Reproducible Test Case:**

```bash
#!/usr/bin/env bash

export HOROVOD_GPU_ALLREDUCE=NCCL
export HOROVOD_GPU_BROADCAST=NCCL
export HOROVOD_NCCL_INCLUDE=/usr/include
export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
export HOROVOD_NCCL_LINK=SHARED
export HOROVOD_WITHOUT_PYTORCH=1
export HOROVOD_WITHOUT_MXNET=1
export HOROVOD_WITH_TENSORFLOW=1
export HOROVOD_WITH_MPI=1
export HOROVOD_BUILD_ARCH_FLAGS="-march=sandybridge -mtune=broadwell"
pip uninstall horovod -y
pip install --no-cache --no-cache-dir horovod==0.19.3

git clone https://github.com/DEKHTIARJonathan/TF_HVD_Stability_Test.git
cd TF_HVD_Stability_Test 

pip install -r requirements.txt
pytest
```

**Will give the following result:**

```bash
platform linux -- Python 3.6.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /workspace, inifile: pytest.ini
plugins: typeguard-2.7.1
collected 18 items                                                                                                                                                                                           
test.py::HorovodTest::test_example_00_RN50_Gradient_Tape_HVD_1GPU PASSED                                                         [  5%]
test.py::HorovodTest::test_example_01_RN50_Gradient_Tape_HVD_AMP_1GPU PASSED                                                     [ 11%]
test.py::HorovodTest::test_example_02_RN50_Gradient_Tape_HVD_AMP_FP16_All_Reduce_1GPU PASSED                                     [ 16%]
test.py::HorovodTest::test_example_03_RN50_Gradient_Tape_HVD_2GPUs PASSED                                                        [ 22%]
test.py::HorovodTest::test_example_04_RN50_Gradient_Tape_HVD_AMP_2GPUs FAILED                                                    [ 27%]        # ======> FAILS
test.py::HorovodTest::test_example_05_RN50_Gradient_Tape_HVD_AMP_FP16_All_Reduce_2GPUs FAILED                                    [ 33%]        # ======> FAILS
test.py::HorovodTest::test_example_06_keras_Sequential_CTL_Gradient_Tape_HVD_1GPU PASSED                                         [ 38%]
test.py::HorovodTest::test_example_07_keras_Sequential_CTL_Gradient_Tape_HVD_AMP_1GPU PASSED                                     [ 44%]
test.py::HorovodTest::test_example_08_keras_Sequential_CTL_Gradient_Tape_HVD_AMP_FP16_All_Reduce_1GPU PASSED                     [ 50%]
test.py::HorovodTest::test_example_09_keras_Sequential_CTL_Gradient_Tape_HVD_2GPUs PASSED                                        [ 55%]
test.py::HorovodTest::test_example_10_keras_Sequential_CTL_Gradient_Tape_HVD_AMP_2GPUs FAILED                                    [ 61%]        # ======> FAILS
test.py::HorovodTest::test_example_11_keras_Sequential_CTL_Gradient_Tape_HVD_AMP_FP16_All_Reduce_2GPUs FAILED                    [ 66%]        # ======> FAILS
test.py::HorovodTest::test_example_12_keras_fit_compile_Gradient_Tape_HVD_1GPU PASSED                                            [ 72%]
test.py::HorovodTest::test_example_13_keras_fit_compile_Gradient_Tape_HVD_AMP_1GPU PASSED                                        [ 77%]
test.py::HorovodTest::test_example_14_keras_fit_compile_Gradient_Tape_HVD_AMP_FP16_All_Reduce_1GPU PASSED                        [ 83%]
test.py::HorovodTest::test_example_15_keras_fit_compile_Gradient_Tape_HVD_2GPUs PASSED                                           [ 88%]
test.py::HorovodTest::test_example_16_keras_fit_compile_Gradient_Tape_HVD_AMP_2GPUs FAILED                                       [ 94%]        # ======> FAILS
test.py::HorovodTest::test_example_17_keras_fit_compile_Gradient_Tape_HVD_AMP_FP16_All_Reduce_2GPUs FAILED                       [100%]        # ======> FAILS
```

**If we look at the traceback, the error is quite explicit:**

```python
[1,1]<stderr>:Traceback (most recent call last):
[1,1]<stderr>:  File "examples/tf2_FitCompile_GradientTape.py", line 49, in <module>
[1,1]<stderr>:    policy = mixed_precision.Policy('mixed_float16')
[1,1]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/mixed_precision/experimental/policy.py", line 349, in __init__
[1,1]<stderr>:    skip_local=True)
[1,1]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/mixed_precision/experimental/device_compatibility_check.py", line 157, in log_device_compatibility_check
[1,1]<stderr>:    device_attr_list = device_lib.list_local_devices()
[1,1]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/device_lib.py", line 43, in list_local_devices
[1,1]<stderr>:    _convert(s) for s in _pywrap_device_lib.list_devices(serialized_config)
[1,1]<stderr>:RuntimeError: TensorFlow device (GPU:0) is being mapped to multiple CUDA devices (0 now, and 1 previously), which is not supported. This may be the result of providing different GPU configurations (ConfigProto.gpu_options, for example different visible_device_list) when creating multiple Sessions in the same process. This is not  currently supported, see https://github.com/tensorflow/tensorflow/issues/19083
```

CC: @reedwm @nluehr @tgaddair @sanjoy