### PR TITLE
Add alltoall support for TensorFlow, PyTorch, and MXNet.

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -191,12 +191,14 @@ class HorovodBasics(object):
         return bool(self.MPI_LIB_CTYPES.horovod_gloo_built())
 
     def nccl_built(self):
-        """Returns True if Horovod was compiled with NCCL support.
+        """Function to check if Horovod was compiled with NCCL support.
 
         Returns:
-          A boolean value indicating whether NCCL support was compiled.
+          An integer value indicating whether NCCL support was compiled.
+          If NCCL support was compiled, returns NCCL_VERSION_CODE. Otherwise,
+          returns 0.
         """
-        return bool(self.MPI_LIB_CTYPES.horovod_nccl_built())
+        return int(self.MPI_LIB_CTYPES.horovod_nccl_built())
 
     def ddl_built(self):
         """Returns True if Horovod was compiled with DDL support.

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -1,5 +1,6 @@
 // Copyright 2018 Uber Technologies, Inc. All Rights Reserved.
 // Modifications copyright (C) 2019 Intel Corporation
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,10 +46,12 @@ namespace common {
 #define NCCL_ALLREDUCE "NCCL_ALLREDUCE"
 #define MEMCPY_OUT_FUSION_BUFFER "MEMCPY_OUT_FUSION_BUFFER"
 #define MPI_BCAST "MPI_BCAST"
+#define MPI_ALLTOALL "MPI_ALLTOALL"
 #define NCCL_REDUCESCATTER "NCCL_REDUCESCATTER"
 #define NCCL_ALLGATHER "NCCL_ALLGATHER"
 #define NCCL_REDUCE "NCCL_REDUCE"
 #define NCCL_BCAST "NCCL_BCAST"
+#define NCCL_ALLTOALL "NCCL_ALLTOALL"
 #define COPY_ALLGATHER_OUTPUT "COPY_ALLGATHER_OUTPUT"
 #define ALLOCATE_SHARED_BUFFER "ALLOCATE_SHARED_BUFFER"
 #define CCL_ALLREDUCE "CCL_ALLREDUCE"
@@ -246,6 +249,12 @@ struct TensorTableEntry {
   int device = CPU_DEVICE_ID;
   // A callback to call with the status.
   StatusCallback callback;
+
+  // Alltoall splits (if tensor is for an Alltoall operation)
+  // Note: splits are stored in TensorTableEntry to avoid N^2
+  // storage complexity of collecting all worker split arrays
+  // on coordinator rank.
+  std::vector<int32_t> splits;
 };
 using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -1,4 +1,5 @@
 // Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,9 +50,11 @@ public:
   virtual void CrossRankBitwiseOr(std::vector<long long>& bitvector,
                                   int count) = 0;
 
-
   virtual void Bcast(void* buffer, size_t size, int root_rank, Communicator
   communicator) = 0;
+
+  virtual void AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
+                                     std::vector<int32_t>& recvsplits) = 0;
 
   virtual void Barrier(Communicator communicator) = 0;
 

--- a/horovod/common/gloo/gloo_controller.cc
+++ b/horovod/common/gloo/gloo_controller.cc
@@ -266,6 +266,13 @@ void GlooController::Bcast(void* buffer, size_t size, int root_rank,
   gloo::broadcast(opts);
 }
 
+void GlooController::AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
+                                           std::vector<int32_t>& recvsplits) {
+    throw std::runtime_error(
+        "GlooController::AlltoallGetRecvcounts not yet implemented. Use Horovod "
+        "with MPI to use this functionality.");
+}
+
 void GlooController::Barrier(Communicator communicator) {
   gloo::BarrierOptions opts(gloo_context_.GetGlooContext(communicator));
   gloo::barrier(opts);

--- a/horovod/common/gloo/gloo_controller.cc
+++ b/horovod/common/gloo/gloo_controller.cc
@@ -269,7 +269,7 @@ void GlooController::Bcast(void* buffer, size_t size, int root_rank,
 void GlooController::AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
                                            std::vector<int32_t>& recvsplits) {
     throw std::runtime_error(
-        "GlooController::AlltoallGetRecvcounts not yet implemented. Use Horovod "
+        "GlooController::AlltoallGetRecvSplits not yet implemented. Use Horovod "
         "with MPI to use this functionality.");
 }
 

--- a/horovod/common/gloo/gloo_controller.h
+++ b/horovod/common/gloo/gloo_controller.h
@@ -50,6 +50,9 @@ public:
 
   void Bcast(void* buffer, size_t size, int root_rank, Communicator communicator) override;
 
+  void AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
+                             std::vector<int32_t>& recvsplits) override;
+
   void Barrier(Communicator communicator) override;
 
 protected:

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -1,6 +1,7 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
 // Modifications copyright Microsoft
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,6 +108,9 @@ const std::string& Request::RequestType_Name(RequestType value) {
     case RequestType::ADASUM:
       static const std::string adasum("ADASUM");
       return adasum;
+    case RequestType::ALLTOALL:
+      static const std::string alltoall("ALLTOALL");
+      return alltoall;
     default:
       static const std::string unknown("<unknown>");
       return unknown;
@@ -277,6 +281,9 @@ const std::string& Response::ResponseType_Name(ResponseType value) {
     case ResponseType::ADASUM:
       static const std::string adasum("ADASUM");
       return adasum;
+    case ResponseType::ALLTOALL:
+      static const std::string alltoall("ALLTOALL");
+      return alltoall;
     case ResponseType::ERROR:
       static const std::string error("ERROR");
       return error;

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -1,6 +1,7 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
 // Modifications copyright Microsoft
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +48,7 @@ std::size_t DataType_Size(DataType value);
 class Request {
 public:
   enum RequestType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL = 5
   };
 
   static const std::string& RequestType_Name(RequestType value);
@@ -132,7 +133,7 @@ private:
 class Response {
 public:
   enum ResponseType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ERROR = 5
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL= 5, ERROR = 6
   };
 
   static const std::string& ResponseType_Name(ResponseType value);

--- a/horovod/common/mpi/mpi_controller.cc
+++ b/horovod/common/mpi/mpi_controller.cc
@@ -1,4 +1,5 @@
 // Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,6 +208,19 @@ void MPIController::Bcast(void* buffer, size_t size, int root_rank,
         "MPI_Broadcast failed, see MPI output for details.");
   }
 }
+
+void MPIController::AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
+                                          std::vector<int32_t>& recvsplits) {
+  recvsplits.resize(size_);
+  MPI_Comm comm = mpi_ctx_.GetMPICommunicator(Communicator::GLOBAL);
+  int ret_code = MPI_Alltoall(splits.data(), 1, MPI_INT,
+                              recvsplits.data(), 1, MPI_INT,
+                              comm);
+  if (ret_code != MPI_SUCCESS) {
+    throw std::runtime_error(
+        "MPI_Alltoall failed, see MPI output for details.");
+  }
+};
 
 void MPIController::Barrier(Communicator communicator) {
   MPI_Comm comm = mpi_ctx_.GetMPICommunicator(communicator);

--- a/horovod/common/mpi/mpi_controller.h
+++ b/horovod/common/mpi/mpi_controller.h
@@ -1,4 +1,5 @@
 // Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +53,9 @@ public:
   void RecvFinalTensors(ResponseList& response_list) override;
 
   void Bcast(void* buffer, size_t size, int root_rank, Communicator communicator) override;
+
+  void AlltoallGetRecvSplits(const std::vector<int32_t>& splits,
+                             std::vector<int32_t>& recvsplits) override;
 
   void Barrier(Communicator communicator) override;
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -147,6 +147,7 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
   std::vector<std::shared_ptr<AllgatherOp>> allgather_ops;
   std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops;
   std::vector<std::shared_ptr<AllreduceOp>> adasum_ops;
+  std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops;
 
 #if HAVE_MPI && HAVE_GPU
   if (mpi_context.IsEnabled()) {
@@ -172,6 +173,11 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
 #endif
     allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
         new MPIHierarchicalAllgather(&mpi_context, &state)));
