### PR TITLE
Fixed computation of the offset when using allgather_object

### DIFF
--- a/horovod/mxnet/functions.py
+++ b/horovod/mxnet/functions.py
@@ -90,7 +90,7 @@ def allgather_object(obj, name=None):
     gathered = allgather(t, name=name + '.t').asnumpy()
 
     def select(i):
-        start = sizes[i - 1] if i > 0 else 0
+        start = sum(sizes[:i])
         end = start + sizes[i]
         return gathered[start:end]
 

--- a/horovod/tensorflow/functions.py
+++ b/horovod/tensorflow/functions.py
@@ -170,7 +170,7 @@ def allgather_object(obj, session=None, name=None):
     gathered = to_numpy(allgather(t, name=name + '.t'))
 
     def select(i):
-        start = sizes[i - 1] if i > 0 else 0
+        start = sum(sizes[:i])
         end = start + sizes[i]
         return gathered[start:end]
 

--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -255,7 +255,7 @@ def allgather_object(obj, name=None):
     gathered = allgather(t, name=name + '.t').numpy()
 
     def select(i):
-        start = sizes[i - 1] if i > 0 else 0
+        start = sum(sizes[:i])
         end = start + sizes[i]
         return gathered[start:end]
 


### PR DESCRIPTION
When running with `np > 2` this becomes an issue as the `size[2]` does not correspond to the `offset[2]`.