### PR TITLE
Fix MXNet allgather implementation.

### DIFF
--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -208,8 +208,8 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
   auto output_var = output->var();
   auto cpu_input_var = cpu_input_tensor->var();
   auto cpu_output_var = cpu_output_tensor->var();
-  if (input_var != output_var) {
-    // Not in-place
+  if (op_type == OperationType::ALLGATHER) {
+    // Use out-of-place path for operations that have unknown output size (allgather)
     MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
                       &MX_EXEC_CTX, &cpu_input_var, 1, &cpu_output_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);
@@ -221,7 +221,7 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
     // Make async copy of CPU output tensor to output tensor.
     TensorUtil::AsyncCopyCPUToCuda(cpu_output_tensor.get(), output);
   } else {
-    // In-place
+    // Use in-place otherwise
     MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
                       &MX_EXEC_CTX, nullptr, 0, &cpu_input_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -1,4 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Modifications copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,19 +70,20 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 
   auto on_complete = *static_cast<CallbackOnComplete*>(on_complete_ptr);
   auto ops_param = static_cast<MpiOpsParam*>(param);
-  auto tensor = ops_param->input_tensor.get();
-  auto output = ops_param->output_tensor.get();
+  auto input_tensor = ops_param->input_tensor.get();
+  auto output_tensor = ops_param->output_tensor.get();
+  auto output = ops_param->output;
   auto name = ops_param->op_name;
-  auto device = TensorUtil::GetDevice(tensor);
+  auto device = TensorUtil::GetDevice(input_tensor);
 
-  auto hvd_tensor = std::make_shared<MXTensor>(tensor);
+  auto hvd_tensor = std::make_shared<MXTensor>(input_tensor);
   auto hvd_context = std::make_shared<MXOpContext>(device, output);  
   std::shared_ptr<Tensor> hvd_output = nullptr;  
 
   Status enqueue_result;
   switch (ops_param->op_type) {
     case OperationType::ALLREDUCE:
-      hvd_output = std::make_shared<MXTensor>(output);
+      hvd_output = std::make_shared<MXTensor>(output_tensor);
       enqueue_result = EnqueueTensorAllreduce(
           hvd_context, hvd_tensor, hvd_output, nullptr, name, device,
           [on_complete](const Status& status) {
@@ -97,7 +99,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
       break;
     case OperationType::BROADCAST:
       if (horovod_rank() != ops_param->root_rank) {
-        hvd_output = std::make_shared<MXTensor>(output);
+        hvd_output = std::make_shared<MXTensor>(output_tensor);
       }
 
       enqueue_result = EnqueueTensorBroadcast(
@@ -125,8 +127,9 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   // before MXNet engine process it
   auto input_copy = std::make_shared<NDArray>(*input);
   auto output_copy = std::make_shared<NDArray>(*output);
-  auto ops_param = CreateMpiOpsParam(input_copy, output_copy,
-    nullptr /* cpu_buffer */, op_type, op_name, root_rank);
+  auto ops_param = CreateMpiOpsParam(input_copy, output_copy, output,
+    nullptr /* cpu_input_tensor */, nullptr /* cpu_output_tensor */,
+    op_type, op_name, root_rank);
 
   // Not in-place
   auto input_var = input->var();
@@ -150,9 +153,9 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   auto on_complete = *static_cast<CallbackOnComplete*>(on_complete_ptr);
   auto ops_param = static_cast<MpiOpsParam*>(param);
   auto name = ops_param->op_name;
-  auto hvd_cpu_buffer = std::make_shared<MXTensor>(ops_param->cpu_tensor.get());
+  auto hvd_cpu_buffer = std::make_shared<MXTensor>(ops_param->cpu_input_tensor.get());
   auto hvd_context = std::make_shared<MXOpContext>(
-    CPU_DEVICE_ID, ops_param->cpu_tensor.get());
+    CPU_DEVICE_ID, ops_param->cpu_output_tensor.get());
 
   Status enqueue_result;
   switch (ops_param->op_type) {
@@ -191,22 +194,41 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
 
-  auto cpu_buffer = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
+  auto cpu_input_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
     input->dtype());
-  auto ops_param = CreateMpiOpsParam(nullptr, nullptr, cpu_buffer,
-                                     op_type, op_name, root_rank);
+  auto cpu_output_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
+    input->dtype());
+  auto ops_param = CreateMpiOpsParam(nullptr, nullptr, output, cpu_input_tensor,
+                                     cpu_output_tensor, op_type, op_name, root_rank);
 
   // Make async copy of input tensor to CPU tensor.
-  TensorUtil::AsyncCopyCudaToCPU(input, cpu_buffer.get());
+  TensorUtil::AsyncCopyCudaToCPU(input, cpu_input_tensor.get());
 
-  // In-place
-  auto cpu_tensor_var = cpu_buffer->var();
-  MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
-                    &MX_EXEC_CTX, nullptr, 0, &cpu_tensor_var, 1,
-                    &MX_FUNC_PROP, priority, op_type_name);
+  auto input_var = input->var();
+  auto output_var = output->var();
+  auto cpu_input_var = cpu_input_tensor->var();
+  auto cpu_output_var = cpu_output_tensor->var();
+  if (input_var != output_var) {
+    // Not in-place
+    MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
+                      &MX_EXEC_CTX, &cpu_input_var, 1, &cpu_output_var, 1,
+                      &MX_FUNC_PROP, priority, op_type_name);
 
-  // Make async copy of CPU tensor to output tensor.
-  TensorUtil::AsyncCopyCPUToCuda(cpu_buffer.get(), output);
+    // Since cpu_output_tensor is resized in out-of-place path, need
+    // to wait for operation to complete before copying to GPU output.
+    cpu_output_tensor->WaitToRead();
+
+    // Make async copy of CPU output tensor to output tensor.
+    TensorUtil::AsyncCopyCPUToCuda(cpu_output_tensor.get(), output);
+  } else {
+    // In-place
+    MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
+                      &MX_EXEC_CTX, nullptr, 0, &cpu_input_var, 1,
+                      &MX_FUNC_PROP, priority, op_type_name);
+
+    // Make async copy of CPU input tensor to output tensor.
+    TensorUtil::AsyncCopyCPUToCuda(cpu_input_tensor.get(), output);
+  }
 }
 #endif
 

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -1,4 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Modifications copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,19 +40,25 @@ typedef std::shared_ptr<NDArray> NDArraySharedPtr;
 struct MpiOpsParam {
   NDArraySharedPtr input_tensor;
   NDArraySharedPtr output_tensor;
-  NDArraySharedPtr cpu_tensor;
+  NDArray* output;
+  NDArraySharedPtr cpu_input_tensor;
+  NDArraySharedPtr cpu_output_tensor;
   OperationType op_type;
   std::string op_name;
   int root_rank;
 
   MpiOpsParam(NDArraySharedPtr input_tensor,
               NDArraySharedPtr output_tensor,
-              NDArraySharedPtr cpu_tensor,
+              NDArray* output,
+              NDArraySharedPtr cpu_input_tensor,
+              NDArraySharedPtr cpu_output_tensor,
               const OperationType& op_type, const std::string& op_name,
               int root_rank)
       : input_tensor(input_tensor),
         output_tensor(output_tensor),
-        cpu_tensor(cpu_tensor),
+        output(output),
+        cpu_input_tensor(cpu_input_tensor),
+        cpu_output_tensor(cpu_output_tensor),
         op_type(op_type),
         op_name(op_name),
         root_rank(root_rank) {
@@ -60,12 +67,14 @@ struct MpiOpsParam {
 
 inline MpiOpsParam* CreateMpiOpsParam(NDArraySharedPtr input_tensor,
                                       NDArraySharedPtr output_tensor,
-                                      NDArraySharedPtr cpu_tensor,
+                                      NDArray* output,
+                                      NDArraySharedPtr cpu_input_tensor,
+                                      NDArraySharedPtr cpu_output_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
                                       int root_rank) {
-  return new MpiOpsParam(input_tensor, output_tensor, cpu_tensor,
-    op_type, op_name, root_rank);
+  return new MpiOpsParam(input_tensor, output_tensor, output, cpu_input_tensor,
+    cpu_output_tensor, op_type, op_name, root_rank);
 }
 
 void DeleteMpiOpsParam(void* param) {


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #1409 and fixes #1669.

This PR makes fixes the MXNet allgather implementation. The existing implementation did not correctly handle resizing the output buffer for allgather with issues described in an old unmerged PR #1424 and issue #1669. 

In one scenario, the use of a shallow copied tensor for the output resulted in modifications of the tensor shape not being propagated to the output Python tensor. This is remedied by passing the real output tensor into Horovod to be modified by the allgather op (and adding sync to ensure that the output tensor is not returned until the operation that modifies this tensor completes).

In the path where the allgather operation is completed on the CPU with input and output GPU tensors, the implementation erroneously uses an in-place operation, but the temporary CPU input tensor cannot be correctly sized to support this. This is fixed by using an out-of-place operation with a second temporary CPU output buffer. For similar reasoning in the first case, a sync is added before the data is copied from the CPU output buffer to the GPU output buffer to ensure the Horovod operation that modifies the CPU output buffer completes.  


