### PR TITLE
Call to mpi_run with os.environ should fail with useful exception

### DIFF
--- a/horovod/run/mpi_run.py
+++ b/horovod/run/mpi_run.py
@@ -134,6 +134,10 @@ def mpi_run(settings, nics, env, command, stdout=None, stderr=None):
         stderr: Stderr of the mpi process.
                 Only used when settings.run_func_mode is True.
     """
+    if env is not None and not isinstance(env, dict):
+        raise Exception('env argument must be a dict, not {type}: {env}'
+                        .format(type=type(env), env=env))
+
     mpi_impl_flags, impl_binding_args = _get_mpi_implementation_flags(settings.tcp_flag, env=env)
     if mpi_impl_flags is None:
         raise Exception(_MPI_NOT_FOUND_ERROR_MSG)

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -474,6 +474,16 @@ class SparkTests(unittest.TestCase):
                                     expected_env=expected_env)
 
     """
+    Test that horovod.spark.run fails with os.environ as env with mpi.
+    """
+    def test_spark_run_with_os_environ_with_mpi(self):
+        with is_built(gloo_is_built=False, mpi_is_built=True):
+            with spark_session('test_spark_run', cores=2):
+                with pytest.raises(Exception, match="^env argument must be a dict, not <class 'os._Environ'>: "):
+                    horovod.spark.run(fn, num_proc=2, use_mpi=True, use_gloo=False,
+                                      env=os.environ, verbose=2)
+
+    """
     Test that horovod.spark.run raises an exception on non-zero exit code of mpi_run using MPI.
     """
     def test_spark_run_with_non_zero_exit_with_mpi(self):


### PR DESCRIPTION
The os.environ cannot be pickled as it is not a `dict` but `os._Environ`:

    AttributeError: Can't pickle local object '_createenviron.<locals>.encode'

Exception now reads `env argument must be a dict, not <class 'os._Environ'>: …`

Fixes #2037

Signed-off-by: Enrico Minack <github@enrico.minack.dev>