+
+#if HOROVOD_GPU_ALLTOALL == 'M'
+    alltoall_ops.push_back(std::shared_ptr<AlltoallOp>(
+        new MPI_GPUAlltoall(&mpi_context, &gpu_context, &state)));
+#endif
   }
 #endif
 
@@ -188,6 +194,13 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
 #if HAVE_NCCL && HOROVOD_GPU_ALLGATHER == 'N'
   allgather_ops.push_back(std::shared_ptr<AllgatherOp>(
       new NCCLAllgather(&nccl_context, &gpu_context, &state)));
+#endif
+
+#if HAVE_NCCL && HOROVOD_GPU_ALLTOALL == 'N'
+#if HAVE_MPI
+  alltoall_ops.push_back(std::shared_ptr<AlltoallOp>(
+      new NCCLAlltoall(&nccl_context, &mpi_context, &gpu_context, &state)));
+#endif
 #endif
 
 #if HAVE_GLOO
@@ -222,6 +235,8 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
         std::shared_ptr<AllgatherOp>(new MPIAllgather(&mpi_context, &state)));
     broadcast_ops.push_back(
         std::shared_ptr<BroadcastOp>(new MPIBroadcast(&mpi_context, &state)));
+    alltoall_ops.push_back(
+        std::shared_ptr<AlltoallOp>(new MPIAlltoall(&mpi_context, &state)));
   }
 #endif
 
@@ -229,7 +244,8 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
   std::shared_ptr<ErrorOp> error_op(new ErrorOp(&state));
 
   return new OperationManager(&state.parameter_manager, allreduce_ops,
-                              allgather_ops, broadcast_ops, join_op, adasum_ops, error_op);
+                              allgather_ops, broadcast_ops, alltoall_ops,
+                              join_op, adasum_ops, error_op);
 }
 
 // Process a Response by doing a reduction, a gather, a broadcast, or
@@ -765,11 +781,11 @@ bool horovod_gloo_built() {
 #endif
 }
 
-bool horovod_nccl_built() {
+int horovod_nccl_built() {
 #if HAVE_NCCL
-  return true;
+  return NCCL_VERSION_CODE;
 #else
-  return false;
+  return 0;
 #endif
 }
 
@@ -919,6 +935,71 @@ Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
   e.ready_event = ready_event;
   e.device = device;
   e.callback = callback;
+
+  if (horovod_global.shut_down) {
+    return SHUT_DOWN_ERROR;
+  }
+  Status status = horovod_global.tensor_queue.AddToTensorQueue(e, message);
+  if (status.ok()) {
+    LOG(TRACE, horovod_global.controller->GetRank()) << "Enqueued " << name;
+  }
+  return status;
+}
+
+// Contexts and controller must be initialized and the background thread
+// must be running before this function is called.
+Status EnqueueTensorAlltoall(std::shared_ptr<OpContext> context,
+                             std::shared_ptr<Tensor> tensor,
+                             std::shared_ptr<Tensor> splits,
+                             std::shared_ptr<ReadyEvent> ready_event,
+                             const std::string name, const int device,
+                             StatusCallback callback) {
+  // Check arguments
+  if (splits->shape().dims() > 1) {
+    return Status::InvalidArgument("alltoall expects a 1D splits tensor");
+  }
+  if (splits->dtype() != HOROVOD_INT32) {
+    return Status::InvalidArgument("alltoall expects splits to contain 32-bit integer elements.");
+  }
+
+  Request message;
+  message.set_request_rank(horovod_global.controller->GetRank());
+  message.set_tensor_name(name);
+  message.set_tensor_type(tensor->dtype());
+  message.set_device(device);
+  message.set_request_type(Request::ALLTOALL);
+  for (int i = 0; i < tensor->shape().dims(); ++i) {
+    message.add_tensor_shape((int64_t)tensor->shape().dim_size(i));
+  }
+
+  TensorTableEntry e;
+  e.tensor_name = name;
+  e.context = context;
+  e.tensor = tensor;
+  e.ready_event = ready_event;
+  e.device = device;
+  e.callback = callback;
+
+  int64_t splits_first_dim = splits->shape().dim_size(0);
+  int64_t tensor_first_dim = tensor->shape().dim_size(0);
+  int world_size = horovod_global.controller->GetSize();
+  if (splits_first_dim == world_size) {
+    auto splits_data = static_cast<const int32_t*>(splits->data());
+    auto sum = std::accumulate(splits_data, splits_data + splits_first_dim, 0);
+    if (sum > tensor_first_dim) {
+      return Status::InvalidArgument("Sum of splits entries is greater than the first dimension of tensor.");
+    }
+    e.splits.assign(splits_data,
+                    splits_data + splits->shape().num_elements());
+  } else if (splits_first_dim == 0) {
+    if (tensor_first_dim % world_size != 0) {
+      return Status::InvalidArgument("splits not provided, but first dimension of tensor is not an even "
+                                     "multiple of the number of workers.");
+    }
+    e.splits.resize(world_size, tensor_first_dim / world_size);
+  } else {
+      return Status::InvalidArgument("Number of entries in splits does not equal number of workers.");
+  }
 
   if (horovod_global.shut_down) {
     return SHUT_DOWN_ERROR;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -197,10 +197,8 @@ OperationManager* CreateOperationManager(HorovodGlobalState& state) {
 #endif
 
 #if HAVE_NCCL && HOROVOD_GPU_ALLTOALL == 'N'
-#if HAVE_MPI
   alltoall_ops.push_back(std::shared_ptr<AlltoallOp>(
-      new NCCLAlltoall(&nccl_context, &mpi_context, &gpu_context, &state)));
-#endif
+      new NCCLAlltoall(&nccl_context, &gpu_context, &state)));
 #endif
 
 #if HAVE_GLOO

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -84,8 +84,9 @@ bool horovod_gloo_enabled();
 // C interface to return flag indicating whether Horovod was compiled with Gloo support.
 bool horovod_gloo_built();
 
-// C interface to return flag indicating whether Horovod was compiled with NCCL support.
-bool horovod_nccl_built();
+// C interface to return integer indicating whether Horovod was compiled with NCCL support.
+// Returns NCCL_VERSION_CODE if NCCL is available, else returns 0.
+int horovod_nccl_built();
 
 // C interface to return flag indicating whether Horovod was compiled with DDL support.
 bool horovod_ddl_built();
@@ -124,6 +125,13 @@ Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
                               std::shared_ptr<ReadyEvent> ready_event,
                               const std::string name, const int device,
                               StatusCallback callback);
