### PR TITLE
add `pip install horovod[mxnet-cu102]`

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -67,11 +67,17 @@ above is installed.
 MXNet
 ~~~~~
 
-To ensure that Horovod is built with MXNet support enabled:
+To ensure that Horovod is built with MXNet CPU support enabled:
 
 .. code-block:: bash
 
     $ HOROVOD_WITH_MXNET=1 pip install horovod[mxnet]
+
+To ensure that Horovod is built with MXNet GPU support enabled for CUDA 10.2:
+
+.. code-block:: bash
+
+    $ HOROVOD_WITH_MXNET=1 pip install horovod[mxnet-cu102]
 
 To skip MXNet, set ``HOROVOD_WITHOUT_MXNET=1`` in your environment.
 

--- a/setup.py
+++ b/setup.py
@@ -1508,7 +1508,8 @@ tensorflow_cpu_require_list = ['tensorflow-cpu']
 tensorflow_gpu_require_list = ['tensorflow-gpu']
 keras_require_list = ['keras>=2.0.8,!=2.0.9,!=2.1.0,!=2.1.1']
 pytorch_require_list = ['torch']
-mxnet_require_list = ['mxnet>=1.4.1']
+mxnet_require_list = ['mxnet-cu102>=1.4.1']
+mxnet_cpu_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         # TODO: change to 'pyspark>=3.0.0' once spark3 is released
                         'pyspark>=3.0.0.dev;python_version>="3.8"']
@@ -1565,6 +1566,7 @@ setup(name='horovod',
           'keras': keras_require_list,
           'pytorch': pytorch_require_list,
           'mxnet': mxnet_require_list,
+          'mxnet-cpu': mxnet_cpu_require_list,
           'spark': spark_require_list
       },
       python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -1508,8 +1508,8 @@ tensorflow_cpu_require_list = ['tensorflow-cpu']
 tensorflow_gpu_require_list = ['tensorflow-gpu']
 keras_require_list = ['keras>=2.0.8,!=2.0.9,!=2.1.0,!=2.1.1']
 pytorch_require_list = ['torch']
-mxnet_require_list = ['mxnet-cu102>=1.4.1']
-mxnet_cpu_require_list = ['mxnet>=1.4.1']
+mxnet_require_list = ['mxnet>=1.4.1']
+mxnet_cu102_require_list = ['mxnet-cu102>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         # TODO: change to 'pyspark>=3.0.0' once spark3 is released
                         'pyspark>=3.0.0.dev;python_version>="3.8"']
@@ -1566,7 +1566,7 @@ setup(name='horovod',
           'keras': keras_require_list,
           'pytorch': pytorch_require_list,
           'mxnet': mxnet_require_list,
-          'mxnet-cpu': mxnet_cpu_require_list,
+          'mxnet-cu102': mxnet_cu102_require_list,
           'spark': spark_require_list
       },
       python_requires='>=3.6',


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Add a separate option for pip installation with mxnet cpu build (`pip install horovod[mxnet-cpu]`). By default `pip install horovod[mxnet]` requires the GPU build. https://github.com/horovod/horovod/issues/2141

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
