### PR TITLE
Add support for horovodrun on kubeflow/mpi-job

### DIFF
--- a/horovod/runner/common/util/env.py
+++ b/horovod/runner/common/util/env.py
@@ -23,6 +23,8 @@ LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 # List of regular expressions to ignore environment variables by.
 IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD', secret.HOROVOD_SECRET_KEY}
 
+KUBEFLOW_MPI_EXEC = '/etc/mpi/kubexec.sh'
+
 
 def is_exportable(v):
     return not any(re.match(r, v) for r in IGNORE_REGEXES)
@@ -45,3 +47,7 @@ def get_env_rank_and_size():
     # Default to rank zero and size one if there are no environment variables
     return 0, 1
 
+
+def is_kubeflow_mpi():
+    rsh_agent = os.environ.get('OMPI_MCA_plm_rsh_agent')
+    return rsh_agent == KUBEFLOW_MPI_EXEC

--- a/horovod/runner/driver/driver_service.py
+++ b/horovod/runner/driver/driver_service.py
@@ -24,7 +24,7 @@ from horovod.runner.common.service import driver_service
 from horovod.runner.common.util import codec, safe_shell_exec
 from horovod.runner.task import task_service
 from horovod.runner.util import cache, lsf, network, threads
-from horovod.runner.util.remote import get_ssh_command
+from horovod.runner.util.remote import get_remote_command
 
 
 class HorovodRunDriverService(driver_service.BasicDriverService):
@@ -102,10 +102,10 @@ def _launch_task_servers(all_host_names, local_host_names, driver_addresses,
                     driver_addresses=codec.dumps_base64(driver_addresses),
                     settings=codec.dumps_base64(settings))
         if host_name not in local_host_names:
-            command = get_ssh_command(command,
-                                      host=host_name,
-                                      port=settings.ssh_port,
-                                      identity_file=settings.ssh_identity_file)
+            command = get_remote_command(command,
+                                         host=host_name,
+                                         port=settings.ssh_port,
+                                         identity_file=settings.ssh_identity_file)
 
         if settings.verbose >= 2:
             print('Launching horovod task function: {}'.format(command))

--- a/horovod/runner/gloo_run.py
+++ b/horovod/runner/gloo_run.py
@@ -31,7 +31,7 @@ from horovod.runner.elastic.driver import ElasticDriver
 from horovod.runner.elastic.rendezvous import create_rendezvous_handler
 from horovod.runner.http.http_server import RendezvousServer
 from horovod.runner.util import network, threads
-from horovod.runner.util.remote import get_ssh_command
+from horovod.runner.util.remote import get_remote_command
 
 
 def _pad_rank(rank, size):
@@ -138,10 +138,10 @@ def _exec_command_fn(settings):
         if host_address not in local_addresses:
             local_command = quote('cd {pwd} > /dev/null 2>&1 ; {command}'
                                   .format(pwd=os.getcwd(), command=command))
-            get_ssh_command(local_command,
-                            host=host_name,
-                            port=settings.ssh_port,
-                            identity_file=settings.ssh_identity_file)
+            get_remote_command(local_command,
+                               host=host_name,
+                               port=settings.ssh_port,
+                               identity_file=settings.ssh_identity_file)
 
         if settings.verbose:
             print(command)

--- a/horovod/runner/util/lsf.py
+++ b/horovod/runner/util/lsf.py
@@ -20,7 +20,7 @@ import yaml
 
 from horovod.common.util import _cache
 from horovod.runner.common.util import safe_shell_exec
-from horovod.runner.util.remote import get_ssh_command
+from horovod.runner.util.remote import get_remote_command
 
 
 class LSFUtils:
@@ -94,7 +94,7 @@ class LSFUtils:
     @_cache
     def get_num_threads():
         """Returns the number of hardware threads."""
-        lscpu_cmd = get_ssh_command(LSFUtils._LSCPU_CMD, host=LSFUtils.get_compute_hosts()[0])
+        lscpu_cmd = get_remote_command(LSFUtils._LSCPU_CMD, host=LSFUtils.get_compute_hosts()[0])
         output = io.StringIO()
         exit_code = safe_shell_exec.execute(lscpu_cmd, stdout=output, stderr=output)
         if exit_code != 0:

--- a/horovod/runner/util/remote.py
+++ b/horovod/runner/util/remote.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from horovod.runner.common.util import env as env_util
+
 SSH_COMMAND_PREFIX = 'ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no'
 
 
@@ -20,3 +22,8 @@ def get_ssh_command(local_command, host, port=None, identity_file=None):
     port_arg = f'-p {port}' if port is not None else ''
     identity_file_arg = f'-i {identity_file}' if identity_file is not None else ''
     return f'{SSH_COMMAND_PREFIX} {host} {port_arg} {identity_file_arg} {local_command}'
+
+
+def get_remote_command(local_command, host, port=None, identity_file=None):
+    return f'{env_util.KUBEFLOW_MPI_EXEC} {host} {local_command}' if env_util.is_kubeflow_mpi() \
+        else get_ssh_command(local_command, host, port, identity_file)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

1. add ~~`is_mpi_job`~~ `is_kubeflow_mpi` under ~~`horovod/run/common/util/env.py`~~ `horovod/runner/common/util/env.py` for determining whether the environment was setup by kubeflow/mpi-operator

~~2. for all shell command with `ssh`, add revision for mpi-job with `/etc/mpi/kubexec.sh`~~

2. wrap `get_ssh_command` with `get_remote_command` to support other shell tools.


Fixes #2198.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