+
+Status EnqueueTensorAlltoall(std::shared_ptr<OpContext> context,
+                             std::shared_ptr<Tensor> tensor,
+                             std::shared_ptr<Tensor> splits,
+                             std::shared_ptr<ReadyEvent> ready_event,
+                             const std::string name, const int device,
+                             StatusCallback callback);
 
 Status EnqueueJoin(std::shared_ptr<OpContext> context,
                               std::shared_ptr<ReadyEvent> ready_event,

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,6 +131,26 @@ public:
   BroadcastOp(HorovodGlobalState* global_state);
 
   virtual ~BroadcastOp() = default;
+
+  virtual Status Execute(std::vector<TensorTableEntry>& entries,
+                         const Response& response) = 0;
+
+  virtual bool Enabled(const ParameterManager& param_manager,
+                       const std::vector<TensorTableEntry>& entries,
+                       const Response& response) const = 0;
+};
+
+class AlltoallOp : public HorovodOp {
+public:
+  AlltoallOp(HorovodGlobalState* global_state);
+
+  virtual ~AlltoallOp() = default;
+
+  virtual Status PrepareOutputAndParams(TensorTableEntry& e,
+                                      std::vector<int32_t>& sdispls,
+                                      std::vector<int32_t>& rdispls,
+                                      std::vector<int32_t>& sendcounts,
+                                      std::vector<int32_t>& recvcounts);
 
   virtual Status Execute(std::vector<TensorTableEntry>& entries,
                          const Response& response) = 0;

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -148,9 +148,9 @@ GPUAlltoall::GPUAlltoall(GPUContext* context,
     : AlltoallOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
 
 bool GPUAlltoall::Enabled(const ParameterManager& param_manager,
-		          const std::vector<TensorTableEntry>& entries,
-			  const Response& response) const {
-    return entries[0].device != CPU_DEVICE_ID;
+                          const std::vector<TensorTableEntry>& entries,
+                          const Response& response) const {
+  return entries[0].device != CPU_DEVICE_ID;
 }
 
 } // namespace common

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -143,5 +143,15 @@ bool GPUBroadcast::Enabled(const ParameterManager& param_manager,
   return entries[0].device != CPU_DEVICE_ID;
 }
 
+GPUAlltoall::GPUAlltoall(GPUContext* context,
+		         HorovodGlobalState* global_state)
+    : AlltoallOp(global_state), gpu_context_(context), gpu_op_context_(context, global_state) {}
+
+bool GPUAlltoall::Enabled(const ParameterManager& param_manager,
+		          const std::vector<TensorTableEntry>& entries,
+			  const Response& response) const {
+    return entries[0].device != CPU_DEVICE_ID;
+}
+
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -173,6 +174,18 @@ public:
 
 protected:
   struct GPUContext* gpu_context_;
+  GPUOpContext gpu_op_context_;
+};
+
+class GPUAlltoall : public AlltoallOp {
+public:
+  GPUAlltoall(GPUContext* context,
+              HorovodGlobalState* global_state);
+  bool Enabled(const ParameterManager& param_manager,
+               const std::vector<TensorTableEntry>& entries,
+               const Response& response) const override;
+protected:
+  GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;
 };
 

--- a/horovod/common/ops/mpi_gpu_operations.h
+++ b/horovod/common/ops/mpi_gpu_operations.h
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +39,19 @@ class MPI_GPUAllgather : public GPUAllgather {
 public:
   MPI_GPUAllgather(MPIContext* mpi_context, GPUContext* gpu_context, HorovodGlobalState* global_state);
   virtual ~MPI_GPUAllgather()=default;
+
+  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+
+protected:
+  MPIContext* mpi_context_;
+};
+
+// TODO: Add MPI_GPUBroadcast implementation
+
+class MPI_GPUAlltoall : public GPUAlltoall {
+public:
+  MPI_GPUAlltoall(MPIContext* mpi_context, GPUContext* gpu_context, HorovodGlobalState* global_state);
+  virtual ~MPI_GPUAlltoall()=default;
 
   Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
 

--- a/horovod/common/ops/mpi_operations.cc
+++ b/horovod/common/ops/mpi_operations.cc
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -368,6 +369,43 @@ Status MPIBroadcast::Execute(std::vector<TensorTableEntry>& entries, const Respo
 }
 
 bool MPIBroadcast::Enabled(const ParameterManager& param_manager,
+                           const std::vector<TensorTableEntry>& entries,
+                           const Response& response) const {
+  return true;
+}
+
+MPIAlltoall::MPIAlltoall(MPIContext* mpi_context, HorovodGlobalState* global_state)
+    : AlltoallOp(global_state), mpi_context_(mpi_context) {}
+
+Status MPIAlltoall::Execute(std::vector<TensorTableEntry>& entries, const Response& response) {
+  assert(entries.size() == 1);
+  auto e = entries[0];
+
+  std::vector<int32_t> sdispls, rdispls;
+  std::vector<int32_t> sendcounts, recvcounts;
+  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts);
+  if (!status.ok()) {
+    return status;
+  }
+
+  const void* sendbuf = e.tensor->data();
+  void* buffer_data = (void*) e.output->data();
+  global_state_->timeline.ActivityStartAll(entries, MPI_ALLTOALL);
+
+  int op = MPI_Alltoallv(sendbuf, sendcounts.data(), sdispls.data(),
+                         mpi_context_->GetMPIDataType(e.tensor->dtype()),
+                         buffer_data, recvcounts.data(), rdispls.data(),
+                         mpi_context_->GetMPIDataType(e.output->dtype()),
+                         mpi_context_->GetMPICommunicator(Communicator::GLOBAL));
+  if (op != MPI_SUCCESS) {
+    throw std::runtime_error("MPI_Alltoallv failed, see MPI output for details.");
+  }
+  global_state_->timeline.ActivityEndAll(entries);
+
+  return Status::OK();
+}
+
+bool MPIAlltoall::Enabled(const ParameterManager& param_manager,
                            const std::vector<TensorTableEntry>& entries,
                            const Response& response) const {
   return true;

--- a/horovod/common/ops/mpi_operations.h
+++ b/horovod/common/ops/mpi_operations.h
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,6 +77,20 @@ private:
 class MPIBroadcast : public BroadcastOp {
 public:
   MPIBroadcast(MPIContext* mpi_context, HorovodGlobalState* global_state);
+
+  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+
+  bool Enabled(const ParameterManager& param_manager,
+               const std::vector<TensorTableEntry>& entries,
+               const Response& response) const override;
+
+protected:
+  MPIContext* mpi_context_;
+};
+
+class MPIAlltoall : public AlltoallOp {
+public:
+  MPIAlltoall(MPIContext* mpi_context, HorovodGlobalState* global_state);
 
   Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
 

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -586,7 +586,11 @@ Status NCCLAlltoall::Execute(std::vector<TensorTableEntry>& entries,
 
   return gpu_op_context_.FinalizeGPUQueue(entries);
 #else
-  throw std::runtime_error("NCCLAlltoall requires NCCL version >= 2.7.0.");
+  throw std::runtime_error("NCCLAlltoall requires NCCL version >= 2.7.0. If your NCCL installation cannot be updated "
+                           "and you installed with HOROVOD_GPU_OPERATIONS=NCCL, reinstall with only supported "
+                           "operations individually specified (i.e. HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_GPU_BROADCAST=NCCL "
+                           "HOROVOD_GPU_ALLGATHER=NCCL). Otherwise, exclude HOROVOD_GPU_ALLTOALL=NCCL from your "
+                           "installation command.");
 #endif
 }
 

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -541,6 +542,52 @@ bool NCCLAllgather::Enabled(const ParameterManager& param_manager,
                               const std::vector<TensorTableEntry>& entries,
                               const Response& response) const {
   return entries[0].device != CPU_DEVICE_ID;
+}
+
+Status NCCLAlltoall::Execute(std::vector<TensorTableEntry>& entries,
+                             const Response& response) {
+#ifdef NCCL_P2P_SUPPORTED
+  assert(entries.size() == 1);
+  auto e = entries[0];
+
+  gpu_op_context_.InitGPU(entries);
+  nccl_op_context_.InitNCCLComm(entries, response.devices());
+  gpu_op_context_.InitGPUQueue(entries, response);
+
+  std::vector<int32_t> sdispls, rdispls;
+  std::vector<int32_t> sendcounts, recvcounts;
+  Status status = PrepareOutputAndParams(e, sdispls, rdispls, sendcounts, recvcounts);
+  if (!status.ok()) {
+    return status;
+  }
+
+  auto world_size = global_state_->controller->GetSize();
+  const void* sendbuf = e.tensor->data();
+  void* buffer_data = (void*) e.output->data();
+
+  nccl_context_->ErrorCheck("ncclGroupStart", ncclGroupStart(), *nccl_op_context_.nccl_comm_);
+
+  for (int i = 0; i < world_size; ++i) {
+    auto nccl_result = ncclRecv((uint8_t*) e.output->data() + rdispls[i] * DataType_Size(e.tensor->dtype()),
+                                recvcounts[i] * DataType_Size(e.tensor->dtype()), ncclChar, i,
+                                *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream);
+    nccl_context_->ErrorCheck("ncclRecv", nccl_result, *nccl_op_context_.nccl_comm_);
+
+    nccl_result = ncclSend((uint8_t*) e.tensor->data() + sdispls[i] * DataType_Size(e.tensor->dtype()),
+                           sendcounts[i] * DataType_Size(e.tensor->dtype()), ncclChar, i,
+                           *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream);
+    nccl_context_->ErrorCheck("ncclSend", nccl_result, *nccl_op_context_.nccl_comm_);
+  }
+  nccl_context_->ErrorCheck("ncclGroupEnd", ncclGroupEnd(), *nccl_op_context_.nccl_comm_);
+
+  if (global_state_->timeline.Initialized()) {
+    gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_ALLTOALL, *gpu_op_context_.stream);
+  }
+
+  return gpu_op_context_.FinalizeGPUQueue(entries);
+#else
+  throw std::runtime_error("NCCLAlltoall requires NCCL version >= 2.7.0.");
+#endif
 }
 
 } // namespace common

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -20,7 +20,7 @@
 
 #if HAVE_CUDA
 #include <nccl.h>
