### PR TITLE
[PyTorch] reset handle when horovod shutdown

### DIFF
--- a/horovod/torch/handle_manager.cc
+++ b/horovod/torch/handle_manager.cc
@@ -50,5 +50,11 @@ std::shared_ptr<Status> HandleManager::ReleaseHandle(int handle) {
   return status;
 }
 
+void HandleManager::Reset() {
+  std::lock_guard<std::mutex> guard(mutex_);
+  results_.clear();
+  last_handle_ = 0;
+}
+
 } // namespace torch
 } // namespace horovod

--- a/horovod/torch/handle_manager.h
+++ b/horovod/torch/handle_manager.h
@@ -34,6 +34,7 @@ public:
   void MarkDone(int handle, const Status& status);
   bool PollHandle(int handle);
   std::shared_ptr<Status> ReleaseHandle(int handle);
+  void Reset();
 
 private:
   std::atomic_int last_handle_;

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -32,7 +32,6 @@ from horovod.torch.compression import Compression
 
 # import basic methods
 init = _basics.init
-shutdown = _basics.shutdown
 is_initialized = _basics.is_initialized
 size = _basics.size
 local_size = _basics.local_size
@@ -46,6 +45,10 @@ gloo_built = _basics.gloo_built
 nccl_built = _basics.nccl_built
 ddl_built = _basics.ddl_built
 ccl_built = _basics.ccl_built
+# shutdown = _basics.shutdown
+def shutdown(*args, **kwargs):
+    mpi_lib.horovod_torch_reset()
+    return _basics.shutdown(*args, **kwargs)
 
 # import reduction op values
 Average = _basics.Average

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -339,6 +339,10 @@ int DoJoin(int device) {
   return handle;
 }
 
+void Reset() {
+  handle_manager.Reset();
+}
+
 
 PYBIND11_MODULE(mpi_lib_v2, m) {
   // allreduce
@@ -483,6 +487,7 @@ PYBIND11_MODULE(mpi_lib_v2, m) {
   // basics
   m.def("horovod_torch_poll", &PollHandle);
   m.def("horovod_torch_wait_and_clear", &WaitAndClear);
+  m.def("horovod_torch_reset", &Reset);
 }
 
 } // namespace torch


### PR DESCRIPTION
## Checklist before submitting

- [ YES ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ N/A ] Did you update the docs?
- [ N/A ] Did you write any tests to validate this change?  
- [ N/A ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

### Issue
The controller will be blocked after do scale up workers action when using **Elastic Horovod** with PyTorch.
This issue only happen in PyTorch because PyTorch need a **handle** to record a uniq tensor name index. This **handle** variable will not be reset during horovod shutdown.   

For example:   
Now we running in one worker:   
* An tensor name of rank0 is **allgather.noname.6**   

Do scale up worker to 2:   
* The first tensor name of rank0 is **allgather.noname.7** and rank1 is **allgather.noname.1**   

In this case, The controller will be blocked to waiting tensor ready forever.

### Solution
Just reset **handle** when horovod shutdown. All working well now.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
