### PR TITLE
Properly forward reduce_op attribute to TF allreduce gradient implementation

### DIFF
--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -114,7 +114,8 @@ def _allreduce_grad(op, grad):
     Returns:
       The gradient with respect to the input of the op.
     """
-    return _allreduce(grad)
+    reduce_op = op.get_attr('reduce_op')
+    return _allreduce(grad, op=reduce_op)
 
 
 def allgather(tensor, name=None):

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -187,6 +187,33 @@ class TensorFlowTests(tf.test.TestCase):
             diff = self.evaluate(max_difference)
             self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
 
+    def test_horovod_allreduce_average_cpu(self):
+        """Test on CPU that the allreduce correctly sums 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                tensor = self.random_uniform(
+                    [17] * dim, -100, 100, dtype=dtype)
+                averaged = hvd.allreduce(tensor, average=True)
+            max_difference = tf.reduce_max(tf.abs(tf.cast(averaged, dtype=dtype) - tensor))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
+
     def test_horovod_allreduce_cpu_fused(self):
         """Test on CPU that the allreduce correctly sums 1D, 2D, 3D tensors
         with Tensor Fusion."""
@@ -242,6 +269,43 @@ class TensorFlowTests(tf.test.TestCase):
                 summed = hvd.allreduce(tensor, average=False)
             multiplied = tensor * size
             max_difference = tf.reduce_max(tf.abs(summed - multiplied))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce on GPU produces incorrect results")
+
+    def test_horovod_allreduce_average_gpu(self):
+        """Test that the allreduce with average works on GPUs."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        dtypes = [tf.int32, tf.int64, tf.float16, tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % local_rank):
+                tensor = self.random_uniform(
+                    [17] * dim, -100, 100, dtype=dtype)
+                averaged = hvd.allreduce(tensor, average=True)
+            max_difference = tf.reduce_max(tf.abs(tf.cast(averaged, dtype=dtype) - tensor))
 
             # Threshold for floating point equality depends on number of
             # ranks, since we're comparing against precise multiplication.
@@ -457,6 +521,40 @@ class TensorFlowTests(tf.test.TestCase):
                             "gradient %s differs from expected %s, "
                             "error: %s" % (grad_out, expected, str(err)))
 
+    def test_horovod_allreduce_average_grad_cpu(self):
+        """Test the correctness of the allreduce with average gradient on CPU."""
+        hvd.init()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(self.random_uniform(
+                        [5] * dim, -100, 100, dtype=dtype))
+                    with tf.GradientTape() as tape:
+                        averaged = hvd.allreduce(tensor, average=True)
+                else:
+                    tensor = self.random_uniform(
+                        [5] * dim, -100, 100, dtype=dtype)
+                    averaged = hvd.allreduce(tensor, average=True)
+
+                grad_ys = tf.ones([5] * dim, dtype=dtype)
+                if _executing_eagerly():
+                    grad_out = tape.gradient(averaged, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(averaged, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones([5] * dim)
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
     def test_horovod_allreduce_grad_gpu(self):
         """Test the correctness of the allreduce gradient on GPU."""
         # Only do this test if there are GPUs available.
@@ -494,6 +592,48 @@ class TensorFlowTests(tf.test.TestCase):
                     grad_out = self.evaluate(grad)
 
             expected = np.ones([5] * dim) * size
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_allreduce_average_grad_gpu(self):
+        """Test the correctness of the allreduce with average gradient on GPU."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % local_rank):
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(
+                        self.random_uniform([5] * dim, -100, 100, dtype=dtype))
+                    with tf.GradientTape() as tape:
+                        averaged = hvd.allreduce(tensor, average=True)
+                else:
+                    tensor = self.random_uniform([5] * dim, -100, 100, dtype=dtype)
+                    averaged = hvd.allreduce(tensor, average=True)
+
+                grad_ys = tf.ones([5] * dim, dtype=dtype)
+                if _executing_eagerly():
+                    grad_out = tape.gradient(averaged, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(averaged, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones([5] * dim)
             err = np.linalg.norm(expected - grad_out)
             self.assertLess(err, 0.00000001,
                             "gradient %s differs from expected %s, "


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
I noticed that the implementation of the allreduce gradient in TF was not forwarding the reduction op type. This is the existing TF grad function:
https://github.com/horovod/horovod/blob/2157e4034ed4f603da2b7a78ef0505090d92016b/horovod/tensorflow/mpi_ops.py#L107-L117
compared to that in PyTorch where `op` is correctly passed in the allreduce for the gradient:
https://github.com/horovod/horovod/blob/2157e4034ed4f603da2b7a78ef0505090d92016b/horovod/torch/mpi_ops.py#L155-L156

This PR adds the proper forwarding of the reduction op in the allreduce gradient, and also adds tests for the allreduce gradient with averaging, using the `test_horovod_allreduce_grad_average` that already exists in `test_torch.py` as a template. I also added tests for allreduce with average in general for TF since those were missing.

It should be noted that for the allreduce with average case at least, the current gradient implementation was fine since the actual division for average happens outside of the `HorovodAllreduce` custom op here: https://github.com/horovod/horovod/blob/master/horovod/tensorflow/__init__.py#L130
and in fact, the new tests for `allreduce_average_grad` passed before the modifications were made to forward the reduction op. However, the existing implementation is broken for `op=Adasum` and would be broken after changes from #1949 where the division for averaging is moved into the framework backend (i.e. within the `HorovodAllreduce` custom op).