### PR TITLE
Added ability to dynamically start and stop timeline programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added ability to dynamically start and stop timeline programmatically. ([#2129](https://github.com/horovod/horovod/pull/2129))
+
 ### Changed
 
 ### Deprecated

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -72,6 +72,31 @@ class HorovodBasics(object):
         """Returns True if Horovod is initialized"""
         return self.MPI_LIB_CTYPES.horovod_is_initialized()
 
+    def start_timeline(self, file_path, mark_cycles=False):
+        """Creates a timeline file at `file_path` and begins recording.
+
+        Args:
+            file_path: String path to the timeline file.
+            mark_cycles: Boolean indicating that cycles should be marked on
+                         the timeline (default: False).
+
+        Raises a `ValueError` if Horovod is not initialized.
+        """
+        result = self.MPI_LIB_CTYPES.horovod_start_timeline(
+            ctypes.c_char_p(file_path.encode('utf-8')),
+            ctypes.c_bool(mark_cycles))
+        if not result:
+            raise ValueError('Horovod has not been initialized; use hvd.init().')
+
+    def stop_timeline(self):
+        """Stops the active timeline recording and closes the file.
+
+        Raises a `ValueError` if Horovod is not initialized.
+        """
+        result = self.MPI_LIB_CTYPES.horovod_stop_timeline()
+        if not result:
+            raise ValueError('Horovod has not been initialized; use hvd.init().')
+
     def size(self):
         """A function that returns the number of Horovod processes.
 

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -17,6 +17,7 @@
 #ifndef HOROVOD_GLOBAL_STATE_H
 #define HOROVOD_GLOBAL_STATE_H
 
+#include <mutex>
 #include <queue>
 #include <thread>
 
@@ -49,6 +50,9 @@ struct HorovodGlobalState {
 
   // Whether the background thread should shutdown.
   std::atomic_bool shut_down{false};
+
+  // Mutex over a single cycle
+  std::recursive_mutex cycle_mutex_;
 
   // Timeline writer.
   Timeline timeline;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -723,6 +723,8 @@ bool horovod_stop_timeline() {
     return false;
   }
 
+  horovod_global.controller->SetTimelineEnabled(false);
+
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Shutdown();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -709,7 +709,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
     return false;
   }
 
-  std::lock_guard<std::recursive_mutex> guard(state.cycle_mutex_);
+  std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
@@ -725,7 +725,7 @@ bool horovod_stop_timeline() {
     return false;
   }
 
-  std::lock_guard<std::recursive_mutex> guard(state.cycle_mutex_);
+  std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
   horovod_global.controller->SetTimelineEnabled(false);
 
   bool is_coordinator = horovod_global.controller->IsCoordinator();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -703,6 +703,23 @@ bool horovod_is_initialized() {
   return horovod_global.initialization_done;
 }
 
+bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
+  if (!horovod_global.initialization_done) {
+    return false;
+  }
+  horovod_global.mark_cycles_in_timeline = mark_cycles;
+  horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  return true;
+}
+
+bool horovod_stop_timeline() {
+  if (!horovod_global.initialization_done) {
+    return false;
+  }
+  horovod_global.timeline.Shutdown();
+  return true;
+}
+
 int horovod_rank() {
   if (!horovod_global.initialization_done) {
     return -1;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -575,6 +575,7 @@ bool RunLoopOnce(HorovodGlobalState& state) {
   }
   state.last_cycle_start = std::chrono::steady_clock::now();
 
+  std::lock_guard<std::recursive_mutex> guard(state.cycle_mutex_);
   if (state.mark_cycles_in_timeline) {
     // Mark start of the new cycle.
     state.timeline.MarkCycleStart();
@@ -708,6 +709,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
     return false;
   }
 
+  std::lock_guard<std::recursive_mutex> guard(state.cycle_mutex_);
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
@@ -723,6 +725,7 @@ bool horovod_stop_timeline() {
     return false;
   }
 
+  std::lock_guard<std::recursive_mutex> guard(state.cycle_mutex_);
   horovod_global.controller->SetTimelineEnabled(false);
 
   bool is_coordinator = horovod_global.controller->IsCoordinator();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -710,6 +710,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   }
 
   std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
+  horovod_global.controller->Barrier(Communicator::GLOBAL);
   horovod_global.response_cache.clear();
 
   bool is_coordinator = horovod_global.controller->IsCoordinator();
@@ -728,6 +729,7 @@ bool horovod_stop_timeline() {
   }
 
   std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
+  horovod_global.controller->Barrier(Communicator::GLOBAL);
   horovod_global.response_cache.clear();
 
   horovod_global.controller->SetTimelineEnabled(false);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -710,6 +710,8 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   }
 
   std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
+  horovod_global.response_cache.clear();
+
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
@@ -726,6 +728,8 @@ bool horovod_stop_timeline() {
   }
 
   std::lock_guard<std::recursive_mutex> guard(horovod_global.cycle_mutex_);
+  horovod_global.response_cache.clear();
+
   horovod_global.controller->SetTimelineEnabled(false);
 
   bool is_coordinator = horovod_global.controller->IsCoordinator();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -707,8 +707,14 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   if (!horovod_global.initialization_done) {
     return false;
   }
+
+  bool is_coordinator = horovod_global.controller->IsCoordinator();
+  if (is_coordinator) {
+    horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  }
+
   horovod_global.mark_cycles_in_timeline = mark_cycles;
-  horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  horovod_global.controller->SetTimelineEnabled(true);
   return true;
 }
 
@@ -716,7 +722,12 @@ bool horovod_stop_timeline() {
   if (!horovod_global.initialization_done) {
     return false;
   }
-  horovod_global.timeline.Shutdown();
+
+  bool is_coordinator = horovod_global.controller->IsCoordinator();
+  if (is_coordinator) {
+    horovod_global.timeline.Shutdown();
+  }
+
   return true;
 }
 

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -171,8 +171,10 @@ void Timeline::Initialize(std::string file_name, unsigned int horovod_size) {
 }
 
 void Timeline::Shutdown() {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
   initialized_ = false;
   writer_.Shutdown();
+  tensor_states_.clear();
 }
 
 long Timeline::TimeSinceStartMicros() const {

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -44,6 +44,7 @@ void TimelineWriter::Shutdown() {
   active_ = false;
   writer_thread_.join();
   file_.close();
+  tensor_table_.clear();
 }
 
 void TimelineWriter::EnqueueWriteEvent(const std::string& tensor_name,

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -19,6 +19,7 @@ import keras.backend as K
 from horovod.tensorflow import init
 from horovod.tensorflow import shutdown
 from horovod.tensorflow import size
+from horovod.tensorflow import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow import local_size
 from horovod.tensorflow import rank
 from horovod.tensorflow import local_rank

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -24,6 +24,7 @@ from horovod.mxnet.mpi_ops import allreduce, allreduce_
 from horovod.mxnet.mpi_ops import alltoall
 from horovod.mxnet.mpi_ops import broadcast, broadcast_
 from horovod.mxnet.mpi_ops import init, shutdown
+from horovod.mxnet.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.mxnet.mpi_ops import size, local_size, rank, local_rank
 from horovod.mxnet.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.mxnet.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -28,6 +28,9 @@ _basics = _HorovodBasics(__file__, 'mpi_lib')
 # import basic methods
 init = _basics.init
 shutdown = _basics.shutdown
+is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -28,6 +28,7 @@ from horovod.tensorflow.compression import Compression
 from horovod.tensorflow.functions import allgather_object, broadcast_object, broadcast_object_fn, broadcast_variables
 from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce, alltoall
 from horovod.tensorflow.mpi_ops import init, shutdown
+from horovod.tensorflow.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank, is_homogeneous
 from horovod.tensorflow.mpi_ops import rank_op, local_rank_op, size_op, local_size_op
 from horovod.tensorflow.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -22,6 +22,7 @@ from tensorflow.python.keras import backend as K
 
 from horovod.tensorflow import init
 from horovod.tensorflow import shutdown
+from horovod.tensorflow import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow import size
 from horovod.tensorflow import local_size
 from horovod.tensorflow import rank

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -50,6 +50,9 @@ _basics = _HorovodBasics(__file__, 'mpi_lib')
 # import basic methods
 init = _basics.init
 shutdown = _basics.shutdown
+is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -32,7 +32,8 @@ from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadc
 from horovod.torch.mpi_ops import alltoall, alltoall_async
 from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
-from horovod.torch.mpi_ops import init, shutdown, is_initialized, start_timeline, stop_timeline
+from horovod.torch.mpi_ops import init, shutdown
+from horovod.torch.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank
 from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -32,7 +32,7 @@ from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadc
 from horovod.torch.mpi_ops import alltoall, alltoall_async
 from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
-from horovod.torch.mpi_ops import init, shutdown, is_initialized
+from horovod.torch.mpi_ops import init, shutdown, is_initialized, start_timeline, stop_timeline
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank
 from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -33,6 +33,8 @@ from horovod.torch.compression import Compression
 # import basic methods
 init = _basics.init
 is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -42,7 +42,7 @@ class TimelineTests(unittest.TestCase):
                 hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
 
                 # Wait for it to register in the timeline.
-                time.sleep(0.1)
+                hvd.stop_timeline()
 
                 if hvd.rank() == 0:
                     with open(t, 'r') as tf:

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
 import torch
 import unittest
 import warnings


### PR DESCRIPTION
This PR introduces a new Python API for starting and stopping the timeline:

```
hvd.start_timeline('/path/to/timeline.json', mark_cycles=True)
...
hvd.stop_timeline()
```

The user may still choose to start the timeline via the command line and then use `hvd.stop_timeline()` to stop it programmatically after some number of steps.

Fixes #2008.