### PR TITLE
Limit usage of size_op and local_size_op to elastic cases.

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -620,7 +620,7 @@ public:
 REGISTER_KERNEL_BUILDER(
     Name("HorovodSize").Device(DEVICE_CPU).HostMemory("size"),
     HorovodReturnScalarOp<int, common::horovod_size>);
-#if HOROVOD_GPU_BROADCAST
+#if HAVE_GPU
 REGISTER_KERNEL_BUILDER(
     Name("HorovodSize").Device(DEVICE_GPU).HostMemory("size"),
     HorovodReturnScalarOp<int, common::horovod_size>);
@@ -643,7 +643,7 @@ Output
 REGISTER_KERNEL_BUILDER(
     Name("HorovodLocalSize").Device(DEVICE_CPU).HostMemory("local_size"),
     HorovodReturnScalarOp<int, common::horovod_local_size>);
-#if HOROVOD_GPU_BROADCAST
+#if HAVE_GPU
 REGISTER_KERNEL_BUILDER(
     Name("HorovodLocalSize").Device(DEVICE_GPU).HostMemory("local_size"),
     HorovodReturnScalarOp<int, common::horovod_local_size>);
@@ -668,7 +668,7 @@ Output
 REGISTER_KERNEL_BUILDER(
     Name("HorovodRank").Device(DEVICE_CPU).HostMemory("rank"),
     HorovodReturnScalarOp<int, common::horovod_rank>);
-#if HOROVOD_GPU_BROADCAST
+#if HAVE_GPU
 REGISTER_KERNEL_BUILDER(
     Name("HorovodRank").Device(DEVICE_GPU).HostMemory("rank"),
     HorovodReturnScalarOp<int, common::horovod_rank>);
@@ -691,7 +691,7 @@ Output
 REGISTER_KERNEL_BUILDER(
     Name("HorovodLocalRank").Device(DEVICE_CPU).HostMemory("local_rank"),
     HorovodReturnScalarOp<int, common::horovod_local_rank>);
-#if HOROVOD_GPU_BROADCAST
+#if HAVE_GPU
 REGISTER_KERNEL_BUILDER(
     Name("HorovodLocalRank").Device(DEVICE_GPU).HostMemory("local_rank"),
     HorovodReturnScalarOp<int, common::horovod_local_rank>);


### PR DESCRIPTION
Recent experiments I've run indicate that the use of `size_op()` and `local_size_op()` in the TF `DistributedOptimizer` can result in degraded performance. To recover performance in non-elastic cases, this PR limits the use of these ops to elastic cases only.

This PR also corrects the use of `HOROVOD_GPU_BROADCAST` with `HAVE_GPU` to determine when to build GPU versions of these scalar ops.


