### PR TITLE
Changed pthread_yield to this_thread::yield for cross platform compatibility

### DIFF
--- a/horovod/common/ops/cuda_operations.cc
+++ b/horovod/common/ops/cuda_operations.cc
@@ -16,7 +16,6 @@
 
 #include "gpu_operations.h"
 
-#include <pthread.h>
 #include <thread>
 
 namespace horovod {
@@ -102,7 +101,7 @@ public:
         if (error_check_callback) {
           error_check_callback();
         }
-        pthread_yield();
+        std::this_thread::yield();
       }
 
       if (name != "") {

--- a/horovod/common/ops/hip_operations.cc
+++ b/horovod/common/ops/hip_operations.cc
@@ -16,7 +16,6 @@
 
 #include "gpu_operations.h"
 
-#include <pthread.h>
 #include <thread>
 
 namespace horovod {
@@ -102,7 +101,7 @@ public:
         if (error_check_callback) {
           error_check_callback();
         }
-        pthread_yield();
+        std::this_thread::yield();
       }
 
       if (name != "") {

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -17,7 +17,6 @@
 
 #include <chrono>
 #include <memory>
-#include <pthread.h>
 #include <thread>
 #include <torch/extension.h>
 #include <torch/torch.h>
@@ -310,7 +309,7 @@ int PollHandle(int handle) { return handle_manager.PollHandle(handle) ? 1 : 0; }
 void WaitAndClear(int handle) {
   while (true) {
     if (handle_manager.PollHandle(handle)) break;
-    pthread_yield();
+    std::this_thread::yield();
   }
   auto status = handle_manager.ReleaseHandle(handle);
   ThrowIfError(*status);


### PR DESCRIPTION
Some platforms, like certain macOS environments, do not have `pthread_yield` available.  

This change also makes the code consistent with `timeline.cc`, which uses this yield function.