### PR TITLE
Fix for ROCm breakage - 200805

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -28,12 +28,21 @@
 #define EIGEN_USE_THREADS
 
 #if HAVE_GPU
-#include <cuda_runtime.h>
 
-// Forward declaration of AsGpuStreamValue or AsCUDAStreamValue
+#if HAVE_CUDA
+#include <cuda_runtime.h>
+using GpuStreamHandle = cudaStream_t;
+#define gpuMemsetAsync cudaMemsetAsync
+#elif HAVE_ROCM
+#include <hip/hip_runtime.h>
+using GpuStreamHandle = hipStream_t;
+#define gpuMemsetAsync hipMemsetAsync
+#endif
+
+// Forward declaration of AsGpuStreamValue
 namespace stream_executor {
 namespace gpu {
-cudaStream_t AsGpuStreamValue(Stream* stream);
+GpuStreamHandle AsGpuStreamValue(Stream* stream);
 } // namespace stream_executor
 } // namespace gpu
 #include "tensorflow/stream_executor/stream.h"
@@ -307,8 +316,9 @@ TFOpContext::AllocateZeros(int64_t num_elements, common::DataType dtype,
 #if HAVE_GPU
     auto device_context = context_->op_device_context();
     auto stream = (device_context != nullptr) ? stream_executor::gpu::AsGpuStreamValue(device_context->stream()) : 0;
-    cudaMemsetAsync((void*)zero_tensor->AccessTensor(hvd_context->GetKernelContext())->tensor_data().data(), 0,
-                zero_tensor->AccessTensor(hvd_context->GetKernelContext())->tensor_data().size(), stream);
+    void *ptr = (void*)zero_tensor->AccessTensor(hvd_context->GetKernelContext())->tensor_data().data();
+    auto size = zero_tensor->AccessTensor(hvd_context->GetKernelContext())->tensor_data().size();
+    gpuMemsetAsync(ptr, 0, size, stream);
 #endif
   } else {
     memset((void*)zero_tensor->AccessTensor(hvd_context->GetKernelContext())->tensor_data().data(), 0,


### PR DESCRIPTION
The following commit breaks ROCm support for horovod-tensorflow

https://github.com/horovod/horovod/commit/7a1c761c663eb758536c1bff62d9d9c9a032dd38

horovod build fails because the `<cuda_runtime.h>` cannot be found on the ROCm platform

This PR/commit fixes the above breakage by including the HIP runtime file (instead of the CUDA one), when compiling with ROCm.

In addition to the above change, this commit also renames a couple of cuda* names to the corresponding gpu* versions instead.

/cc @jeffdaily 