### PR TITLE
Set multiple affinity in one variable HOROVOD_THREAD_AFFINITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Moved `horovod.run.runner.run` to `horovod.run`. ([#2099](https://github.com/horovod/horovod/pull/2099))
 
+- HOROVOD_THREAD_AFFINITY accepts multiple values, one for every Horovod rank ([#2131](https://github.com/horovod/horovod/pull/2131))
+
 ### Deprecated
+
+- HOROVOD_CCL_BGT_AFFINITY is deprected. Use HOROVOD_THREAD_AFFINITY instead ([#2131](https://github.com/horovod/horovod/pull/2131))
 
 ### Removed
 

--- a/docs/oneccl.md
+++ b/docs/oneccl.md
@@ -59,12 +59,15 @@ workers available.
 
 Set oneCCL workers affinity:
 ```bash
-$ export CCL_WORKER_AFFINITY=c0,c1,..,cX
+$ export CCL_WORKER_AFFINITY=c0,c1,..,c(X-1)
 ```
-where c0,c1,..,cX are core IDs dedicated to oneCCL workers (uses X 'last' cores by default). This variable sets affinity for all
+where c0,c1,..,c(X-1) are core IDs dedicated to oneCCL workers (uses X 'last' cores by default). This variable sets affinity for all
 oneCCL workers (CCL_WORKER_COUNT * Number of ranks per node) that are available for all the ranks running on one node.
 
-For instance, we have 2 nodes and each node has 2 sockets: socket0 CPUs:0-17,36-53 and socket1 CPUs:18-35,54-71
+For instance, we have 2 nodes and each node has 2 sockets: socket0 CPUs:0-17,36-53 and socket1 CPUs:18-35,54-71. We decide to pin CCL
+workers to the last two cores of each socket while pinning Horovod background thread to one of the hyper-thread cores of CCL workers's
+cores. All these cores are excluded from Intel MPI pinning using I_MPI_PIN_PROCESSOR_EXCLUDE_LIST to dedicate them to CCL and Horovod
+tasks only, thus avoiding the conflict with framework's computational threads. 
 ```bash
 $ export I_MPI_PIN_PROCESSOR_EXCLUDE_LIST="16,17,34,35,52,53,70,71"
 $ export I_MPI_PIN_DOMAIN=socket

--- a/docs/oneccl.md
+++ b/docs/oneccl.md
@@ -40,25 +40,36 @@ or via pip
 $ pip install horovod
 ```
 
-**Advanced:** You can specify the affinity for BackgroundThread with the HOROVOD_CCL_BGT_AFFINITY environment variable.
+**Advanced:** You can specify the affinity for BackgroundThread with the HOROVOD_THREAD_AFFINITY environment variable.
 See the instructions below.
 
-Set Horovod background thread affinity:
+Set Horovod background thread affinity according to the rule. If there is N Horovod ranks per node, this variable should
+contain all the values for every rank using comma as a separator:
 ```bash
-$ export HOROVOD_CCL_BGT_AFFINITY=c0
+$ export HOROVOD_THREAD_AFFINITY=c0,c1,...,c(N-1)
 ```
-where c0 is a core ID to attach background thread to.
+where c0,...,c(N-1) are core IDs to attach background thread to.
 
 Set the number of oneCCL workers:
 ```bash
 $ export CCL_WORKER_COUNT=X
 ```
-where X is the number of threads you’d like to dedicate for driving communication. This means that for every rank there are X oneCCL
+where X is the number of threads you'd like to dedicate for driving communication. This means that for every rank there are X oneCCL
 workers available.
 
 Set oneCCL workers affinity:
 ```bash
-$ export CCL_WORKER_AFFINITY=c1,c2,..,cX
+$ export CCL_WORKER_AFFINITY=c0,c1,..,cX
 ```
-where c1,c2,..,cX are core IDs dedicated to oneCCL workers (uses X ‘last’ cores by default). This variable sets affinity for all
+where c0,c1,..,cX are core IDs dedicated to oneCCL workers (uses X 'last' cores by default). This variable sets affinity for all
 oneCCL workers (CCL_WORKER_COUNT * Number of ranks per node) that are available for all the ranks running on one node.
+
+For instance, we have 2 nodes and each node has 2 sockets: socket0 CPUs:0-17,36-53 and socket1 CPUs:18-35,54-71
+```bash
+$ export I_MPI_PIN_PROCESSOR_EXCLUDE_LIST="16,17,34,35,52,53,70,71"
+$ export I_MPI_PIN_DOMAIN=socket
+$ export HOROVOD_THREAD_AFFINITY="53,71"
+$ export CCL_WORKER_COUNT=2
+$ export CCL_WORKER_AFFINITY="16,17,34,35"
+$ mpirun -n 4 -ppn 2 -hostfile hosts python ./run_example.py
+```

--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -183,8 +183,7 @@ void parse_and_set_affinity(const char* affinity, int local_size, int local_rank
                  << core_id << " in "
                  << HOROVOD_THREAD_AFFINITY << "=" << affinity;
       break;
-    }
-    else {
+    } else {
       core_ids[count] = core_id;
       count++;
     }
@@ -193,8 +192,7 @@ void parse_and_set_affinity(const char* affinity, int local_size, int local_rank
   if (count < local_size) {
     LOG(ERROR) << "Expected " << local_size << " core ids but got " << count << ". "
                << HOROVOD_THREAD_AFFINITY << "=" << affinity;
-  }
-  else {
+  } else {
     set_affinity(core_ids[local_rank]);
   }
 

--- a/horovod/common/common.cc
+++ b/horovod/common/common.cc
@@ -19,6 +19,8 @@
 
 #include <sstream>
 #include <cassert>
+#include <cstring>
+#include <limits.h>
 
 namespace horovod {
 namespace common {
@@ -114,7 +116,7 @@ int64_t TensorShape::num_elements() const {
 const std::vector<int64_t>& TensorShape::to_vector() const { return shape_; }
 
 #ifdef __linux__
-void server_affinity_set(int affinity) {
+void set_affinity(int affinity) {
   cpu_set_t cpuset;
   pthread_t current_thread = pthread_self();
 
@@ -137,11 +139,67 @@ void server_affinity_set(int affinity) {
   }
 }
 #else
-void server_affinity_set(int affinity) {
+void set_affinity(int affinity) {
   // TODO(travis): explore equivalent for macOS
   throw std::runtime_error("Environment variable HOROVOD_THREAD_AFFINITY is not supported on macOS.");
 }
 #endif
+
+void parse_and_set_affinity(const char* affinity, int local_size, int local_rank) {
+  if (affinity == nullptr) {
+    return;
+  }
+
+  size_t affinity_len = strlen(affinity);
+
+  // copy is needed because strsep is going to modify the buffer
+  char* affinity_copy = (char*)calloc(affinity_len + 1, sizeof(char));
+  memcpy(affinity_copy, affinity, affinity_len);
+  char* tmp = affinity_copy;
+  char *endptr;
+
+  std::vector<int> core_ids(local_size);
+  int count = 0;
+
+  while (*tmp != 0 && count < local_size) {
+    auto core_id_str = strsep(&tmp, ",");
+    errno = 0;
+    auto core_id = std::strtol(core_id_str, &endptr, 10);
+    if (errno == ERANGE && (core_id == LONG_MAX || core_id == LONG_MIN)
+        || (errno != 0 && core_id == 0)){
+        LOG(ERROR) << "Core ID value is invalid in " << HOROVOD_THREAD_AFFINITY
+                   << "=" << affinity;
+        break;
+    }
+
+    if (endptr == core_id_str) {
+        LOG(ERROR) << "No digits were found in " << HOROVOD_THREAD_AFFINITY
+                   << "=" << affinity;
+        break;
+    }
+    
+    if (core_id < 0) {
+      LOG(ERROR) << "Core ID cannot be less than zero but got "
+                 << core_id << " in "
+                 << HOROVOD_THREAD_AFFINITY << "=" << affinity;
+      break;
+    }
+    else {
+      core_ids[count] = core_id;
+      count++;
+    }
+  }
+    
+  if (count < local_size) {
+    LOG(ERROR) << "Expected " << local_size << " core ids but got " << count << ". "
+               << HOROVOD_THREAD_AFFINITY << "=" << affinity;
+  }
+  else {
+    set_affinity(core_ids[local_rank]);
+  }
+
+  free(affinity_copy);
+}
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -76,7 +76,6 @@ namespace common {
 #define HOROVOD_HIERARCHICAL_ALLREDUCE "HOROVOD_HIERARCHICAL_ALLREDUCE"
 #define HOROVOD_HIERARCHICAL_ALLGATHER "HOROVOD_HIERARCHICAL_ALLGATHER"
 #define HOROVOD_CACHE_CAPACITY "HOROVOD_CACHE_CAPACITY"
-#define HOROVOD_CCL_BGT_AFFINITY "HOROVOD_CCL_BGT_AFFINITY"
 #define HOROVOD_NUM_NCCL_STREAMS "HOROVOD_NUM_NCCL_STREAMS"
 #define HOROVOD_CPU_OPERATIONS "HOROVOD_CPU_OPERATIONS"
 #define HOROVOD_CONTROLLER "HOROVOD_CONTROLLER"
@@ -251,7 +250,8 @@ struct TensorTableEntry {
 using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
 
 // Set affinity function
-void server_affinity_set(int affinity);
+void set_affinity(int affinity);
+void parse_and_set_affinity(const char* affinity, int local_size, int local_rank);
 
 } // namespace common
 } // namespace horovod


### PR DESCRIPTION
Signed-off-by: Yana Shchyokotova <yana.shchyokotova@intel.com>

Now HOROVOD_THREAD_AFFINITY accepts several values, one for every local Horovod rank to make the pinning easier to set for multi-socket systems.

In case parse function detects some errors, the pinning is skipped.