### PR TITLE
Replaced integral division with explicit floor division for PyTorch

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -130,7 +130,7 @@ RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 # Install PyTorch.
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch==1.6.0.dev20200601+cpu ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -107,7 +107,7 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
 RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-	pip install --pre torch==1.6.0.dev20200601+cu${PYTORCH_CUDA} ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+	pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
     else \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -50,6 +50,16 @@ int GetDeviceID(const ::torch::Tensor& tensor) {
 
 } // namespace
 
+void DivideInPlace(::torch::Tensor& tensor, int divisor) {
+#if TORCH_VERSION >= 1005000000
+  if (isIntegralType(tensor.scalar_type())) {
+    tensor.floor_divide_(divisor);
+    return;
+  }
+#endif
+  tensor.div_(divisor);
+}
+
 int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
                 const std::string& name, int reduce_op_int) {
   ThrowIfError(common::CheckInitialized());
@@ -69,11 +79,7 @@ int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
       [handle, divisor, output](const Status& status) mutable {
         // Will execute in the `device` context.
         if (divisor > 1) {
-          if (isIntegralType(output.scalar_type())) {
-            output.floor_divide_(divisor);
-          } else{
-            output.div_(divisor);
-          }
+          DivideInPlace(output, divisor);
         }
         handle_manager.MarkDone(handle, status);
       }, reduce_op);
@@ -108,11 +114,7 @@ int DoAllreduceCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int div
         with_device device_guard(device);
         output.copy_(cpu_buffer);
         if (divisor > 1) {
-          if (isIntegralType(output.scalar_type())) {
-            output.floor_divide_(divisor);
-          } else{
-            output.div_(divisor);
-          }
+          DivideInPlace(output, divisor);
         }
         handle_manager.MarkDone(handle, status);
       }, reduce_op);

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -69,7 +69,11 @@ int DoAllreduce(::torch::Tensor tensor, ::torch::Tensor output, int divisor,
       [handle, divisor, output](const Status& status) mutable {
         // Will execute in the `device` context.
         if (divisor > 1) {
-          output.div_(divisor);
+          if (isIntegralType(output.scalar_type())) {
+            output.floor_divide_(divisor);
+          } else{
+            output.div_(divisor);
+          }
         }
         handle_manager.MarkDone(handle, status);
       }, reduce_op);
@@ -104,7 +108,11 @@ int DoAllreduceCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output, int div
         with_device device_guard(device);
         output.copy_(cpu_buffer);
         if (divisor > 1) {
-          output.div_(divisor);
+          if (isIntegralType(output.scalar_type())) {
+            output.floor_divide_(divisor);
+          } else{
+            output.div_(divisor);
+          }
         }
         handle_manager.MarkDone(handle, status);
       }, reduce_op);


### PR DESCRIPTION
This change is for compatibility with upcoming PyTorch 1.6.0 release which removes support for `tensor.div_` for integral tensors.  

See: https://github.com/pytorch/pytorch/pull/38620.