-#if NCCL_VERSION_CODE >= 2700
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 7, 0)
 #define NCCL_P2P_SUPPORTED
 #endif
 #elif HAVE_ROCM

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -1,5 +1,6 @@
 // Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 // Modifications copyright (C) 2019 Uber Technologies, Inc.
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +20,9 @@
 
 #if HAVE_CUDA
 #include <nccl.h>
+#if NCCL_VERSION_CODE >= 2700
+#define NCCL_P2P_SUPPORTED
+#endif
 #elif HAVE_ROCM
 #include <rccl.h>
 #endif
@@ -95,6 +99,25 @@ public:
   NCCLBroadcast(NCCLContext* nccl_context, GPUContext* gpu_context,
                 HorovodGlobalState* global_state)
       : GPUBroadcast(gpu_context, global_state),
+        nccl_context_(nccl_context),
+        nccl_op_context_(nccl_context, global_state, Communicator::GLOBAL),
+        global_state_(global_state){};
+
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
+
+protected:
+  NCCLContext* nccl_context_;
+  NCCLOpContext nccl_op_context_;
+  HorovodGlobalState* global_state_;
+};
+
+class NCCLAlltoall : public GPUAlltoall {
+public:
+  NCCLAlltoall(NCCLContext* nccl_context, MPIContext* mpi_context,
+               GPUContext* gpu_context,
+               HorovodGlobalState* global_state)
+      : GPUAlltoall(gpu_context, global_state),
         nccl_context_(nccl_context),
         nccl_op_context_(nccl_context, global_state, Communicator::GLOBAL),
         global_state_(global_state){};

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -114,8 +114,7 @@ protected:
 
 class NCCLAlltoall : public GPUAlltoall {
 public:
-  NCCLAlltoall(NCCLContext* nccl_context, MPIContext* mpi_context,
-               GPUContext* gpu_context,
+  NCCLAlltoall(NCCLContext* nccl_context, GPUContext* gpu_context,
                HorovodGlobalState* global_state)
       : GPUAlltoall(gpu_context, global_state),
         nccl_context_(nccl_context),

--- a/horovod/common/ops/operation_manager.cc
+++ b/horovod/common/ops/operation_manager.cc
@@ -1,5 +1,6 @@
 // Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
 // Modifications copyright Microsoft
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@ OperationManager::OperationManager(ParameterManager* param_manager,
                                    std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops,
                                    std::vector<std::shared_ptr<AllgatherOp>> allgather_ops,
                                    std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops,
+                                   std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops,
                                    std::shared_ptr<JoinOp> join_op,
                                    std::vector<std::shared_ptr<AllreduceOp>> adasum_ops,
                                    std::shared_ptr<ErrorOp> error_op)
@@ -30,6 +32,7 @@ OperationManager::OperationManager(ParameterManager* param_manager,
       allreduce_ops_(std::move(allreduce_ops)),
       allgather_ops_(std::move(allgather_ops)),
       broadcast_ops_(std::move(broadcast_ops)),
+      alltoall_ops_(std::move(alltoall_ops)),
       join_op_(std::move(join_op)),
       adasum_ops_(std::move(adasum_ops)),
       error_op_(std::move(error_op)) {}
@@ -64,6 +67,16 @@ Status OperationManager::ExecuteBroadcast(std::vector<TensorTableEntry>& entries
   throw std::logic_error("No Broadcast operation enabled");
 }
 
+Status OperationManager::ExecuteAlltoall(std::vector<TensorTableEntry>& entries,
+                                         const Response& response) const {
+  for (auto& op : alltoall_ops_) {
+    if (op->Enabled(*param_manager_, entries, response)) {
+      return op->Execute(entries, response);
+    }
+  }
+  throw std::logic_error("No Alltoall operation enabled");
+}
+
 Status OperationManager::ExecuteJoin(std::vector<TensorTableEntry>& entries,
                                           const Response& response) const {
   return join_op_->Execute(entries, response);
@@ -92,6 +105,8 @@ Status OperationManager::ExecuteOperation(std::vector<TensorTableEntry>& entries
     return ExecuteAllgather(entries, response);
   } else if (response.response_type() == Response::BROADCAST) {
     return ExecuteBroadcast(entries, response);
+  } else if (response.response_type() == Response::ALLTOALL) {
+    return ExecuteAlltoall(entries, response);
   } else if (response.response_type() == Response::JOIN) {
     return ExecuteJoin(entries, response);
   } else if (response.response_type() == Response::ADASUM) {

--- a/horovod/common/ops/operation_manager.h
+++ b/horovod/common/ops/operation_manager.h
@@ -1,5 +1,6 @@
 // Copyright 2019 Uber Technologies, Inc. All Rights Reserved.
 // Modifications copyright Microsoft
+// Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +30,7 @@ public:
                    std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops,
                    std::vector<std::shared_ptr<AllgatherOp>> allgather_ops,
                    std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops,
+                   std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops,
                    std::shared_ptr<JoinOp> join_op,
                    std::vector<std::shared_ptr<AllreduceOp>> adasum_ops,
                    std::shared_ptr<ErrorOp> error_op);
@@ -40,6 +42,8 @@ public:
   Status ExecuteAllgather(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
   Status ExecuteBroadcast(std::vector<TensorTableEntry>& entries, const Response& response) const;
+
+  Status ExecuteAlltoall(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
   Status ExecuteError(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
@@ -55,6 +59,7 @@ private:
   std::vector<std::shared_ptr<AllreduceOp>> allreduce_ops_;
   std::vector<std::shared_ptr<AllgatherOp>> allgather_ops_;
   std::vector<std::shared_ptr<BroadcastOp>> broadcast_ops_;
+  std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops_;
   std::shared_ptr<JoinOp> join_op_;
   std::vector<std::shared_ptr<AllreduceOp>> adasum_ops_;
   std::shared_ptr<ErrorOp> error_op_;

--- a/horovod/common/tensor_queue.cc
+++ b/horovod/common/tensor_queue.cc
@@ -82,6 +82,7 @@ void TensorQueue::GetTensorEntriesFromResponse(
       assert(response.response_type() == Response::ALLREDUCE ||
              response.response_type() == Response::ALLGATHER ||
              response.response_type() == Response::BROADCAST ||
+             response.response_type() == Response::ALLTOALL ||
              response.response_type() == Response::ADASUM ||
              response.response_type() == Response::ERROR);
 

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -21,6 +21,7 @@ check_extension('horovod.mxnet', 'HOROVOD_WITH_MXNET',
 from horovod.mxnet.functions import broadcast_object
 from horovod.mxnet.mpi_ops import allgather
 from horovod.mxnet.mpi_ops import allreduce, allreduce_
+from horovod.mxnet.mpi_ops import alltoall
 from horovod.mxnet.mpi_ops import broadcast, broadcast_
 from horovod.mxnet.mpi_ops import init, shutdown
 from horovod.mxnet.mpi_ops import size, local_size, rank, local_rank

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -42,6 +42,7 @@ static const auto MX_FUNC_PROP = FnProperty::kCPUPrioritized;
 static const char* ALLREDUCE_OP_TYPE_NAME = "horovod_allreduce";
 static const char* ALLGATHER_OP_TYPE_NAME = "horovod_allgather";
 static const char* BROADCAST_OP_TYPE_NAME = "horovod_broadcast";
+static const char* ALLTOALL_OP_TYPE_NAME = "horovod_alltoall";
 
 inline void InvokeCompleteCallback(CallbackOnComplete on_complete, const Status& status) {
   if (status.ok()) {
@@ -60,9 +61,15 @@ inline const char* GetOpTypeName(OperationType op_type) {
       return ALLGATHER_OP_TYPE_NAME;
     case OperationType::BROADCAST:
       return BROADCAST_OP_TYPE_NAME;
+    case OperationType::ALLTOALL:
+      return ALLTOALL_OP_TYPE_NAME;
     default:
       throw std::logic_error("Unsupported Horovod operation type.");
   }
+}
+
+bool IsTensorOnCPU(NDArray* tensor) {
+  return tensor->ctx().dev_mask() == cpu::kDevMask;
 }
 
 void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
@@ -109,6 +116,16 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
             InvokeCompleteCallback(on_complete, status);
       });
       break;
+    case OperationType::ALLTOALL:
+    {
+      auto hvd_splits = std::make_shared<MXTensor>(ops_param->splits_tensor.get());
+      enqueue_result = EnqueueTensorAlltoall(
+          hvd_context, hvd_tensor, hvd_splits, nullptr, name, device,
+          [on_complete](const Status& status) {
+            InvokeCompleteCallback(on_complete, status);
+      });
+      break;
+    }
     default:
       throw std::logic_error("Unsupported Horovod operation type.");
   }
@@ -118,7 +135,8 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 
 inline void PushHorovodOperation(OperationType op_type, NDArray* input,
                                  NDArray* output, const char* name,
-                                 int priority, int root_rank = -1) {
+                                 int priority, int root_rank = -1,
+                                 NDArray* splits = nullptr) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
 
@@ -127,21 +145,41 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   // before MXNet engine process it
   auto input_copy = std::make_shared<NDArray>(*input);
   auto output_copy = std::make_shared<NDArray>(*output);
+  std::shared_ptr<NDArray> splits_tensor;
+  if (splits) {
+    // We expect splits to be a tensor on CPU. Create CPU copy if required.
+    if (!IsTensorOnCPU(splits)) {
+      splits_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
+      splits->dtype());
+      TensorUtil::AsyncCopyCudaToCPU(splits, splits_tensor.get());
+    } else {
+      splits_tensor = std::make_shared<NDArray>(*splits);
+    }
+  }
   auto ops_param = CreateMpiOpsParam(input_copy, output_copy, output,
     nullptr /* cpu_input_tensor */, nullptr /* cpu_output_tensor */,
-    op_type, op_name, root_rank);
+    op_type, op_name, root_rank, splits_tensor);
 
   // Not in-place
   auto input_var = input->var();
   auto output_var = output->var();
   if (input_var != output_var) {
+    std::vector<void*> input_vars {input_var};
+    if (splits) {
+      // Add splits tensor to input list to enforce dependency on possible async D2H copy
+      input_vars.push_back(splits_tensor->var());
+    }
     MXEnginePushAsync(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
-                      &MX_EXEC_CTX, &input_var, 1, &output_var, 1,
+                      &MX_EXEC_CTX, input_vars.data(), input_vars.size(), &output_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);
   // In-place
   } else {
+    std::vector<void*> input_vars;
+    if (splits) {
+      input_vars.push_back(splits_tensor->var());
+    }
     MXEnginePushAsync(DoHorovodOperation, ops_param, DeleteMpiOpsParam,
-                      &MX_EXEC_CTX, nullptr, 0, &output_var, 1,
+                      &MX_EXEC_CTX, input_vars.data(), input_vars.size(), &output_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);
   }
 }
@@ -181,6 +219,16 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
             InvokeCompleteCallback(on_complete, status);
       });
       break;
+    case OperationType::ALLTOALL:
+    {
+      auto hvd_splits = std::make_shared<MXTensor>(ops_param->splits_tensor.get());
+      enqueue_result = EnqueueTensorAlltoall(
+          hvd_context, hvd_cpu_buffer, hvd_splits, nullptr, name, CPU_DEVICE_ID,
+          [on_complete](const Status& status) {
+            InvokeCompleteCallback(on_complete, status);
+      });
+      break;
+    }
     default:
       throw std::logic_error("Unsupported Horovod operation type.");
   }
@@ -190,7 +238,8 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
 
 inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
                                           NDArray* output, const char* name,
-                                          int priority, int root_rank = -1) {
+                                          int priority, int root_rank = -1,
+                                          NDArray* splits = nullptr) {
   auto op_type_name = GetOpTypeName(op_type);
   auto op_name = GetOpName(op_type_name, name);
 
@@ -198,20 +247,41 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
     input->dtype());
   auto cpu_output_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
     input->dtype());
