### PR TITLE
Fixed allgather gradient for cases where the tensor shape is not known during graph construction

### DIFF
--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -152,8 +152,8 @@ def _allgather_grad(op, grad):
     with tf.device('/cpu:0'):
         # Keep the tensor of split sizes on CPU.
         x = op.inputs[0]
-        d0 = x.get_shape().as_list()[0]
-        d = tf.convert_to_tensor([d0], dtype=tf.int32)
+        d = tf.shape(x)
+        d = tf.reshape(d[0], [1])
 
         s = size()
         d = tf.reshape(allgather(d), [s])


### PR DESCRIPTION
In TensorFlow 2, when wrapping an `allgather` call with `tf.function`, the shape of the input tensor may not be known (e.g., `(None, 128)`), in which case the existing gradient computation will fail when it attempts to calculate the size of the first dimension, which is `None`.  This PR changes this behavior to use graph-compatible ops that can be evaluated lazily.

Fixes #2110.

