### PR TITLE
Pin pandas<1.1.0 for older framework versions that install old versions of numpy

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -123,7 +123,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" "pandas<1.1.0"
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -97,7 +97,7 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" pandas
+RUN pip install ${KERAS_PACKAGE} h5py "scipy<1.4.0" "pandas<1.1.0"
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \


### PR DESCRIPTION
Pandas 1.1.0 is incompatible with older versions of numpy, but these numpy versions are required by some older framework versions.  This results in the following error:

```
[1,1]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/pandas/compat/numpy/__init__.py", line 21, in <module>
[1,1]<stderr>:    "this version of pandas is incompatible with numpy < 1.15.4\n"
[1,1]<stderr>:ImportError: this version of pandas is incompatible with numpy < 1.15.4
[1,1]<stderr>:your numpy version is 1.14.6.
[1,1]<stderr>:Please upgrade numpy to >= 1.15.4 to use this pandas version
```

For testing, we pin pandas < 1.1.0 so older versions of numpy can be supported.