### PR TITLE
Added allgather_object utility function for TensorFlow, PyTorch, and MXNet

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -18,7 +18,7 @@ from horovod.common.util import check_extension
 check_extension('horovod.mxnet', 'HOROVOD_WITH_MXNET',
                 __file__, 'mpi_lib')
 
-from horovod.mxnet.functions import broadcast_object
+from horovod.mxnet.functions import allgather_object, broadcast_object
 from horovod.mxnet.mpi_ops import allgather
 from horovod.mxnet.mpi_ops import allreduce, allreduce_
 from horovod.mxnet.mpi_ops import alltoall

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -25,7 +25,7 @@ check_extension('horovod.tensorflow', 'HOROVOD_WITH_TENSORFLOW', __file__, 'mpi_
 
 from horovod.tensorflow import elastic
 from horovod.tensorflow.compression import Compression
-from horovod.tensorflow.functions import broadcast_object, broadcast_object_fn, broadcast_variables
+from horovod.tensorflow.functions import allgather_object, broadcast_object, broadcast_object_fn, broadcast_variables
 from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce, alltoall
 from horovod.tensorflow.mpi_ops import init, shutdown
 from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank, is_homogeneous

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -25,7 +25,7 @@ except:
 
 from horovod.torch import elastic
 from horovod.torch.compression import Compression
-from horovod.torch.functions import broadcast_object, broadcast_optimizer_state, broadcast_parameters
+from horovod.torch.functions import allgather_object, broadcast_object, broadcast_optimizer_state, broadcast_parameters
 from horovod.torch.mpi_ops import allreduce, allreduce_async, allreduce_, allreduce_async_
 from horovod.torch.mpi_ops import allgather, allgather_async
 from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_

--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -21,9 +21,9 @@ from collections.abc import Iterable
 import cloudpickle
 import torch
 
-from horovod.torch.mpi_ops import broadcast_, broadcast_async_
+from horovod.torch.mpi_ops import allgather, broadcast_, broadcast_async_
 from horovod.torch.mpi_ops import synchronize
-from horovod.torch.mpi_ops import rank
+from horovod.torch.mpi_ops import rank, size
 from horovod.torch.optimizer import DistributedOptimizer
 
 
@@ -224,3 +224,39 @@ def broadcast_object(obj, root_rank=0, name=None):
         obj = cloudpickle.load(buf)
 
     return obj
+
+
+def allgather_object(obj, name=None):
+    """
+    Serializes and allgathers an object from all other processes.
+
+    Arguments:
+        obj: An object capable of being serialized without losing any context.
+        name: Optional name to use during allgather, will default to the class
+              type.
+
+    Returns:
+        The list of objects that were allgathered across all ranks.
+    """
+    if name is None:
+        name = type(obj).__name__
+
+    def load(byte_array):
+        buf = io.BytesIO(byte_array.tobytes())
+        return cloudpickle.load(buf)
+
+    b = io.BytesIO()
+    cloudpickle.dump(obj, b)
+
+    t = torch.ByteTensor(bytearray(b.getvalue()))
+    sz = torch.IntTensor([t.shape[0]])
+
+    sizes = allgather(sz, name=name + '.sz').numpy()
+    gathered = allgather(t, name=name + '.t').numpy()
+
+    def select(i):
+        start = sizes[i - 1] if i > 0 else 0
+        end = start + sizes[i]
+        return gathered[start:end]
+
+    return [load(select(i)) for i in range(size())]

--- a/test/test_mxnet.py
+++ b/test/test_mxnet.py
@@ -609,6 +609,25 @@ class MXTests(unittest.TestCase):
         # To prevent premature shutdown from rank 0 for this test
         mx.nd.waitall()
 
+    def test_allgather_object(self):
+        hvd.init()
+
+        d = {'metric_val_1': hvd.rank()}
+        if hvd.rank() == 1:
+            d['metric_val_2'] = 42
+
+        results = hvd.allgather_object(d)
+
+        expected = [{'metric_val_1': i} for i in range(hvd.size())]
+        if hvd.size() > 1:
+            expected[1] = {'metric_val_1': 1, 'metric_val_2': 42}
+
+        self.assertEqual(len(results), hvd.size())
+        self.assertListEqual(results, expected)
+
+        # To prevent premature shutdown from rank 0 for this test
+        mx.nd.waitall()
+
     def test_horovod_alltoall(self):
         """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors."""
         hvd.init()

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -1966,6 +1966,23 @@ class TensorFlowTests(tf.test.TestCase):
             obj = bcast(obj)
             self.assertDictEqual(obj, expected_obj)
 
+    def test_allgather_object(self):
+        hvd.init()
+
+        with tf.device("/cpu:0"):
+            d = {'metric_val_1': hvd.rank()}
+            if hvd.rank() == 1:
+                d['metric_val_2'] = 42
+
+            results = hvd.allgather_object(d)
+
+            expected = [{'metric_val_1': 0}] * hvd.size()
+            if hvd.size() > 1:
+                expected[1] = {'metric_val_1': 1, 'metric_val_2': 42}
+
+            self.assertEqual(len(results), hvd.size())
+            self.assertListEqual(results, expected)
+
     def test_elastic_state(self):
         if LooseVersion(tf.__version__) < LooseVersion('1.15.0'):
             self.skipTest("Broadcasting object requires TensorFlow 1.15 or above")

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -1976,7 +1976,7 @@ class TensorFlowTests(tf.test.TestCase):
 
             results = hvd.allgather_object(d)
 
-            expected = [{'metric_val_1': 0}] * hvd.size()
+            expected = [{'metric_val_1': i} for i in range(hvd.size())]
             if hvd.size() > 1:
                 expected[1] = {'metric_val_1': 1, 'metric_val_2': 42}
 

--- a/test/test_tensorflow.py
+++ b/test/test_tensorflow.py
@@ -1967,6 +1967,9 @@ class TensorFlowTests(tf.test.TestCase):
             self.assertDictEqual(obj, expected_obj)
 
     def test_allgather_object(self):
+        if LooseVersion(tf.__version__) < LooseVersion('1.15.0'):
+            self.skipTest("Broadcasting object requires TensorFlow 1.15 or above")
+
         hvd.init()
 
         with tf.device("/cpu:0"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1442,6 +1442,22 @@ class TorchTests(unittest.TestCase):
         obj = hvd.broadcast_object(obj, root_rank=0)
         self.assertDictEqual(obj, expected_obj)
 
+    def test_allgather_object(self):
+        hvd.init()
+
+        d = {'metric_val_1': hvd.rank()}
+        if hvd.rank() == 1:
+            d['metric_val_2'] = 42
+
+        results = hvd.allgather_object(d)
+
+        expected = [{'metric_val_1': 0}] * hvd.size()
+        if hvd.size() > 1:
+            expected[1] = {'metric_val_1': 1, 'metric_val_2': 42}
+
+        self.assertEqual(len(results), hvd.size())
+        self.assertListEqual(results, expected)
+
     def test_compression_fp16(self):
         valid_dtypes = [torch.float32, torch.float64]
         invalid_dtypes = [torch.uint8, torch.int8, torch.int16,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1451,7 +1451,7 @@ class TorchTests(unittest.TestCase):
 
         results = hvd.allgather_object(d)
 
-        expected = [{'metric_val_1': 0}] * hvd.size()
+        expected = [{'metric_val_1': i} for i in range(hvd.size())]
         if hvd.size() > 1:
             expected[1] = {'metric_val_1': 1, 'metric_val_2': 42}
 


### PR DESCRIPTION
This provides a controller-agnostic function to allgather arbitrary Python objects, useful for metrics aggregation when using Gloo (or MPI without needing to install `mpi4py`).