### PR TITLE
Added NCCL async error handling

### DIFF
--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -16,6 +16,7 @@
 
 #include "gpu_operations.h"
 
+#include <pthread>
 #include <thread>
 
 namespace horovod {
@@ -75,7 +76,8 @@ public:
   }
 
   void WaitForEvents(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
-      const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
+      const std::vector<TensorTableEntry>& entries, Timeline& timeline,
+      std::function<void()>& error_check_callback) {
     while (!event_queue.empty()) {
       std::string name;
       cudaEvent_t event;
@@ -84,7 +86,23 @@ public:
       if (name != "") {
         timeline.ActivityStartAll(entries, name);
       }
-      ErrorCheck("cudaEventSynchronize", cudaEventSynchronize(event));
+
+      // Check for async (networking) errors while waiting for the event to complete
+      cudaError_t cuda_result;
+      while (true) {
+        cuda_result = cudaEventQuery(event);
+        if (cuda_result == cudaSuccess) {
+          break;
+        }
+
+        if (cuda_result != cudaErrorNotReady) {
+          throw std::logic_error("cudaEventQuery failed: " + cudaGetErrorString(cuda_result));
+        }
+
+        error_check_callback();
+        pthread_yield();
+      }
+
       if (name != "") {
         timeline.ActivityEndAll(entries);
       }

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -77,7 +77,7 @@ public:
 
   void WaitForEvents(std::queue<std::pair<std::string, cudaEvent_t>>& event_queue,
       const std::vector<TensorTableEntry>& entries, Timeline& timeline,
-      std::function<void()>& error_check_callback) {
+      const std::function<void()>& error_check_callback) {
     while (!event_queue.empty()) {
       std::string name;
       cudaEvent_t event;

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -99,7 +99,9 @@ public:
           throw std::logic_error(std::string("cudaEventQuery failed: ") + cudaGetErrorString(cuda_result));
         }
 
-        error_check_callback();
+        if (error_check_callback) {
+          error_check_callback();
+        }
         pthread_yield();
       }
 

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -16,7 +16,7 @@
 
 #include "gpu_operations.h"
 
-#include <pthread>
+#include <pthread.h>
 #include <thread>
 
 namespace horovod {

--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -96,7 +96,7 @@ public:
         }
 
         if (cuda_result != cudaErrorNotReady) {
-          throw std::logic_error("cudaEventQuery failed: " + cudaGetErrorString(cuda_result));
+          throw std::logic_error(std::string("cudaEventQuery failed: ") + cudaGetErrorString(cuda_result));
         }
 
         error_check_callback();

--- a/horovod/common/ops/gpu_context_impl.cc
+++ b/horovod/common/ops/gpu_context_impl.cc
@@ -13,8 +13,8 @@ void GPUContext::RecordEvent(std::queue<std::pair<std::string, gpuEvent_t>>& eve
   pimpl->RecordEvent(event_queue, name, stream);
 }
 
-void GPUContext::WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, const std::vector<TensorTableEntry>& entries, Timeline& timeline) {
-  pimpl->WaitForEvents(event_queue, entries, timeline);
+void GPUContext::WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, const std::vector<TensorTableEntry>& entries, Timeline& timeline, std::function<void()>& error_check_callback) {
+  pimpl->WaitForEvents(event_queue, entries, timeline, error_check_callback);
 }
 
 void GPUContext::StreamCreate(gpuStream_t *stream) {

--- a/horovod/common/ops/gpu_context_impl.cc
+++ b/horovod/common/ops/gpu_context_impl.cc
@@ -13,7 +13,7 @@ void GPUContext::RecordEvent(std::queue<std::pair<std::string, gpuEvent_t>>& eve
   pimpl->RecordEvent(event_queue, name, stream);
 }
 
-void GPUContext::WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, const std::vector<TensorTableEntry>& entries, Timeline& timeline, std::function<void()>& error_check_callback) {
+void GPUContext::WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue, const std::vector<TensorTableEntry>& entries, Timeline& timeline, const std::function<void()>& error_check_callback) {
   pimpl->WaitForEvents(event_queue, entries, timeline, error_check_callback);
 }
 

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -44,7 +44,8 @@ void GPUOpContext::InitGPUQueue(const std::vector<TensorTableEntry>& entries, co
   }
 }
 
-Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer /*= true*/) {
+Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer /*= true*/,
+                                      std::function<void()>& error_check_callback) {
   // Use completion marker via event because it's faster than
   // blocking gpuStreamSynchronize() in this thread.
   gpu_context_->RecordEvent(event_queue, "", *stream);
@@ -61,10 +62,10 @@ Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entri
       first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
 
   gpu_context_->finalizer_thread_pool.execute([entries, first_entry, cpu_buffer, fusion_buffer, free_host_buffer,
-                                                evt_queue, &timeline, &gpu_context]() mutable {
+                                                evt_queue, &timeline, &gpu_context, &error_check_callback]() mutable {
     gpu_context->SetDevice(first_entry.device);
 
-    gpu_context->WaitForEvents(evt_queue, entries, timeline);
+    gpu_context->WaitForEvents(evt_queue, entries, timeline, error_check_callback);
     if (free_host_buffer && cpu_buffer != nullptr) {
       free(cpu_buffer);
     }

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -45,7 +45,7 @@ void GPUOpContext::InitGPUQueue(const std::vector<TensorTableEntry>& entries, co
 }
 
 Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer /*= true*/,
-                                      std::function<void()>& error_check_callback) {
+                                      const std::function<void()>& error_check_callback) {
   // Use completion marker via event because it's faster than
   // blocking gpuStreamSynchronize() in this thread.
   gpu_context_->RecordEvent(event_queue, "", *stream);

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -62,7 +62,7 @@ Status GPUOpContext::FinalizeGPUQueue(const std::vector<TensorTableEntry>& entri
       first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
 
   gpu_context_->finalizer_thread_pool.execute([entries, first_entry, cpu_buffer, fusion_buffer, free_host_buffer,
-                                                evt_queue, &timeline, &gpu_context, &error_check_callback]() mutable {
+                                                evt_queue, &timeline, &gpu_context, error_check_callback]() mutable {
     gpu_context->SetDevice(first_entry.device);
 
     gpu_context->WaitForEvents(evt_queue, entries, timeline, error_check_callback);

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -69,7 +69,7 @@ public:
 
   void WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue,
                      const std::vector<TensorTableEntry>& entries, Timeline& timeline,
-                     std::function<void()>& error_check_callback = {});
+                     const std::function<void()>& error_check_callback = {});
 
   void StreamCreate(gpuStream_t *stream);
   void StreamSynchronize(gpuStream_t stream);
@@ -100,7 +100,7 @@ public:
   void InitGPUQueue(const std::vector<TensorTableEntry>& entries, const Response& response);
 
   Status FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer = true,
-                          std::function<void()>& error_check_callback = {});
+                          const std::function<void()>& error_check_callback = {});
 
   // GPU events are used as an alternative to host-device synchronization (which stalls the GPU pipeline)
   // for the purpose of recording timing on the Horovod timeline.

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -68,7 +68,8 @@ public:
                    gpuStream_t& stream);
 
   void WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue,
-                     const std::vector<TensorTableEntry>& entries, Timeline& timeline);
+                     const std::vector<TensorTableEntry>& entries, Timeline& timeline,
+                     std::function<void()>& error_check_callback = {});
 
   void StreamCreate(gpuStream_t *stream);
   void StreamSynchronize(gpuStream_t stream);
@@ -98,7 +99,8 @@ public:
 
   void InitGPUQueue(const std::vector<TensorTableEntry>& entries, const Response& response);
 
-  Status FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer = true);
+  Status FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer = true,
+                          std::function<void()>& error_check_callback = {});
 
   // GPU events are used as an alternative to host-device synchronization (which stalls the GPU pipeline)
   // for the purpose of recording timing on the Horovod timeline.

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -69,7 +69,7 @@ public:
 
   void WaitForEvents(std::queue<std::pair<std::string, gpuEvent_t>>& event_queue,
                      const std::vector<TensorTableEntry>& entries, Timeline& timeline,
-                     const std::function<void()>& error_check_callback = {});
+                     const std::function<void()>& error_check_callback = nullptr);
 
   void StreamCreate(gpuStream_t *stream);
   void StreamSynchronize(gpuStream_t stream);