-  auto ops_param = CreateMpiOpsParam(nullptr, nullptr, output, cpu_input_tensor,
-                                     cpu_output_tensor, op_type, op_name, root_rank);
 
   // Make async copy of input tensor to CPU tensor.
   TensorUtil::AsyncCopyCudaToCPU(input, cpu_input_tensor.get());
+
+  std::shared_ptr<NDArray> splits_tensor;
+  if (splits) {
+    // We expect splits to be a tensor on CPU. Create CPU copy if required.
+    if (!IsTensorOnCPU(splits)) {
+      splits_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
+      splits->dtype());
+      TensorUtil::AsyncCopyCudaToCPU(splits, splits_tensor.get());
+    } else {
+      splits_tensor = std::make_shared<NDArray>(*splits);
+    }
+  }
+
+  auto ops_param = CreateMpiOpsParam(nullptr, nullptr, output, cpu_input_tensor,
+                                     cpu_output_tensor, op_type, op_name, root_rank,
+                                     splits_tensor);
 
   auto input_var = input->var();
   auto output_var = output->var();
   auto cpu_input_var = cpu_input_tensor->var();
   auto cpu_output_var = cpu_output_tensor->var();
-  if (op_type == OperationType::ALLGATHER) {
-    // Use out-of-place path for operations that have unknown output size (allgather)
+  if (op_type == OperationType::ALLGATHER ||
+      op_type == OperationType::ALLTOALL) {
+    // Use out-of-place path for operations that have unknown output size (allgather, alltoall)
+    std::vector<void*> input_vars {cpu_input_var};
+    if (splits) {
+      // Add splits tensor to input list to enforce dependency on possible async D2H copy
+      input_vars.push_back(splits_tensor->var());
+    }
+
     MXEnginePushAsync(DoHorovodOperationCudaOnCPU, ops_param, DeleteMpiOpsParam,
-                      &MX_EXEC_CTX, &cpu_input_var, 1, &cpu_output_var, 1,
+                      &MX_EXEC_CTX, input_vars.data(), input_vars.size(), &cpu_output_var, 1,
                       &MX_FUNC_PROP, priority, op_type_name);
 
     // Since cpu_output_tensor is resized in out-of-place path, need
@@ -231,10 +301,6 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* input,
   }
 }
 #endif
