### PR TITLE
Multi GPU unittest skip if only one GPU is available

### DIFF
--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -287,6 +287,10 @@ class TensorFlowTests(tf.test.TestCase):
         if not tf.test.is_gpu_available(cuda_only=True):
             self.skipTest(("No GPUs available"))
 
+        # Only do this test if there are enough GPUs available.
+        if len(tf.config.experimental.list_physical_devices('GPU')) < 2:
+            self.skipTest(("Too few GPUs available"))
+
         if os.environ.get('HOROVOD_MIXED_INSTALL'):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
             self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")


### PR DESCRIPTION
Simple fix in unittests to avoid having a unittest failure in case only one GPU is available.