### PR TITLE
Include new Horovod tutorial in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,7 @@ See `here <docs/autotune.rst>`__ for full details and usage instructions.
 Guides
 ------
 1. Run distributed training in Microsoft Azure using `Batch AI and Horovod <https://github.com/Azure/BatchAI/tree/master/recipes/Horovod>`_.
+2. `Distributed model training using Horovod <https://spell.ml/blog/distributed-model-training-using-horovod-XvqEGRUAACgAa5th>`_.
 
 Send us links to any user guides you want to publish on this site
 

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -361,6 +361,7 @@ See `here <autotune.rst>`__ for full details and usage instructions.
 Guides
 ------
 1. Run distributed training in Microsoft Azure using `Batch AI and Horovod <https://github.com/Azure/BatchAI/tree/master/recipes/Horovod>`_.
+2. `Distributed model training using Horovod <https://spell.ml/blog/distributed-model-training-using-horovod-XvqEGRUAACgAa5th>`_.
 
 Send us links to any user guides you want to publish on this site
 


### PR DESCRIPTION
Adding [a tutorial on Horovod](https://spell.ml/blog/distributed-model-training-using-horovod-XvqEGRUAACgAa5th) with some benchmarks I wrote to the `Guides` section of the `README`.

We have a native `horovod` integration built into @spellrun, so I went ahead and wrote a tutorial explaining how it works and providing some benchmarks comparing it to `DataParallel` and `DistributedDataParallel` in PyTorch. `horovod` looks very appealing in these:

![image](https://user-images.githubusercontent.com/3466341/86624020-9c7f3680-bf90-11ea-969c-a836d4a346c6.png)

The Horovod `README` mentions open pull requests for user guides, and I think this would can be a good resource for anyone looking to learn how it works, hence this pull request.