### PR TITLE
Fix TF allgather tests

### DIFF
--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -510,11 +510,11 @@ class TensorFlowTests(tf.test.TestCase):
                   tf.float64, tf.bool]
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
+            tensor = tf.ones([17] * dim) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/cpu:0"):
-                tensor = tf.ones([17] * dim) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             gathered_tensor = self.evaluate(gathered)
@@ -557,11 +557,11 @@ class TensorFlowTests(tf.test.TestCase):
                   tf.float64, tf.bool]
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
+            tensor = tf.ones([17] * dim) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/gpu:%d" % local_rank):
-                tensor = tf.ones([17] * dim) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             gathered_tensor = self.evaluate(gathered)
@@ -598,11 +598,11 @@ class TensorFlowTests(tf.test.TestCase):
         tests = []
         shape_tests = []
         for dtype, dim in itertools.product(dtypes, dims):
+            tensor = tf.ones([17] * dim) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/cpu:0"):
-                tensor = tf.ones([17] * dim) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             shape_tests.append(
@@ -656,11 +656,11 @@ class TensorFlowTests(tf.test.TestCase):
         tests = []
         shape_tests = []
         for dtype, dim in itertools.product(dtypes, dims):
+            tensor = tf.ones([17] * dim) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/gpu:%d" % local_rank):
-                tensor = tf.ones([17] * dim) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             shape_tests.append(
@@ -714,11 +714,11 @@ class TensorFlowTests(tf.test.TestCase):
             tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
             tensor_sizes = tensor_sizes[:size]
 
+            tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/cpu:0"):
-                tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
             shape_tests.append(
                 tf.reduce_all(tf.equal(tf.shape(gathered),
@@ -777,11 +777,11 @@ class TensorFlowTests(tf.test.TestCase):
             tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
             tensor_sizes = tensor_sizes[:size]
 
+            tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/gpu:%d" % local_rank):
-                tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
             shape_tests.append(
                 tf.reduce_all(tf.equal(tf.shape(gathered),
@@ -836,11 +836,11 @@ class TensorFlowTests(tf.test.TestCase):
             tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
             tensor_sizes = tensor_sizes[:size]
 
+            tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/gpu:%d" % local_rank):
-                tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             gathered_tensor = self.evaluate(gathered)
@@ -884,11 +884,11 @@ class TensorFlowTests(tf.test.TestCase):
             tensor_sizes = [17, 32, 81, 12, 15, 23, 22] * 5
             tensor_sizes = tensor_sizes[:size]
 
+            tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
+            if dtype == tf.bool:
+                tensor = tensor % 2
+            tensor = tf.cast(tensor, dtype=dtype)
             with tf.device("/cpu:0"):
-                tensor = tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
-                if dtype == tf.bool:
-                    tensor = tensor % 2
-                tensor = tf.cast(tensor, dtype=dtype)
                 gathered = hvd.allgather(tensor)
 
             gathered_tensor = self.evaluate(gathered)

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -753,6 +753,10 @@ class TensorFlowTests(tf.test.TestCase):
         """Test that the allgather correctly gathers 1D, 2D, 3D tensors with
         Tensor Fusion, even if those tensors have different sizes along the
         first dim."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
         hvd.init()
         rank = hvd.rank()
         local_rank = hvd.rank()
@@ -811,6 +815,10 @@ class TensorFlowTests(tf.test.TestCase):
     def test_horovod_allgather_variable_size_gpu(self):
         """Test that the allgather correctly gathers 1D, 2D, 3D tensors,
         even if those tensors have different sizes along the first dim."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
         hvd.init()
         rank = hvd.rank()
         local_rank = hvd.rank()


### PR DESCRIPTION
When testing Horovod in the 20.06 NGC TensorFlow container with `HOROVOD_GPU_ALLGATHER=NCCL`, I found that some of the allgather tests were failing due to not properly setting devices. Not sure why the Horovod CI testing does not catch these issues. This PR fixes issues I encountered by splitting the problematic tests into `_cpu` and `_gpu` variants (see `test_horovod_allgather_variable_size_*` tests), or fixing the scope of the with device statement in existing tests (see `test_horovod_allgather_grad_*` tests).