### PR TITLE
Revert "Spark 3 has been released, use released version for testing"

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -60,8 +60,8 @@ services:
         PYTORCH_PACKAGE: torch==1.5.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.5.0+cpu
         MXNET_PACKAGE: mxnet==1.5.0
-        PYSPARK_PACKAGE: pyspark==3.0.0
-        SPARK_PACKAGE: spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
+        PYSPARK_PACKAGE: pyspark==3.0.0.dev2
+        SPARK_PACKAGE: spark-3.0.0-preview2/spark-3.0.0-preview2-bin-hadoop2.7.tgz
   test-cpu-openmpi-py3_6-tf1_14_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_4_0:
     extends: test-cpu-base
     build:


### PR DESCRIPTION
Reverts horovod/horovod#2040. The Spark 3.0.0 release breaks `SparkTests.test_get_available_devices`: https://buildkite.com/horovod/horovod/builds/3124#ba8762c7-89f7-40ef-9b4b-240a24893791/209-2539 All workers get the same GPU allocated. Lets fix this separately.

**Alternatively, we can disable that test.** That test might have been fixed by https://github.com/horovod/horovod/pull/2063#issuecomment-650811959. There is ticket [SPARK-32120](https://issues.apache.org/jira/browse/SPARK-32120) to see if that changed behaviour is a bug or a feature.

This blocks #2063 and #1956.