### PR TITLE
Add broadcast_object function for MXNet.

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -18,6 +18,7 @@ from horovod.common.util import check_extension
 check_extension('horovod.mxnet', 'HOROVOD_WITH_MXNET',
                 __file__, 'mpi_lib')
 
+from horovod.mxnet.functions import broadcast_object
 from horovod.mxnet.mpi_ops import allgather
 from horovod.mxnet.mpi_ops import allreduce, allreduce_
 from horovod.mxnet.mpi_ops import broadcast, broadcast_

--- a/horovod/mxnet/functions.py
+++ b/horovod/mxnet/functions.py
@@ -1,0 +1,60 @@
+
+# Copyright 2020 Uber Technologies, Inc. All Rights Reserved.
+# Modifications copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import io
+
+import cloudpickle
+import mxnet as mx
+
+from horovod.mxnet.mpi_ops import broadcast_
+from horovod.mxnet.mpi_ops import rank
+
+def broadcast_object(obj, root_rank=0, name=None):
+    """
+    Serializes and broadcasts an object from root rank to all other processes.
+
+    Arguments:
+        obj: An object capable of being serialized without losing any context.
+        root_rank: The rank of the process from which parameters will be
+                   broadcasted to all other processes.
+        name: Optional name to use during broadcast, will default to the class
+              type.
+    Returns:
+        The object that was broadcast from the `root_rank`.
+    """
+    if name is None:
+        name = type(obj).__name__
+
+    if rank() == root_rank:
+        b = io.BytesIO()
+        cloudpickle.dump(obj, b)
+        t = mx.nd.array(bytearray(b.getvalue()), dtype='byte')
+        sz = mx.nd.array([t.size], dtype='int')
+
+        broadcast_(sz, root_rank, name + '.sz')
+    else:
+        sz = mx.nd.empty(shape=[1], dtype='int')
+        broadcast_(sz, root_rank, name + '.sz')
+        t = mx.nd.empty(shape=[sz.asscalar()], dtype='byte')
+
+    broadcast_(t, root_rank, name + '.t')
+
+    if rank() != root_rank:
+        buf = io.BytesIO(t.asnumpy().tobytes())
+        obj = cloudpickle.load(buf)
+
+    return obj

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -587,6 +587,21 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
+    def test_broadcast_object(self):
+        hvd.init()
+
+        expected_obj = {
+            'hello': 123,
+            0: [1, 2]
+        }
+        obj = expected_obj if hvd.rank() == 0 else {}
+
+        obj = hvd.broadcast_object(obj, root_rank=0)
+        self.assertDictEqual(obj, expected_obj)
+
+        # To prevent premature shutdown from rank 0 for this test
+        mx.nd.waitall()
+
     @unittest.skipUnless(has_gpu, "no gpu detected")
     def test_gluon_trainer(self):
         """Test using horovod allreduce in MXNet Gluon trainer."""


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Recently, `broadcast_object` functions were added for TensorFlow and PyTorch to enable broadcasting Python objects using Horovod. This PR adds a `broadcast_object` implementation for MXNet, based on the existing PyTorch implementation.
