### PR TITLE
Unpin Keras following 2.4.2 release

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -98,7 +98,7 @@ services:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly
-        KERAS_PACKAGE: git+https://github.com/keras-team/keras.git@7a39b6c62d43c25472b2c2476bd2a8983ae4f682
+        KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision==0.6.0.dev20200413
         MXNET_PACKAGE: mxnet-nightly
@@ -226,7 +226,7 @@ services:
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
         TENSORFLOW_PACKAGE: tf-nightly-gpu
-        KERAS_PACKAGE: git+https://github.com/keras-team/keras.git@7a39b6c62d43c25472b2c2476bd2a8983ae4f682
+        KERAS_PACKAGE: git+https://github.com/keras-team/keras.git
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision==0.6.0.dev20200413
         MXNET_PACKAGE: mxnet-nightly


### PR DESCRIPTION
See https://github.com/keras-team/keras/issues/14129, which removes dependency on tensorflow.