@@ -100,7 +100,7 @@ public:
   void InitGPUQueue(const std::vector<TensorTableEntry>& entries, const Response& response);
 
   Status FinalizeGPUQueue(const std::vector<TensorTableEntry>& entries, bool free_host_buffer = true,
-                          const std::function<void()>& error_check_callback = {});
+                          const std::function<void()>& error_check_callback = nullptr);
 
   // GPU events are used as an alternative to host-device synchronization (which stalls the GPU pipeline)
   // for the purpose of recording timing on the Horovod timeline.

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -76,7 +76,7 @@ public:
 
   void WaitForEvents(std::queue<std::pair<std::string, hipEvent_t>>& event_queue,
       const std::vector<TensorTableEntry>& entries, Timeline& timeline,
-      std::function<void()>& error_check_callback) {
+      const std::function<void()>& error_check_callback) {
     while (!event_queue.empty()) {
       std::string name;
       hipEvent_t event;

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -96,7 +96,7 @@ public:
         }
 
         if (hip_result != hipErrorNotReady) {
-          throw std::logic_error("hipEventQuery failed: " + hipGetErrorString(hip_result));
+          throw std::logic_error(std::string("hipEventQuery failed: ") + hipGetErrorString(hip_result));
         }
 
         error_check_callback();

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -99,7 +99,9 @@ public:
           throw std::logic_error(std::string("hipEventQuery failed: ") + hipGetErrorString(hip_result));
         }
 
-        error_check_callback();
+        if (error_check_callback) {
+          error_check_callback();
+        }
         pthread_yield();
       }
 

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -16,6 +16,7 @@
 
 #include "gpu_operations.h"
 
+#include <pthread.h>
 #include <thread>
 
 namespace horovod {

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -309,7 +309,8 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     gpu_op_context_.host_buffer = malloc(total_buffer_len);
 
     // Synchronize.
-    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline, nccl_op_context_.AsyncErrorCheck);
+    auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
+    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline, error_check_callback);
 
     // According to https://docs.nvidia.com/cuda/cuda-runtime-api/
     // api-sync-behavior.html#api-sync-behavior__memcpy-async,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -171,8 +171,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
 
-  auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
-  return gpu_op_context_.FinalizeGPUQueue(entries, true, error_check_callback);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.error_check_callback_);
 }
 
 #if HAVE_MPI
@@ -309,8 +308,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     gpu_op_context_.host_buffer = malloc(total_buffer_len);
 
     // Synchronize.
-    auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
-    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline, error_check_callback);
+    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline, nccl_op_context_.error_check_callback_);
 
     // According to https://docs.nvidia.com/cuda/cuda-runtime-api/
     // api-sync-behavior.html#api-sync-behavior__memcpy-async,
@@ -370,8 +368,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
 
-  auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
-  return gpu_op_context_.FinalizeGPUQueue(entries, true, error_check_callback);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.error_check_callback_);
 }
 
 bool NCCLHierarchicalAllreduce::Enabled(const ParameterManager& param_manager,
@@ -414,8 +411,7 @@ Status NCCLBroadcast::Execute(std::vector<TensorTableEntry>& entries,
     gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);
   }
 
-  auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
-  return gpu_op_context_.FinalizeGPUQueue(entries, true, error_check_callback);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.error_check_callback_);
 }
 
 Status NCCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
@@ -538,8 +534,7 @@ Status NCCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
   delete[] entry_component_sizes;
   delete[] entry_component_offsets;
 
-  auto error_check_callback = std::bind(&NCCLOpContext::AsyncErrorCheck, nccl_op_context_);
-  return gpu_op_context_.FinalizeGPUQueue(entries, true, error_check_callback);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.error_check_callback_);
 }
 
 bool NCCLAllgather::Enabled(const ParameterManager& param_manager,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -92,6 +92,21 @@ void NCCLOpContext::InitNCCLComm(const std::vector<TensorTableEntry>& entries,
   nccl_comm_ = &nccl_comm;
 }
 
+void NCCLOpContext::AsyncErrorCheck() {
+  ncclResult_t nccl_async_err;
+  auto nccl_err = ncclGetAsyncError(nccl_comm_, &nccl_async_err);
+  if (nccl_err != ncclSuccess) {
+    throw std::logic_error("ncclGetAsyncError failed: " + ncclGetErrorString(nccl_err));
+  }
+
+  if (nccl_async_err != ncclSuccess) {
+    ncclCommAbort(nccl_comm_);
+    throw std::logic_error("NCCL async error: " + ncclGetErrorString(nccl_async_err));
+  }
+
+
+}
+
 void NCCLOpContext::PopulateNCCLCommStrategy(int& nccl_rank, int& nccl_size,
                                              Communicator& nccl_id_bcast_comm) {
   if (communicator_type_ == Communicator::GLOBAL) {
@@ -156,7 +171,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
 
-  return gpu_op_context_.FinalizeGPUQueue(entries);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.AsyncErrorCheck);
 }
 
 #if HAVE_MPI
@@ -293,7 +308,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     gpu_op_context_.host_buffer = malloc(total_buffer_len);
 
     // Synchronize.
-    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline);
+    gpu_context_->WaitForEvents(gpu_op_context_.event_queue, entries, timeline, nccl_op_context_.AsyncErrorCheck);
 
     // According to https://docs.nvidia.com/cuda/cuda-runtime-api/
     // api-sync-behavior.html#api-sync-behavior__memcpy-async,