-
-bool IsTensorOnCPU(NDArray* tensor) {
-  return tensor->ctx().dev_mask() == cpu::kDevMask;
-}
 
 extern "C" int horovod_mxnet_allreduce_async(NDArray* input, NDArray* output,
                                              const char* name, bool average,
@@ -300,6 +366,30 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
 #else
   PushHorovodOperation(OperationType::BROADCAST, input, output,
                        name, priority, root_rank);
+#endif
+
+  MX_API_END();
+}
+
+extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
+                                            NDArray* output,
+                                            const char* name,
+                                            NDArray* splits,
+                                            int priority) {
+  MX_API_BEGIN();
+
+#if HAVE_CUDA && !HOROVOD_GPU_ALLTOALL
+  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
+    PushHorovodOperation(OperationType::ALLTOALL, input, output,
+                         name, priority, -1, splits);
+
+  } else {
+    PushHorovodOperationCudaOnCPU(OperationType::ALLTOALL, input, output,
+                                  name, priority, -1, splits);
+  }
+#else
+  PushHorovodOperation(OperationType::ALLTOALL, input, output,
+                       name, priority, -1, splits);
 #endif
 
   MX_API_END();

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -147,6 +147,7 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
   auto output_copy = std::make_shared<NDArray>(*output);
   std::shared_ptr<NDArray> splits_tensor;
   if (splits) {
+#if HAVE_CUDA
     // We expect splits to be a tensor on CPU. Create CPU copy if required.
     if (!IsTensorOnCPU(splits)) {
       splits_tensor = std::make_shared<NDArray>(Context::Create(Context::kCPU, 0),
@@ -155,6 +156,9 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* input,
     } else {
       splits_tensor = std::make_shared<NDArray>(*splits);
     }
+#else
+    splits_tensor = std::make_shared<NDArray>(*splits);
+#endif
   }
   auto ops_param = CreateMpiOpsParam(input_copy, output_copy, output,
     nullptr /* cpu_input_tensor */, nullptr /* cpu_output_tensor */,

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -46,6 +46,7 @@ struct MpiOpsParam {
   OperationType op_type;
   std::string op_name;
   int root_rank;
+  NDArraySharedPtr splits_tensor;
 
   MpiOpsParam(NDArraySharedPtr input_tensor,
               NDArraySharedPtr output_tensor,
@@ -53,7 +54,8 @@ struct MpiOpsParam {
               NDArraySharedPtr cpu_input_tensor,
               NDArraySharedPtr cpu_output_tensor,
               const OperationType& op_type, const std::string& op_name,
-              int root_rank)
+              int root_rank,
+              NDArraySharedPtr splits_tensor)
       : input_tensor(input_tensor),
         output_tensor(output_tensor),
         output(output),
@@ -61,7 +63,8 @@ struct MpiOpsParam {
         cpu_output_tensor(cpu_output_tensor),
         op_type(op_type),
         op_name(op_name),
-        root_rank(root_rank) {
+        root_rank(root_rank),
+        splits_tensor(splits_tensor) {
   }
 };
 
@@ -72,9 +75,10 @@ inline MpiOpsParam* CreateMpiOpsParam(NDArraySharedPtr input_tensor,
                                       NDArraySharedPtr cpu_output_tensor,
                                       const OperationType& op_type,
                                       const std::string& op_name,
-                                      int root_rank) {
+                                      int root_rank,
+                                      NDArraySharedPtr splits_tensor) {
   return new MpiOpsParam(input_tensor, output_tensor, output, cpu_input_tensor,
-    cpu_output_tensor, op_type, op_name, root_rank);
+    cpu_output_tensor, op_type, op_name, root_rank, splits_tensor);
 }
 
 void DeleteMpiOpsParam(void* param) {
@@ -93,6 +97,11 @@ extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, int root_rank,
                                              int priority);
+extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
+                                            NDArray* output,
+                                            const char* name,
+                                            NDArray* splits,
+                                            int priority);
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -26,7 +26,7 @@ check_extension('horovod.tensorflow', 'HOROVOD_WITH_TENSORFLOW', __file__, 'mpi_
 from horovod.tensorflow import elastic
 from horovod.tensorflow.compression import Compression
 from horovod.tensorflow.functions import broadcast_object, broadcast_object_fn, broadcast_variables
-from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce
+from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce, alltoall
 from horovod.tensorflow.mpi_ops import init, shutdown
 from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank, is_homogeneous
 from horovod.tensorflow.mpi_ops import rank_op, local_rank_op, size_op, local_size_op

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -29,6 +29,7 @@ from horovod.torch.functions import broadcast_object, broadcast_optimizer_state,
 from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allreduce_async_
 from horovod.torch.mpi_ops import allgather, allgather_async
 from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
+from horovod.torch.mpi_ops import alltoall, alltoall_async
 from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
 from horovod.torch.mpi_ops import init, shutdown, is_initialized

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Uber Technologies, Inc. All Rights Reserved.
+# Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -601,6 +602,212 @@ class MXTests(unittest.TestCase):
 
         # To prevent premature shutdown from rank 0 for this test
         mx.nd.waitall()
+
+    def test_horovod_alltoall(self):
+        """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        dtypes = ['int32',   'int64',
+                  'float32', 'float64']
+        dims = [1,2,3]
+        ctx = self._current_context()
+        for dtype, dim in itertools.product(dtypes, dims):
+            vals = []
+            for i in range(size):
+              vals += [i] * (rank + 1)
+
+            tensor = mx.ndarray.array(vals, dtype=dtype, ctx=ctx)
+            for _ in range(dim - 1):
+              tensor = mx.ndarray.expand_dims(tensor, axis=1)
+              tensor = mx.ndarray.concat(tensor, tensor, dim=1)
+
+            splits = mx.ndarray.array([rank + 1] * size, dtype='int32', ctx=ctx)
+            collected = hvd.alltoall(tensor, splits)
+
+            assert collected.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.size == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+
+    def test_horovod_alltoall_equal_split(self):
+        """Test that the alltoall correctly distributes 1D tensors with default splitting."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        dtypes = ['int32',   'int64',
+                  'float32', 'float64']
+        dims = [1,2,3]
+        ctx = self._current_context()
+        for dtype, dim in itertools.product(dtypes, dims):
+            vals = []
+            for i in range(size):
+              vals += [i] * (rank + 1)
+
+            tensor = mx.ndarray.array(vals, dtype=dtype, ctx=ctx)
+            for _ in range(dim - 1):
+              tensor = mx.ndarray.expand_dims(tensor, axis=1)
+              tensor = mx.ndarray.concat(tensor, tensor, dim=1)
+            collected = hvd.alltoall(tensor)
+
+            assert collected.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.size == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+
+    def test_horovod_alltoall_type_error(self):
+        """Test that the alltoall returns an error if the tensor types differ
+           across the processes."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        ctx = self._current_context()
+        if rank % 2:
+          tensor = mx.ndarray.empty([size], dtype='int32', ctx=ctx)
+        else:
+          tensor = mx.ndarray.empty([size], dtype='float32', ctx=ctx)
+
+        try:
+            hvd.alltoall(tensor)
+            assert False, 'hvd.alltoall did not throw error'
+        except (MXNetError, RuntimeError):
+            pass
+
+    def test_horovod_alltoall_equal_split_length_error(self):
+        """Test that the alltoall with default splitting returns an error if the first dimension
+        of tensor is not a multiple of the number of workers."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        ctx = self._current_context()
+        tensor = mx.ndarray.empty([size + 1], ctx=ctx)
+        try:
+            hvd.alltoall(tensor)
+            assert False, 'hvd.alltoall did not throw error'
+        except (MXNetError, RuntimeError):
+            pass
+
+    def test_horovod_alltoall_splits_error(self):
+        """Test that the alltoall returns an error if the sum of the splits entries exceeds
+        the first dimension of the input tensor."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        ctx = self._current_context()
+        tensor = mx.ndarray.empty([size-1], ctx=ctx)
+        splits = mx.ndarray.ones([size], dtype='int32', ctx=ctx)
+        try:
+            hvd.alltoall(tensor, splits)
+            assert False, 'hvd.alltoall did not throw error'
+        except (MXNetError, RuntimeError):
+            pass
+
+    def test_horovod_alltoall_splits_type_error(self):
+        """Test that the alltoall returns an error if the splits tensor does not
+           contain 32-bit integers."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        ctx = self._current_context()
+        tensor = mx.ndarray.empty([size], ctx=ctx)
+        splits = mx.ndarray.ones([size], dtype='float32', ctx=ctx)
+        try:
+            hvd.alltoall(tensor, splits)
+            assert False, 'hvd.alltoall did not throw error'
+        except (MXNetError, ValueError):
+            pass
+
+    def test_horovod_alltoall_rank_error(self):
+        """Test that the alltoall returns an error if any dimension besides
+        the first is different among the tensors being processed."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        ctx = self._current_context()
+
+        tensor_size = [2 * size] * 3
+        tensor_size[1] = 10 * (rank + 1)
+        tensor = mx.ndarray.ones(shape=tensor_size, ctx=ctx)
+
+        try:
+            hvd.alltoall(tensor)
+            assert False, 'hvd.alltoall did not throw error'
+        except (MXNetError, RuntimeError):
+            pass
+
 
     @unittest.skipUnless(has_gpu, "no gpu detected")
     def test_gluon_trainer(self):

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -1376,10 +1376,6 @@ class TensorFlowTests(tf.test.TestCase):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
             self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
 
-        # This test does not apply if using gloo controller
-        if hvd.gloo_enabled():
-            self.skipTest("Alltoall currently does not support Gloo controller.")
-
         hvd.init()
         rank = hvd.rank()
         local_rank = hvd.local_rank()

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -1,6 +1,7 @@
 # Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 # Modifications copyright (C) 2018 Uber Technologies, Inc.
 # Modifications copyright (C) 2019 Intel Corporation
+# Modifications copyright (C) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -676,6 +677,7 @@ class TensorFlowTests(tf.test.TestCase):
                     self.evaluate(tf.reduce_all(
                         tf.equal(tf.cast(rank_tensor, tf.int32), value))),
                     "hvd.allgather produces incorrect gathered tensor")
+
 
     def test_horovod_allgather_gpu(self):
         """Test that the allgather correctly gathers 1D, 2D, 3D tensors."""
@@ -1374,6 +1376,10 @@ class TensorFlowTests(tf.test.TestCase):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
             self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
 
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
         hvd.init()
         rank = hvd.rank()
         local_rank = hvd.local_rank()
@@ -1414,6 +1420,463 @@ class TensorFlowTests(tf.test.TestCase):
             self.assertLess(err, 0.00000001,
                             "gradient %s differs from expected %s, "
                             "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_alltoall_cpu(self):
+        """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+                splits = tf.convert_to_tensor([rank+1] * size, dtype=tf.int32)
+                collected = hvd.alltoall(tensor, splits)
+
+                self.assertTrue(
+                    self.evaluate(tf.reduce_all(
+                        tf.equal(tf.cast(collected, tf.int32), rank))),
+                    "hvd.alltoall produces incorrect collected tensor")
+
+                self.assertTrue(
+                    self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
+                    "hvd.alltoall collected wrong number of values")
+
+    def test_horovod_alltoall_gpu(self):
+        """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors on GPU."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        hvd.init()
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%s" % local_rank):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+                splits = tf.convert_to_tensor([rank+1] * size, dtype=tf.int32)
+                collected = hvd.alltoall(tensor, splits)
+
+                self.assertTrue(
+                    self.evaluate(tf.reduce_all(
+                        tf.equal(tf.cast(collected, tf.int32), rank))),
+                    "hvd.alltoall produces incorrect collected tensor")
+
+                self.assertTrue(
+                    self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
+                    "hvd.alltoall collected wrong number of values")
+
+    def test_horovod_alltoall_equal_split_cpu(self):
+        """Test that the alltoall correctly distributes 1D tensors with default splitting."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+                collected = hvd.alltoall(tensor)
+
+                self.assertTrue(
+                    self.evaluate(tf.reduce_all(
+                        tf.equal(tf.cast(collected, tf.int32), rank))),
+                    "hvd.alltoall produces incorrect collected tensor")
+
+                self.assertTrue(
+                    self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
+                    "hvd.alltoall collected wrong number of values")
+
+    def test_horovod_alltoall_equal_split_gpu(self):
+        """Test that the alltoall correctly distributes 1D tensors with default splitting on GPU."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        hvd.init()
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%s" % local_rank):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+                collected = hvd.alltoall(tensor)
+
+                self.assertTrue(
+                    self.evaluate(tf.reduce_all(
+                        tf.equal(tf.cast(collected, tf.int32), rank))),
+                    "hvd.alltoall produces incorrect collected tensor")
+
+                self.assertTrue(
+                    self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
+                    "hvd.alltoall collected wrong number of values")
+
+    def test_horovod_alltoall_type_error(self):
+        """Test that the alltoall returns an error if the tensor types differ
+           across the processes."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        with tf.device("/cpu:0"):
+            if rank % 2:
+                tensor = tf.ones([size], dtype=tf.int32)
+            else:
+                tensor = tf.ones([size], dtype=tf.float32)
+
+            with self.assertRaises(tf.errors.FailedPreconditionError):
+                self.evaluate(hvd.alltoall(tensor))
+
+    def test_horovod_alltoall_equal_split_length_error(self):
+        """Test that the alltoall with default splitting returns an error if the tensor length is not a multiple
+        of the number of workers."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        with tf.device("/cpu:0"):
+            tensor = tf.ones([size + 1], dtype=tf.float32)
+
+            with self.assertRaises(tf.errors.InvalidArgumentError):
+                self.evaluate(hvd.alltoall(tensor))
+
+    def test_horovod_alltoall_splits_error(self):
+        """Test that the alltoall returns an error if the sum of the splits entries exceeds
+        the first dimension of the input tensor."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        with tf.device("/cpu:0"):
+            tensor = tf.ones([size-1], dtype=tf.float32)
+            splits = tf.ones([size], dtype=tf.int32)
+
+            with self.assertRaises(tf.errors.InvalidArgumentError):
+                self.evaluate(hvd.alltoall(tensor))
+
+    def test_horovod_alltoall_rank_error(self):
+        """Test that the alltoall returns an error if any dimension besides
+        the first is different among the tensors being processed."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        tensor_size = [2 * size] * 3
+        tensor_size[1] = 10 * (rank + 1)
+        with tf.device("/cpu:0"):
+            tensor = tf.ones(tensor_size)
+
+            with self.assertRaises(tf.errors.FailedPreconditionError):
+                self.evaluate(hvd.alltoall(tensor))
+
+    def test_horovod_alltoall_grad_cpu(self):
+        """Test the correctness of the alltoall gradient on CPU."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(tensor)
+                    splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
+                    with tf.GradientTape() as tape:
+                        collected = hvd.alltoall(tensor, splits)
+                else:
+                    splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
+                    collected = hvd.alltoall(tensor, splits)
+
+                grad_ys = tf.ones(tf.shape(collected))
+                if _executing_eagerly():
+                    grad_out = tape.gradient(collected, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(collected, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones(tensor.get_shape().as_list())
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_alltoall_grad_gpu(self):
+        """Test the correctness of the alltoall gradient on GPU."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        hvd.init()
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%s" % local_rank):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(tensor)
+                    splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
+                    with tf.GradientTape() as tape:
+                        collected = hvd.alltoall(tensor, splits)
+                else:
+                    splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
+                    collected = hvd.alltoall(tensor, splits)
+
+                grad_ys = tf.ones(tf.shape(collected))
+                if _executing_eagerly():
+                    grad_out = tape.gradient(collected, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(collected, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones(tensor.get_shape().as_list())
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_alltoall_equal_split_grad_cpu(self):
+        """Test the correctness of the alltoall gradient with default splitting on CPU."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(tensor)
+                    with tf.GradientTape() as tape:
+                        collected = hvd.alltoall(tensor)
+                else:
+                    collected = hvd.alltoall(tensor)
+
+                grad_ys = tf.ones(tf.shape(collected))
+                if _executing_eagerly():
+                    grad_out = tape.gradient(collected, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(collected, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones(tensor.get_shape().as_list())
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_alltoall_equal_split_grad_gpu(self):
+        """Test the correctness of the alltoall gradient with default splitting on GPU."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if os.environ.get('HOROVOD_MIXED_INSTALL'):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        # This test does not apply if using gloo controller
+        if hvd.gloo_enabled():
+            self.skipTest("Alltoall currently does not support Gloo controller.")
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        hvd.init()
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%s" % local_rank):
+                vals = []
+                for i in range(size):
+                  vals += [i] * (rank+1)
+                tensor = tf.convert_to_tensor(vals, dtype=dtype)
+                for _ in range(dim - 1):
+                  tensor = tf.expand_dims(tensor, axis=1)
+                  tensor = tf.concat([tensor, tensor], axis=1)
+
+                if _executing_eagerly():
+                    tensor = self.tfe.Variable(tensor)
+                    with tf.GradientTape() as tape:
+                        collected = hvd.alltoall(tensor)
+                else:
+                    collected = hvd.alltoall(tensor)
+
+                grad_ys = tf.ones(tf.shape(collected))
+                if _executing_eagerly():
+                    grad_out = tape.gradient(collected, tensor, grad_ys)
+                else:
+                    grad = tf.gradients(collected, tensor, grad_ys)[0]
+                    grad_out = self.evaluate(grad)
+
+            expected = np.ones(tensor.get_shape().as_list())
+            err = np.linalg.norm(expected - grad_out)
+            self.assertLess(err, 0.00000001,
+                            "gradient %s differs from expected %s, "
+                            "error: %s" % (grad_out, expected, str(err)))
+
 
     def test_horovod_broadcast_eager_mode_error(self):
         """Test that tries to broadcast tensorflow global variables


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR adds support for the all-to-all collective in Horovod. The all-to-all collective can be described as a combination of a scatter and gather, where each worker will scatter a tensor to each worker, while also gathering scattered data from other workers. This type of collective communication can arise in model-parallel training strategies. 

The `hvd.alltoall` function introduced in this PR is `hvd.alltoall(tensor, splits=None)`,
where `tensor` is a multi-dimensional tensor of data to scattered and `splits` is an optional 1D tensor of integers with length equal to the number of workers, describing how to split and distribute `tensor`. `splits` is applied along the first dimension of tensor. If `splits` is not provided, an equal splitting is assumed, where the first dimension is divided by the number of workers. 

To better illustrate this, here is a diagram of three workers distributing a 2D tensor using `hvd.alltoall` with default (equal) splits:


![a2a_equal](https://user-images.githubusercontent.com/5974496/88603751-a560a680-d02a-11ea-83ad-0c9979ca0a1b.png)

Alternatively, here is a diagram of three workers distributing a 2D tensor using `hvd.alltoall` with user-provided `splits` tensors:


![a2a_unequal](https://user-images.githubusercontent.com/5974496/88603777-b7dae000-d02a-11ea-8d88-ec08e4ec15b7.png)

The implementation supports TensorFlow, PyTorch, and MXNet using the MPI backend, the CUDA-aware MPI backend via `HOROVOD_GPU_ALLTOALL=MPI`, and the NCCL backend via `HOROVOD_GPU_ALLTOALL=NCCL`. 

Some limitations and points for discussion:
1. The implementation currently requires using the MPI-based controller. The reason for this limitation is that an all-to-all communication of the `splits` tensors is done before the MPI/NCCL all-to-all operation in order to determine the receive-side splits/displacements for the output (see `Controller::AlltoallGetRecvSplits` and usage in `AlltoallOp::PrepareOutputAndParams` for an example of this). The Gloo controller is currently unsupported since there is no all-to-all collective available in Gloo to be used in the controller for this purpose, however I think it is possible to implement one. 
An alternative implementation for this would be to have the coordinator gather all the `splits` arrays, similar to how for allgather the coordinator gathers all the first dimensions across the workers. However, I opted against this approach since unlike for allgather where only a single integer per worker is gathered, the coordinator would need to gather the full `splits` array for each worker for all-to-all, yielding a lot of unnecessary communication of metadata to the coordinator rank, growing with the square of the number of workers. 

2. For the NCCL backend, this implementation requires the new `ncclSend/ncclRecv` functions introduced in NCCL 2.7.0. Currently, Horovod testing uses builds with an older unsupported version of NCCL and the new tests I have implemented will be skipped in the CI in those cases. It would be good to enable testing with a supported version of NCCL to get coverage of this feature before landing this PR.