### PR TITLE
Remove blocking sync flag from cudaEvents.

### DIFF
--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -42,7 +42,7 @@ public:
       }
     }
 
-    return cudaEventCreateWithFlags(event, cudaEventBlockingSync | cudaEventDisableTiming);
+    return cudaEventCreateWithFlags(event, cudaEventDisableTiming);
   }
 
   cudaError_t ReleaseGpuEvent(cudaEvent_t event) {

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -42,7 +42,7 @@ public:
       }
     }
 
-    return hipEventCreateWithFlags(event, hipEventBlockingSync | hipEventDisableTiming);
+    return hipEventCreateWithFlags(event, hipEventDisableTiming);
   }
 
   hipError_t ReleaseGpuEvent(hipEvent_t event) {


### PR DESCRIPTION

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This removes the `cudaEventBlockingSync` flag when creating `cudaEvent`s in Horovod. Blocking adds additional latency and should not be preferred over the default behavior.