@@ -353,7 +368,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
 
-  return gpu_op_context_.FinalizeGPUQueue(entries);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.AsyncErrorCheck);
 }
 
 bool NCCLHierarchicalAllreduce::Enabled(const ParameterManager& param_manager,
@@ -396,7 +411,7 @@ Status NCCLBroadcast::Execute(std::vector<TensorTableEntry>& entries,
     gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);
   }
 
-  return gpu_op_context_.FinalizeGPUQueue(entries);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.AsyncErrorCheck);
 }
 
 Status NCCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
@@ -519,7 +534,7 @@ Status NCCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
   delete[] entry_component_sizes;
   delete[] entry_component_offsets;
 
-  return gpu_op_context_.FinalizeGPUQueue(entries);
+  return gpu_op_context_.FinalizeGPUQueue(entries, true, nccl_op_context_.AsyncErrorCheck);
 }
 
 bool NCCLAllgather::Enabled(const ParameterManager& param_manager,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -94,13 +94,13 @@ void NCCLOpContext::InitNCCLComm(const std::vector<TensorTableEntry>& entries,
 
 void NCCLOpContext::AsyncErrorCheck() {
   ncclResult_t nccl_async_err;
-  auto nccl_err = ncclCommGetAsyncError(nccl_comm_, &nccl_async_err);
+  auto nccl_err = ncclCommGetAsyncError(*nccl_comm_, &nccl_async_err);
   if (nccl_err != ncclSuccess) {
     throw std::logic_error(std::string("ncclGetAsyncError failed: ") + ncclGetErrorString(nccl_err));
   }
 
   if (nccl_async_err != ncclSuccess) {
-    ncclCommAbort(nccl_comm_);
+    ncclCommAbort(*nccl_comm_);
     throw std::logic_error(std::string("NCCL async error: ") + ncclGetErrorString(nccl_async_err));
   }
 

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -29,6 +29,8 @@
 
 #include "gpu_operations.h"
 
+#include <functional>
+
 namespace horovod {
 namespace common {
 
@@ -58,7 +60,7 @@ public:
   void AsyncErrorCheck();
 
   ncclComm_t* nccl_comm_;
-  std::function<void> error_check_callback_;
+  std::function<void()> error_check_callback_;
 
 private:
   void PopulateNCCLCommStrategy(int& nccl_rank, int& nccl_size,

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -47,6 +47,7 @@ public:
   NCCLOpContext(NCCLContext* nccl_context, HorovodGlobalState* global_state,
                 horovod::common::Communicator communicator_type)
       : nccl_comm_(nullptr),
+        error_check_callback_(std::bind(&NCCLOpContext::AsyncErrorCheck, this)),
         nccl_context_(nccl_context),
         global_state_(global_state),
         communicator_type_(communicator_type){};
@@ -57,6 +58,7 @@ public:
   void AsyncErrorCheck();
 
   ncclComm_t* nccl_comm_;
+  std::function<void> error_check_callback_;
 
 private:
   void PopulateNCCLCommStrategy(int& nccl_rank, int& nccl_size,

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -54,6 +54,8 @@ public:
   void InitNCCLComm(const std::vector<TensorTableEntry>& entries,
                     const std::vector<int32_t>& nccl_device_map);
 
+  void AsyncErrorCheck();
+
   ncclComm_t* nccl_comm_;
 
 private:


### PR DESCRIPTION
Follow-up from a discussion in #1849 regarding handling networking failures (due to removed workers) gracefully in NCCL.

This follows the approach outlined by NVIDIA in https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#asynchronous-errors-and-error-handling.