### PR TITLE
Wrap dataset generation function to disable autograph to fix issues with invalid tensor shapes

### DIFF
--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -15,6 +15,8 @@
 
 import io
 
+from distutils.version import LooseVersion
+
 import h5py
 import numpy as np
 import tensorflow as tf
@@ -27,6 +29,8 @@ from horovod.spark.keras import optimizer, remote
 
 BARE_KERAS = 'keras'
 TF_KERAS = 'tf_keras'
+
+_HAS_AUTOGRAPH = LooseVersion(tf.__version__) >= LooseVersion('1.15')
 
 
 class TFKerasUtil(object):
@@ -74,7 +78,7 @@ class TFKerasUtil(object):
 
             dataset = dataset.batch(batch_size).map(prep_data_tf_keras)
             return dataset
-        return fn
+        return tf.autograph.experimental.do_not_convert(fn) if _HAS_AUTOGRAPH else fn
 
     @staticmethod
     def get_horovod():


### PR DESCRIPTION
When the `make_dataset` function is pickled and sent to the remote workers, TensorFlow's Autograph system attempts to convert it into the graph, but in the process changes the behavior, resulting in tensors with invalid shapes being fed to the Keras model.  This PR disables autograph in affected versions of TensorFlow.