### PR TITLE
Dynamic timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added Ray integration. ([#2218](https://github.com/horovod/horovod/pull/2218))
 
+- Added ability to dynamically start and stop timeline programmatically. ([#2129](https://github.com/horovod/horovod/pull/2129))
+
 ### Changed
 
 - Moved `horovod.run.runner.run` to `horovod.run`. ([#2099](https://github.com/horovod/horovod/pull/2099))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added Ray integration. ([#2218](https://github.com/horovod/horovod/pull/2218))
 
-- Added ability to dynamically start and stop timeline programmatically. ([#2129](https://github.com/horovod/horovod/pull/2129))
+- Added ability to dynamically start and stop timeline programmatically. ([#2215](https://github.com/horovod/horovod/pull/2215))
 
 ### Changed
 

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -72,6 +72,31 @@ class HorovodBasics(object):
         """Returns True if Horovod is initialized"""
         return self.MPI_LIB_CTYPES.horovod_is_initialized()
 
+    def start_timeline(self, file_path, mark_cycles=False):
+        """Creates a timeline file at `file_path` and begins recording.
+
+        Args:
+            file_path: String path to the timeline file.
+            mark_cycles: Boolean indicating that cycles should be marked on
+                         the timeline (default: False).
+
+        Raises a `ValueError` if Horovod is not initialized.
+        """
+        result = self.MPI_LIB_CTYPES.horovod_start_timeline(
+            ctypes.c_char_p(file_path.encode('utf-8')),
+            ctypes.c_bool(mark_cycles))
+        if not result:
+            raise ValueError('Horovod has not been initialized; use hvd.init().')
+
+    def stop_timeline(self):
+        """Stops the active timeline recording and closes the file.
+
+        Raises a `ValueError` if Horovod is not initialized.
+        """
+        result = self.MPI_LIB_CTYPES.horovod_stop_timeline()
+        if not result:
+            raise ValueError('Horovod has not been initialized; use hvd.init().')
+
     def size(self):
         """A function that returns the number of Horovod processes.
 

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -859,5 +859,40 @@ bool Controller::IncrementTensorCount(const Request& msg, int joined_size) {
   return ready_to_reduce;
 }
 
+void Controller::SetTimelineEnabled(bool value) {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  timeline_enabled_pending_ = value;
+  timeline_enabled_ = value;
+}
+
+void Controller::SetTimelineEnabledPending(bool value) {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  timeline_enabled_pending_ = value;
+}
+
+void Controller::SetMarkCyclesInTimelinePending(bool value) {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  mark_cycles_in_timeline_pending_ = value;
+}
+
+void Controller::SynchronizeTimelineEnabled() {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  timeline_enabled_ = timeline_enabled_pending_;
+}
+
+bool Controller::TimeLineEnabled() {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  return timeline_enabled_;
+}
+
+bool Controller::TimelineEnabledPending() {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  return timeline_enabled_pending_;
+}
+
+bool Controller::MarkCyclesInTimelinePending() {
+  std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+  return mark_cycles_in_timeline_pending_;
+}
 } // namespace common
 } // namespace horovod

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -117,7 +117,12 @@ public:
   void SetTimelineEnabled(bool value) { timeline_enabled_pending_ = value; timeline_enabled_ = value;}
   void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
   void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
-  void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load(); std::cout<< "Timeline synchronized\n";}
+  void SynchronizeTimelineEnabled() {
+    if(timeline_enabled_.load() != timeline_enabled_pending_.load()) {
+      timeline_enabled_ = timeline_enabled_pending_.load();
+      std::cout<< "Timeline synchronized\n";
+    }
+  }
   inline bool TimeLineEnabledSynchronized() { return timeline_enabled_.load() == timeline_enabled_pending_.load();}
   inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
   inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -119,29 +119,33 @@ public:
     timeline_enabled_pending_ = value;
     timeline_enabled_ = value;
   }
+
   void SetTimelineEnabledPending(bool value) {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     timeline_enabled_pending_ = value;
   }
+
   void SetMarkCyclesInTimelinePending(bool value) {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     mark_cycles_in_timeline_pending_ = value;
   }
+
   void SynchronizeTimelineEnabled() {
       std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
       timeline_enabled_ = timeline_enabled_pending_;
-      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_ << " Pending:" << timeline_enabled_pending_ << "\n";
   }
+
   inline bool TimeLineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     auto p = (timeline_enabled_ == timeline_enabled_pending_);
-    std::cout<< "timeline_enabled_ " << timeline_enabled_ << " Pending:" << timeline_enabled_pending_ << " comparison:" << p << "\n";
     return timeline_enabled_;
   }
+
   inline bool TimelineEnabledPending() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     return timeline_enabled_pending_;
   }
+
   inline bool MarkCyclesInTimelinePending() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     return mark_cycles_in_timeline_pending_;

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -123,7 +123,7 @@ public:
     if(timeline_enabled_.load() != timeline_enabled_pending_.load()) {
 
       timeline_enabled_.exchange(timeline_enabled_pending_.load());
-      timeline_enabled_pending_.exchange(timeline_enabled_.load())
+      timeline_enabled_pending_.exchange(timeline_enabled_.load());
       std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n"
     }
   }

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -131,13 +131,12 @@ public:
   }
 
   void SynchronizeTimelineEnabled() {
-      std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-      timeline_enabled_ = timeline_enabled_pending_;
+    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
+    timeline_enabled_ = timeline_enabled_pending_;
   }
 
   inline bool TimeLineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    auto p = (timeline_enabled_ == timeline_enabled_pending_);
     return timeline_enabled_;
   }
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -114,7 +114,13 @@ public:
     }
   };
 
-  void SetTimelineEnabled(bool value) { timeline_enabled_ = value; }
+  void SetTimelineEnabled(bool value) { timeline_enabled_pending_ = value; timeline_enabled_ = value;}
+  void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
+  void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
+  void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load();}
+  inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
+  inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}
+
   std::vector<int>& GetRanks() { return ranks_; };
   int GetRank() { return rank_; };
   int GetLocalRank() { return local_rank_; };
@@ -195,7 +201,10 @@ protected:
   // requests to allreduce every tensor (keyed by tensor name).
   MessageTable message_table_;
 
-  bool timeline_enabled_ = false;
+  std::atomic_bool timeline_enabled_{false};
+  std::atomic_bool timeline_enabled_pending_{false};
+  std::atomic_bool mark_cycles_in_timeline_pending_{false};
+
 
   // Outside dependencies
   TensorQueue& tensor_queue_;

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -118,7 +118,7 @@ public:
   void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
   void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
   void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load();}
-  inline bool TimeLineEnabledSynchronized() { return (timeline_enabled_ == timeline_enabled_pending_) && ;}
+  inline bool TimeLineEnabledSynchronized() { return timeline_enabled_ == timeline_enabled_pending_;}
   inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
   inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -118,8 +118,11 @@ public:
   void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
   void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
   void SynchronizeTimelineEnabled() {
+    std::cout<< " In synch timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n";
+
     if(timeline_enabled_.load() != timeline_enabled_pending_.load()) {
-      timeline_enabled_ = timeline_enabled_pending_.load();
+
+      timeline_enabled_.store(timeline_enabled_pending_.load());
       std::cout<< "Timeline synchronized\n";
     }
   }

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -122,8 +122,9 @@ public:
 
     if(timeline_enabled_.load() != timeline_enabled_pending_.load()) {
 
-      timeline_enabled_.store(timeline_enabled_pending_.load());
-      std::cout<< "Timeline synchronized\n";
+      timeline_enabled_.exchange(timeline_enabled_pending_.load());
+      timeline_enabled_pending_.exchange(timeline_enabled_.load())
+      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n"
     }
   }
   inline bool TimeLineEnabled() {

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -117,8 +117,8 @@ public:
   void SetTimelineEnabled(bool value) { timeline_enabled_pending_ = value; timeline_enabled_ = value;}
   void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
   void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
-  void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load();}
-  inline bool TimeLineEnabledSynchronized() { return timeline_enabled_ == timeline_enabled_pending_;}
+  void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load(); std::cout<< "Timeline synchronized\n";}
+  inline bool TimeLineEnabledSynchronized() { return timeline_enabled_.load() == timeline_enabled_pending_.load();}
   inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
   inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -114,42 +114,6 @@ public:
     }
   };
 
-  void SetTimelineEnabled(bool value) {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    timeline_enabled_pending_ = value;
-    timeline_enabled_ = value;
-  };
-
-  void SetTimelineEnabledPending(bool value) {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    timeline_enabled_pending_ = value;
-  };
-
-  void SetMarkCyclesInTimelinePending(bool value) {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    mark_cycles_in_timeline_pending_ = value;
-  };
-
-  void SynchronizeTimelineEnabled() {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    timeline_enabled_ = timeline_enabled_pending_;
-  };
-
-  inline bool TimeLineEnabled() {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    return timeline_enabled_;
-  };
-
-  inline bool TimelineEnabledPending() {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    return timeline_enabled_pending_;
-  };
-
-  inline bool MarkCyclesInTimelinePending() {
-    std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    return mark_cycles_in_timeline_pending_;
-  };
-
   std::vector<int>& GetRanks() { return ranks_; };
   int GetRank() { return rank_; };
   int GetLocalRank() { return local_rank_; };
@@ -160,7 +124,13 @@ public:
   const std::vector<int>& GetLocalCommRanks() { return local_comm_ranks_; };
   bool IsCoordinator() const { return is_coordinator_; };
   bool IsHomogeneous() const { return is_homogeneous_; };
-
+  void SetTimelineEnabled(bool value);
+  bool TimeLineEnabled();
+  void SetTimelineEnabledPending(bool value);
+  bool TimelineEnabledPending();
+  void SetMarkCyclesInTimelinePending(bool value);
+  bool MarkCyclesInTimelinePending();
+  void SynchronizeTimelineEnabled();
   StallInspector& GetStallInspector() { return stall_inspector_; };
 
 protected:

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -118,6 +118,7 @@ public:
   void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
   void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
   void SynchronizeTimelineEnabled() { timeline_enabled_ = timeline_enabled_pending_.load();}
+  inline bool TimeLineEnabledSynchronized() { return (timeline_enabled_ == timeline_enabled_pending_) && ;}
   inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
   inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -114,9 +114,9 @@ public:
     }
   };
 
-  void SetTimelineEnabled(bool value) { timeline_enabled_pending_ = value; timeline_enabled_ = value;}
-  void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_ = value;}
-  void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_ = value;}
+  void SetTimelineEnabled(bool value) { timeline_enabled_pending_.exchange(value); timeline_enabled_.exchange(value);}
+  void SetTimelineEnabledPending(bool value) { timeline_enabled_pending_.exchange(value);}
+  void SetMarkCyclesInTimelinePending(bool value) {mark_cycles_in_timeline_pending_.exchange(value);}
   void SynchronizeTimelineEnabled() {
     std::cout<< " In synch timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n";
 
@@ -124,7 +124,7 @@ public:
 
       timeline_enabled_.exchange(timeline_enabled_pending_.load());
       timeline_enabled_pending_.exchange(timeline_enabled_.load());
-      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n"
+      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n";
     }
   }
   inline bool TimeLineEnabled() {

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -123,7 +123,11 @@ public:
       std::cout<< "Timeline synchronized\n";
     }
   }
-  inline bool TimeLineEnabledSynchronized() { return timeline_enabled_.load() == timeline_enabled_pending_.load();}
+  inline bool TimeLineEnabled() {
+    auto p = (timeline_enabled_.load() == timeline_enabled_pending_.load());
+    std::cout<< "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << " comparison:" << p << "\n";
+    return timeline_enabled_.load();
+  }
   inline bool TimelineEnabledPending() { return timeline_enabled_pending_; }
   inline bool MarkCyclesInTimelinePending() { return mark_cycles_in_timeline_pending_;}
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -116,7 +116,7 @@ public:
 
   void SetTimelineEnabled(bool value) {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    timeline_enabled_pending = value;
+    timeline_enabled_pending_ = value;
     timeline_enabled_ = value;
   }
   void SetTimelineEnabledPending(bool value) {
@@ -130,12 +130,12 @@ public:
   void SynchronizeTimelineEnabled() {
       std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
       timeline_enabled_ = timeline_enabled_pending_;
-      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n";
+      std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_ << " Pending:" << timeline_enabled_pending_ << "\n";
   }
   inline bool TimeLineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-    auto p = (timeline_enabled_.load() == timeline_enabled_pending_.load());
-    std::cout<< "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << " comparison:" << p << "\n";
+    auto p = (timeline_enabled_ == timeline_enabled_pending_);
+    std::cout<< "timeline_enabled_ " << timeline_enabled_ << " Pending:" << timeline_enabled_pending_ << " comparison:" << p << "\n";
     return timeline_enabled_;
   }
   inline bool TimelineEnabledPending() {

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -131,11 +131,9 @@ public:
       std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
       timeline_enabled_ = timeline_enabled_pending_;
       std::cout<< "Timeline synchronized. " << "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << "\n";
-    }
   }
   inline bool TimeLineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
-
     auto p = (timeline_enabled_.load() == timeline_enabled_pending_.load());
     std::cout<< "timeline_enabled_ " << timeline_enabled_.load() << " Pending:" << timeline_enabled_pending_.load() << " comparison:" << p << "\n";
     return timeline_enabled_;

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -118,37 +118,37 @@ public:
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     timeline_enabled_pending_ = value;
     timeline_enabled_ = value;
-  }
+  };
 
   void SetTimelineEnabledPending(bool value) {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     timeline_enabled_pending_ = value;
-  }
+  };
 
   void SetMarkCyclesInTimelinePending(bool value) {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     mark_cycles_in_timeline_pending_ = value;
-  }
+  };
 
   void SynchronizeTimelineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     timeline_enabled_ = timeline_enabled_pending_;
-  }
+  };
 
   inline bool TimeLineEnabled() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     return timeline_enabled_;
-  }
+  };
 
   inline bool TimelineEnabledPending() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     return timeline_enabled_pending_;
-  }
+  };
 
   inline bool MarkCyclesInTimelinePending() {
     std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
     return mark_cycles_in_timeline_pending_;
-  }
+  };
 
   std::vector<int>& GetRanks() { return ranks_; };
   int GetRank() { return rank_; };

--- a/horovod/common/global_state.h
+++ b/horovod/common/global_state.h
@@ -57,7 +57,7 @@ struct HorovodGlobalState {
   bool timeline_enabled = false;
 
   // Flag indicating whether to mark cycles in the timeline.
-  bool mark_cycles_in_timeline = false;
+  std::atomic_bool mark_cycles_in_timeline{false};
 
   ParameterManager parameter_manager;
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -723,6 +723,8 @@ bool horovod_stop_timeline() {
     return false;
   }
 
+  horovod_global.controller->SetTimelineEnabled(false);
+
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Shutdown();

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -726,7 +726,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   horovod_global.controller->SetMarkCyclesInTimelinePending(mark_cycles);
   // block until timeline is started
   while(! horovod_global.controller->TimeLineEnabledSynchronized()){
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return true;
 }

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -703,6 +703,23 @@ bool horovod_is_initialized() {
   return horovod_global.initialization_done;
 }
 
+bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
+  if (!horovod_global.initialization_done) {
+    return false;
+  }
+  horovod_global.mark_cycles_in_timeline = mark_cycles;
+  horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  return true;
+}
+
+bool horovod_stop_timeline() {
+  if (!horovod_global.initialization_done) {
+    return false;
+  }
+  horovod_global.timeline.Shutdown();
+  return true;
+}
+
 int horovod_rank() {
   if (!horovod_global.initialization_done) {
     return -1;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -717,6 +717,10 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
     return false;
   }
   bool is_coordinator = horovod_global.controller->IsCoordinator();
+  if(horovod_global.controller->TimelineEnabledPending()){
+    LOG(INFO) << " Timeline is already enabled. Please stop timeline before restarting it.";
+    return;
+  }
   if (is_coordinator) {
     horovod_global.timeline.Initialize(std::string(file_name), horovod_global.controller->GetSize());
     horovod_global.timeline.SetPendingTimelineFile(std::string(file_name));

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -588,8 +588,9 @@ bool RunLoopOnce(HorovodGlobalState& state) {
   auto response_list =
       state.controller->ComputeResponseList(horovod_global.shut_down, state);
 
-  state.controller->SynchronizeTimelineEnabled();
   state.mark_cycles_in_timeline = state.controller->MarkCyclesInTimelinePending();
+  state.controller->SynchronizeTimelineEnabled();
+
   // Get tensor name and size data for autotuning.
   int64_t total_tensor_size = 0;
   std::vector<std::string> tensor_names;
@@ -723,6 +724,10 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   }
   horovod_global.controller->SetTimelineEnabledPending(true);
   horovod_global.controller->SetMarkCyclesInTimelinePending(mark_cycles);
+  // block until timeline is started
+  while(! horovod_global.controller->TimeLineEnabledSynchronized()){
+    std::this_thread::sleep_for(1ms);
+  }
   return true;
 }
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -719,7 +719,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if(horovod_global.controller->TimelineEnabledPending()){
     LOG(INFO) << " Timeline is already enabled. Please stop timeline before restarting it.";
-    return;
+    return true;
   }
   if (is_coordinator) {
     horovod_global.timeline.Initialize(std::string(file_name), horovod_global.controller->GetSize());
@@ -739,7 +739,10 @@ bool horovod_stop_timeline() {
   if (!horovod_global.initialization_done) {
     return false;
   }
-
+  if(!horovod_global.controller->TimelineEnabledPending()){
+    LOG(INFO) << " Timeline is already stopped. Please start timeline before stopping it.";
+    return true;
+  }
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
       horovod_global.timeline.SetPendingTimelineFile(std::string(""));

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -743,6 +743,10 @@ bool horovod_stop_timeline() {
   }
   horovod_global.controller->SetTimelineEnabledPending(false);
   horovod_global.controller->SetMarkCyclesInTimelinePending(false);
+  while(horovod_global.controller->TimeLineEnabled()){
+    std::cout<< " Stop timeline not yet synchrnonized.\n";
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
   return true;
 }
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -414,17 +414,14 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
 #endif
 
   // Open the timeline file on coordinator.
-  auto horovod_timeline = std::getenv(HOROVOD_TIMELINE);
-  if (horovod_timeline == nullptr) {
-    char *default_val = (char *)"";
-    horovod_timeline = default_val;
-  }
+  auto timeline_env = std::getenv(HOROVOD_TIMELINE);
+  auto horovod_timeline = timeline_env != nullptr ? std::string(timeline_env) : std::string("");
   bool should_enable_timeline = false;
   if (is_coordinator) {
-    state.timeline.Initialize(std::string(horovod_timeline),
+    state.timeline.Initialize(horovod_timeline,
                               static_cast<unsigned int>(size));
   }
-  if (strcmp(horovod_timeline, "") != 0) {
+  if (horovod_timeline != "") {
       should_enable_timeline = true;
   }
   state.controller->SetTimelineEnabled(should_enable_timeline);

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -726,6 +726,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   horovod_global.controller->SetMarkCyclesInTimelinePending(mark_cycles);
   // block until timeline is started
   while(! horovod_global.controller->TimeLineEnabledSynchronized()){
+    std::cout<< " Start timeline not yet synchrnonized.\n";
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return true;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -716,7 +716,6 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   if (!horovod_global.initialization_done) {
     return false;
   }
-
   bool is_coordinator = horovod_global.controller->IsCoordinator();
   if (is_coordinator) {
     horovod_global.timeline.Initialize(std::string(file_name), horovod_global.controller->GetSize());

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -725,7 +725,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   horovod_global.controller->SetTimelineEnabledPending(true);
   horovod_global.controller->SetMarkCyclesInTimelinePending(mark_cycles);
   // block until timeline is started
-  while(! horovod_global.controller->TimeLineEnabledSynchronized()){
+  while(! horovod_global.controller->TimeLineEnabled()){
     std::cout<< " Start timeline not yet synchrnonized.\n";
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -726,7 +726,7 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   horovod_global.controller->SetMarkCyclesInTimelinePending(mark_cycles);
   // block until timeline is started
   while(! horovod_global.controller->TimeLineEnabled()){
-    std::cout<< " Start timeline not yet synchrnonized.\n";
+    LOG(DEBUG)<< " Start timeline not yet synchronized.";
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return true;
@@ -744,7 +744,7 @@ bool horovod_stop_timeline() {
   horovod_global.controller->SetTimelineEnabledPending(false);
   horovod_global.controller->SetMarkCyclesInTimelinePending(false);
   while(horovod_global.controller->TimeLineEnabled()){
-    std::cout<< " Stop timeline not yet synchrnonized.\n";
+    LOG(DEBUG)<< " Stop timeline not yet synchronized.";
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return true;

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -707,8 +707,14 @@ bool horovod_start_timeline(const char* file_name, bool mark_cycles) {
   if (!horovod_global.initialization_done) {
     return false;
   }
+
+  bool is_coordinator = horovod_global.controller->IsCoordinator();
+  if (is_coordinator) {
+    horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  }
+
   horovod_global.mark_cycles_in_timeline = mark_cycles;
-  horovod_global.timeline.Initialize(file_name, horovod_global.controller->GetSize());
+  horovod_global.controller->SetTimelineEnabled(true);
   return true;
 }
 
@@ -716,7 +722,12 @@ bool horovod_stop_timeline() {
   if (!horovod_global.initialization_done) {
     return false;
   }
-  horovod_global.timeline.Shutdown();
+
+  bool is_coordinator = horovod_global.controller->IsCoordinator();
+  if (is_coordinator) {
+    horovod_global.timeline.Shutdown();
+  }
+
   return true;
 }
 

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -24,46 +24,51 @@
 namespace horovod {
 namespace common {
 
-TimelineWriter::TimelineWriter(){
+TimelineWriter::TimelineWriter() {
   cur_filename_ = "";
   new_pending_filename_ = "";
 }
 
-void TimelineWriter::SetPendingTimelineFile(std::string filename){
-    std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-    new_pending_filename_ = filename;
+void TimelineWriter::SetPendingTimelineFile(std::string filename) {
+  std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
+  new_pending_filename_ = filename;
 }
 
-std::string TimelineWriter::PendingTimelineFile(){
-    std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-    return new_pending_filename_;
+std::string TimelineWriter::PendingTimelineFile() {
+  std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
+  return new_pending_filename_;
 }
 
-void TimelineWriter::SetTimelineFile(std::string filename){
-  LOG(INFO) << "Setting TimelineFile. Current file:" << cur_filename_ << " New filename:" << filename;
+void TimelineWriter::SetTimelineFile(std::string filename) {
+  LOG(INFO) << "Setting TimelineFile. Current file:" << cur_filename_
+            << " New filename:" << filename;
   // Close if there existing file open and new file is not same as existing file
-  if (cur_filename_ != "" && cur_filename_ != filename){
-      if (file_.is_open() && file_.good()){
-        file_.close();
-        LOG(INFO) << "Closed timeline file:" << cur_filename_;
-      }
-      tensor_table_.clear();
+  if (cur_filename_ != "" && cur_filename_ != filename) {
+    if (file_.is_open() && file_.good()) {
+      file_.close();
+      LOG(INFO) << "Closed timeline file:" << cur_filename_;
+    }
+    tensor_table_.clear();
   }
-  // if new filename is empty, we need to stop accepting activities. This would stopping timeline
-  if(filename == "") {
+  // if new filename is empty, we need to stop accepting activities. This would
+  // stopping timeline
+  if (filename == "") {
     cur_filename_ = filename;
     new_pending_filename_ = cur_filename_;
-    // empty filename is special which tells that init the timeline but don't activate it.
+    // empty filename is special which tells that init the timeline but don't
+    // activate it.
     healthy_ = true;
     active_ = false;
-    LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename passed is empty string";
+    LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename "
+                 "passed is empty string";
     return;
   }
-  // if newfile is same as existing file, it should be no-op and we can continue writing in existing file.
-  if(cur_filename_ == filename) {
+  // if newfile is same as existing file, it should be no-op and we can continue
+  // writing in existing file.
+  if (cur_filename_ == filename) {
     if (file_.good()) {
       LOG(INFO) << "Timeline cur_filename_ is same as existing filename:"
-                << filename << " Set active and healthy to true" ;
+                << filename << " Set active and healthy to true";
       cur_filename_ = filename;
       new_pending_filename_ = cur_filename_;
       is_new_file_ = false;
@@ -71,18 +76,20 @@ void TimelineWriter::SetTimelineFile(std::string filename){
       active_ = true;
       return;
     } else {
-        LOG(ERROR) << "Filename:" << filename
-                  << " is not good. Setting healthy to true and active to false since file is not good";
-        cur_filename_ = filename;
-        new_pending_filename_ = cur_filename_;
-        healthy_ = true;
-        active_ = false;
+      LOG(ERROR) << "Filename:" << filename
+                 << " is not good. Setting healthy to true and active to false "
+                    "since file is not good";
+      cur_filename_ = filename;
+      new_pending_filename_ = cur_filename_;
+      healthy_ = true;
+      active_ = false;
     }
   }
   // all other cases, need to create a new file
   file_.open(filename, std::ios::out | std::ios::trunc);
   if (file_.good()) {
-    LOG(INFO) << "Opened new timeline file" << filename << " Set active and healthy to true";
+    LOG(INFO) << "Opened new timeline file" << filename
+              << " Set active and healthy to true";
     cur_filename_ = filename;
     new_pending_filename_ = cur_filename_;
     is_new_file_ = true;
@@ -96,12 +103,18 @@ void TimelineWriter::SetTimelineFile(std::string filename){
   }
 }
 
-void TimelineWriter::Initialize(std::string file_name, std::chrono::steady_clock::time_point start_time_) {
+void TimelineWriter::Initialize(
+    std::string file_name, std::chrono::steady_clock::time_point start_time_) {
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
-  auto tt = std::chrono::duration_cast<std::chrono::microseconds>(start_time_ - std::chrono::steady_clock::now()).count();
-  start_time_since_epoch_utc_micros_ = std::chrono::duration_cast<std::chrono::microseconds>(
-                    p1.time_since_epoch()).count() + tt;
+  auto tt = std::chrono::duration_cast<std::chrono::microseconds>(
+                start_time_ - std::chrono::steady_clock::now())
+                .count();
+  start_time_since_epoch_utc_micros_ =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          p1.time_since_epoch())
+          .count() +
+      tt;
   // Spawn writer thread.
   writer_thread_ = std::thread(&TimelineWriter::WriterLoop, this);
 }
@@ -110,15 +123,15 @@ void TimelineWriter::Shutdown() {
   active_ = false;
   healthy_ = false;
   try {
-    if (writer_thread_.joinable()){
-        writer_thread_.join();
+    if (writer_thread_.joinable()) {
+      writer_thread_.join();
     }
-  } catch(const std::system_error& e) {
-    LOG(INFO) << "Caught system_error while joining writer thread. Code " << e.code()
-              << " meaning " << e.what();
+  } catch (const std::system_error& e) {
+    LOG(INFO) << "Caught system_error while joining writer thread. Code "
+              << e.code() << " meaning " << e.what();
   }
 
-  if (cur_filename_ != "" && file_.is_open() && file_.good()){
+  if (cur_filename_ != "" && file_.is_open() && file_.good()) {
     file_.close();
   }
   tensor_table_.clear();
@@ -151,32 +164,34 @@ void TimelineWriter::EnqueueWriteMarker(const std::string& name,
     ;
 }
 
-void TimelineWriter::WriteAtFileStart(){
-    file_ << "[\n";
+void TimelineWriter::WriteAtFileStart() {
+  file_ << "[\n";
 
-    file_ << "{";
-    file_ << "\"name\": \"process_name\"";
-    // Note name of process can be given in args{"name:"}
-    file_ << ", \"ph\": \"M\"";
-    file_ << ", \"pid\": " << 0 << "";
-    file_ << ", \"args\": {\"start_time_since_epoch_in_micros\":" << start_time_since_epoch_utc_micros_ << "}";
-    file_ << "}," << std::endl;
-    file_ << "{";
-    file_ << "\"name\": \"process_sort_index\"";
-    file_ << ", \"ph\": \"M\"";
-    file_ << ", \"pid\": " << 0 << "";
-    file_ << ", \"args\": {\"sort_index\": " << 0 << "}";
-    file_ << "}," << std::endl;
+  file_ << "{";
+  file_ << "\"name\": \"process_name\"";
+  // Note name of process can be given in args{"name:"}
+  file_ << ", \"ph\": \"M\"";
+  file_ << ", \"pid\": " << 0 << "";
+  file_ << ", \"args\": {\"start_time_since_epoch_in_micros\":"
+        << start_time_since_epoch_utc_micros_ << "}";
+  file_ << "}," << std::endl;
+  file_ << "{";
+  file_ << "\"name\": \"process_sort_index\"";
+  file_ << ", \"ph\": \"M\"";
+  file_ << ", \"pid\": " << 0 << "";
+  file_ << ", \"args\": {\"sort_index\": " << 0 << "}";
+  file_ << "}," << std::endl;
 }
 void TimelineWriter::DoWriteEvent(const TimelineRecord& r) {
   assert(r.type == TimelineRecordType::EVENT);
-  if(is_new_file_){
+  if (is_new_file_) {
     WriteAtFileStart();
     is_new_file_ = false;
   } else {
-    // last event closed the json ']' , need to seek to one position back and write ',' to continue
+    // last event closed the json ']' , need to seek to one position back and
+    // write ',' to continue
     long pos = file_.tellp();
-    file_.seekp (pos-1);
+    file_.seekp(pos - 1);
     file_ << ",";
   }
   auto& tensor_idx = tensor_table_[r.tensor_name];
@@ -218,13 +233,14 @@ void TimelineWriter::DoWriteEvent(const TimelineRecord& r) {
 
 void TimelineWriter::DoWriteMarker(const TimelineRecord& r) {
   assert(r.type == TimelineRecordType::MARKER);
-  if(is_new_file_){
+  if (is_new_file_) {
     WriteAtFileStart();
     is_new_file_ = false;
   } else {
-    // last event closed the json ']' , need to seek to one position back and write ',' to continue
+    // last event closed the json ']' , need to seek to one position back and
+    // write ',' to continue
     long pos = file_.tellp();
-    file_.seekp (pos-1);
+    file_.seekp(pos - 1);
     file_ << ",";
   }
   file_ << "{";
@@ -234,7 +250,6 @@ void TimelineWriter::DoWriteMarker(const TimelineRecord& r) {
   file_ << ", \"s\": \"g\"";
   // We make sure that the events are written always produce valid json file
   file_ << "}]";
-
 }
 
 void TimelineWriter::WriterLoop() {
@@ -259,16 +274,16 @@ void TimelineWriter::WriterLoop() {
         active_ = false;
       }
     }
-    if(!active_){
+    if (!active_) {
       // drain record_queue
-      while(!record_queue_.empty()){
+      while (!record_queue_.empty()) {
         record_queue_.pop();
       }
     }
     // check if we need to call SetTimeLineFile
     std::string pending_timeline_file = PendingTimelineFile();
     if (pending_timeline_file != cur_filename_) {
-        SetTimelineFile(pending_timeline_file);
+      SetTimelineFile(pending_timeline_file);
     }
     // Allow scheduler to schedule other work for this core.
     std::this_thread::yield();
@@ -337,8 +352,7 @@ void Timeline::NegotiateStart(const std::string& tensor_name,
   }
 
   assert(tensor_states_[tensor_name] == TimelineState::UNKNOWN);
-  auto event_category =
-      "NEGOTIATE_" + Request::RequestType_Name(request_type);
+  auto event_category = "NEGOTIATE_" + Request::RequestType_Name(request_type);
   WriteEvent(tensor_name, 'B', event_category);
   tensor_states_[tensor_name] = TimelineState::NEGOTIATING;
 }
@@ -445,8 +459,8 @@ void Timeline::MarkCycleStart() {
 }
 
 void Timeline::SetPendingTimelineFile(std::string filename) {
-    writer_.SetPendingTimelineFile(filename);
-    LOG(INFO) << "Set pending timeline file to " << filename;
+  writer_.SetPendingTimelineFile(filename);
+  LOG(INFO) << "Set pending timeline file to " << filename;
 }
 } // namespace common
 } // namespace horovod

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -164,7 +164,7 @@ void TimelineWriter::Initialize(
   std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
   if(healthy_) return;
 
-  std::cout<< " Initializing TimelineWriter with filename" << filename << "\n";
+  std::cout<< " Initializing TimelineWriter with filename" << file_name << "\n";
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
   auto tt = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -39,8 +39,13 @@ void TimelineWriter::SetPendingTimelineFile(std::string filename) {
   while (pending_status_.load()) {
     LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
                   "pending_status is still true.";
-    std::cout << "StopTimeline is called. Blocking thread since "
-                 "pending_status is still true.";
+    if(filename==""){
+        std::cout << "StopTimeline is called. Blocking thread since "
+                    "pending_status is still true.\n";
+    } else {
+        std::cout << "StartTimeline is called. Blocking thread since "
+                    "pending_status is still true.\n";
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -39,6 +39,8 @@ void TimelineWriter::SetPendingTimelineFile(std::string filename) {
   while (pending_status_.load()) {
     LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
                   "pending_status is still true.";
+    std::cout << "StopTimeline is called. Blocking thread since "
+                 "pending_status is still true.";
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
@@ -75,6 +77,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     // activate it.
     healthy_ = true;
     active_ = false;
+    pending_status = false;
     LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename "
                  "passed is empty string";
     return;
@@ -90,6 +93,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       is_new_file_ = false;
       healthy_ = true;
       active_ = true;
+      pending_status = false;
       return;
     } else {
       LOG(ERROR) << "Filename:" << filename

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -27,7 +27,6 @@ namespace common {
 TimelineWriter::TimelineWriter(){
   cur_filename_ = "";
   new_pending_filename_ = "";
-  start_time_ = std::chrono::steady_clock::now();
 }
 
 void TimelineWriter::SetPendingTimelineFile(std::string filename){
@@ -97,7 +96,7 @@ void TimelineWriter::SetTimelineFile(std::string filename){
   }
 }
 
-void TimelineWriter::Initialize(std::string file_name) {
+void TimelineWriter::Initialize(std::string file_name, std::chrono::steady_clock::time_point start_time_) {
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
   auto tt = std::chrono::duration_cast<std::chrono::microseconds>(start_time_ - std::chrono::steady_clock::now()).count();
@@ -280,8 +279,10 @@ void Timeline::Initialize(std::string file_name, unsigned int horovod_size) {
   if (initialized_) {
     return;
   }
+  start_time_ = std::chrono::steady_clock::now();
+
   // Start the writer.
-  writer_.Initialize(file_name);
+  writer_.Initialize(file_name, start_time_);
 
   // Initialize if we were able to open the file successfully.
   initialized_ = writer_.IsHealthy();

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -67,8 +67,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
 
   LOG(INFO) << "Setting TimelineFile. Current file:" << cur_filename_
             << " New filename:" << filename;
-  std::cout << "Setting TimelineFile. Current file:" << cur_filename_
-            << " New filename:" << filename << "\n";
 
   // Close if there existing file open and new file is not same as existing file
   if (cur_filename_ != "" && cur_filename_ != filename) {
@@ -76,9 +74,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     if (!record_queue_.empty()) {
       LOG(DEBUG) << " SetTimelineFile is no-op as there are events in "
                     "record_queue. Will allow those events to be dumped.";
-      std::cout << " SetTimelineFile is no-op as there are events in "
-                   "record_queue. Will allow those events to be dumped."
-                << "\n";
       active_ = false;
       // Give chance to dump existing event
       return;
@@ -86,7 +81,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     if (file_.is_open()) {
       file_.close();
       LOG(INFO) << "Closed timeline file:" << cur_filename_;
-      std::cout << "Closed timeline file:" << cur_filename_ << "\n";
     }
     tensor_table_.clear();
   }
@@ -104,9 +98,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     pending_status_ = false;
     LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename "
                  "passed is empty string";
-    std::cout << "Inited TimelineWriter but active_ is false, since filename "
-                 "passed is empty string"
-              << "\n";
     return;
   }
   // if newfile is same as existing file, it should be no-op and we can continue
@@ -115,9 +106,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     if (file_.good()) {
       LOG(INFO) << "Timeline cur_filename_ is same as existing filename:"
                 << filename << " Set active and healthy to true";
-      std::cout << "Timeline cur_filename_ is same as existing filename:"
-                << filename << " Set active and healthy to true"
-                << "\n";
       cur_filename_ = filename;
       new_pending_filename_ = cur_filename_;
       is_new_file_ = false;
@@ -129,10 +117,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       LOG(ERROR) << "Filename:" << filename
                  << " is not good. Setting healthy to true and active to false "
                     "since file is not good";
-      std::cout << "Filename:" << filename
-                << " is not good. Setting healthy to true and active to false "
-                   "since file is not good"
-                << "\n";
       cur_filename_ = filename;
       new_pending_filename_ = cur_filename_;
       healthy_ = true;
@@ -146,8 +130,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
   if (file_.good()) {
     LOG(INFO) << "Opened new timeline file" << filename
               << " Set active and healthy to true";
-    std::cout << "Opened new timeline file" << filename
-              << " Set active and healthy to true\n";
     cur_filename_ = filename;
     new_pending_filename_ = cur_filename_;
     is_new_file_ = true;
@@ -156,8 +138,6 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
   } else {
     LOG(ERROR) << "Error opening the Horovod Timeline file " << filename
                << ", will not write a timeline.";
-    std::cout << "Error opening the Horovod Timeline file " << filename
-              << ", will not write a timeline.";
     healthy_ = true;
     active_ = false;
   }
@@ -170,8 +150,6 @@ void TimelineWriter::Initialize(
   if (healthy_)
     return;
 
-  std::cout << " Initializing TimelineWriter with filename" << file_name
-            << "\n";
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
   auto tt = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -39,7 +39,7 @@ void TimelineWriter::SetPendingTimelineFile(std::string filename) {
   while (pending_status_.load()) {
     LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
                   "pending_status is still true.";
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -171,8 +171,10 @@ void Timeline::Initialize(std::string file_name, unsigned int horovod_size) {
 }
 
 void Timeline::Shutdown() {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
   initialized_ = false;
   writer_.Shutdown();
+  tensor_states_.clear();
 }
 
 long Timeline::TimeSinceStartMicros() const {

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -44,13 +44,11 @@ void TimelineWriter::SetPendingTimelineFile(std::string filename) {
          return;
        }
     }
-    LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
-                  "pending_status is still true.";
     if(filename==""){
-        std::cout << "StopTimeline is called. Blocking thread since "
+        LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
                     "pending_status is still true.\n";
     } else {
-        std::cout << "StartTimeline is called. Blocking thread since "
+        LOG(DEBUG) << "StartTimeline is called. Blocking thread since "
                     "pending_status is still true.\n";
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -68,6 +66,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
 
   LOG(INFO) << "Setting TimelineFile. Current file:" << cur_filename_
             << " New filename:" << filename;
+
   // Close if there existing file open and new file is not same as existing file
   if (cur_filename_ != "" && cur_filename_ != filename) {
 
@@ -314,12 +313,8 @@ void TimelineWriter::WriterLoop() {
     }
     {
       std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-
       // check if we need to call SetTimeLineFile
-      std::string pending_timeline_file = PendingTimelineFile();
-      if (pending_timeline_file != cur_filename_) {
-        SetTimelineFile(pending_timeline_file);
-      }
+      SetTimelineFile(PendingTimelineFile());
     }
     // Allow scheduler to schedule other work for this core.
     std::this_thread::yield();

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -44,6 +44,7 @@ void TimelineWriter::Shutdown() {
   active_ = false;
   writer_thread_.join();
   file_.close();
+  tensor_table_.clear();
 }
 
 void TimelineWriter::EnqueueWriteEvent(const std::string& tensor_name,

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -39,16 +39,16 @@ void TimelineWriter::SetPendingTimelineFile(std::string filename) {
   // block until pending_Status is applied
   while (true) {
     {
-       std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-       if(!pending_status_){
-         return;
-       }
+      std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
+      if (!pending_status_) {
+        return;
+      }
     }
-    if(filename==""){
-        LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
+    if (filename == "") {
+      LOG(DEBUG) << "StopTimeline is called. Blocking thread since "
                     "pending_status is still true.\n";
     } else {
-        LOG(DEBUG) << "StartTimeline is called. Blocking thread since "
+      LOG(DEBUG) << "StartTimeline is called. Blocking thread since "
                     "pending_status is still true.\n";
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -72,7 +72,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
 
     if (!record_queue_.empty()) {
       LOG(DEBUG) << " SetTimelineFile is no-op as there are events in "
-                  "record_queue. Will allow those events to be dumped.";
+                    "record_queue. Will allow those events to be dumped.";
       active_ = false;
       return;
     }

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -314,7 +314,8 @@ void TimelineWriter::WriterLoop() {
     {
       std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
       // check if we need to call SetTimeLineFile
-      SetTimelineFile(PendingTimelineFile());
+      if(pending_status_)
+        SetTimelineFile(PendingTimelineFile());
     }
     // Allow scheduler to schedule other work for this core.
     std::this_thread::yield();

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -77,7 +77,8 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       LOG(DEBUG) << " SetTimelineFile is no-op as there are events in "
                     "record_queue. Will allow those events to be dumped.";
       std::cout << " SetTimelineFile is no-op as there are events in "
-                    "record_queue. Will allow those events to be dumped." << "\n";
+                   "record_queue. Will allow those events to be dumped."
+                << "\n";
       active_ = false;
       // Give chance to dump existing event
       return;
@@ -104,7 +105,8 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename "
                  "passed is empty string";
     std::cout << "Inited TimelineWriter but active_ is false, since filename "
-                 "passed is empty string" << "\n";
+                 "passed is empty string"
+              << "\n";
     return;
   }
   // if newfile is same as existing file, it should be no-op and we can continue
@@ -114,7 +116,8 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       LOG(INFO) << "Timeline cur_filename_ is same as existing filename:"
                 << filename << " Set active and healthy to true";
       std::cout << "Timeline cur_filename_ is same as existing filename:"
-                << filename << " Set active and healthy to true" << "\n";
+                << filename << " Set active and healthy to true"
+                << "\n";
       cur_filename_ = filename;
       new_pending_filename_ = cur_filename_;
       is_new_file_ = false;
@@ -127,12 +130,14 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
                  << " is not good. Setting healthy to true and active to false "
                     "since file is not good";
       std::cout << "Filename:" << filename
-                 << " is not good. Setting healthy to true and active to false "
-                    "since file is not good" << "\n";
+                << " is not good. Setting healthy to true and active to false "
+                   "since file is not good"
+                << "\n";
       cur_filename_ = filename;
       new_pending_filename_ = cur_filename_;
       healthy_ = true;
       active_ = false;
+      return;
     }
   }
 
@@ -152,7 +157,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     LOG(ERROR) << "Error opening the Horovod Timeline file " << filename
                << ", will not write a timeline.";
     std::cout << "Error opening the Horovod Timeline file " << filename
-               << ", will not write a timeline.";
+              << ", will not write a timeline.";
     healthy_ = true;
     active_ = false;
   }
@@ -162,9 +167,11 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
 void TimelineWriter::Initialize(
     std::string file_name, std::chrono::steady_clock::time_point start_time_) {
   std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-  if(healthy_) return;
+  if (healthy_)
+    return;
 
-  std::cout<< " Initializing TimelineWriter with filename" << file_name << "\n";
+  std::cout << " Initializing TimelineWriter with filename" << file_name
+            << "\n";
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
   auto tt = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -210,7 +217,8 @@ void TimelineWriter::EnqueueWriteEvent(const std::string& tensor_name,
   r.ts_micros = ts_micros;
   {
     std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-    if(!active_ || !healthy_) return;
+    if (!active_ || !healthy_)
+      return;
   }
   while (healthy_ && active_ && !record_queue_.push(r))
     ;
@@ -224,7 +232,8 @@ void TimelineWriter::EnqueueWriteMarker(const std::string& name,
   r.ts_micros = ts_micros;
   {
     std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
-    if(!active_ || !healthy_) return;
+    if (!active_ || !healthy_)
+      return;
   }
   while (healthy_ && active_ && !record_queue_.push(r))
     ;
@@ -337,11 +346,13 @@ void TimelineWriter::WriterLoop() {
     {
       std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
       // check if we need to call SetTimeLineFile
-      if(pending_status_)
+      if (pending_status_)
         SetTimelineFile(PendingTimelineFile());
       if (active_ && !file_.good()) {
         LOG(ERROR) << "Error writing to the Horovod Timeline after it was "
-                      "successfully opened, will stop writing the timeline." << " eofbit:" << file_.eof() << " failbit:" << file_.fail() << " badbit"<< file_.bad() << "\n";
+                      "successfully opened, will stop writing the timeline."
+                   << " eofbit:" << file_.eof() << " failbit:" << file_.fail()
+                   << " badbit" << file_.bad() << "\n";
         active_ = false;
       }
     }

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -161,6 +161,10 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
 
 void TimelineWriter::Initialize(
     std::string file_name, std::chrono::steady_clock::time_point start_time_) {
+  std::lock_guard<std::recursive_mutex> guard(writer_mutex_);
+  if(healthy_) return;
+
+  std::cout<< " Initializing TimelineWriter with filename" << filename << "\n";
   SetTimelineFile(file_name);
   auto p1 = std::chrono::system_clock::now();
   auto tt = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -77,7 +77,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     // activate it.
     healthy_ = true;
     active_ = false;
-    pending_status = false;
+    pending_status_ = false;
     LOG(INFO) << "Inited TimelineWriter but active_ is false, since filename "
                  "passed is empty string";
     return;
@@ -93,7 +93,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       is_new_file_ = false;
       healthy_ = true;
       active_ = true;
-      pending_status = false;
+      pending_status_ = false;
       return;
     } else {
       LOG(ERROR) << "Filename:" << filename

--- a/horovod/common/timeline.cc
+++ b/horovod/common/timeline.cc
@@ -82,7 +82,7 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       // Give chance to dump existing event
       return;
     }
-    if (file_.is_open() && file_.good()) {
+    if (file_.is_open()) {
       file_.close();
       LOG(INFO) << "Closed timeline file:" << cur_filename_;
       std::cout << "Closed timeline file:" << cur_filename_ << "\n";
@@ -135,11 +135,14 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
       active_ = false;
     }
   }
+
   // all other cases, need to create a new file
   file_.open(filename, std::ios::out | std::ios::trunc);
   if (file_.good()) {
     LOG(INFO) << "Opened new timeline file" << filename
               << " Set active and healthy to true";
+    std::cout << "Opened new timeline file" << filename
+              << " Set active and healthy to true\n";
     cur_filename_ = filename;
     new_pending_filename_ = cur_filename_;
     is_new_file_ = true;
@@ -147,6 +150,8 @@ void TimelineWriter::SetTimelineFile(std::string filename) {
     active_ = true;
   } else {
     LOG(ERROR) << "Error opening the Horovod Timeline file " << filename
+               << ", will not write a timeline.";
+    std::cout << "Error opening the Horovod Timeline file " << filename
                << ", will not write a timeline.";
     healthy_ = true;
     active_ = false;
@@ -182,7 +187,7 @@ void TimelineWriter::Shutdown() {
               << e.code() << " meaning " << e.what();
   }
 
-  if (cur_filename_ != "" && file_.is_open() && file_.good()) {
+  if (cur_filename_ != "" && file_.is_open()) {
     file_.close();
   }
   tensor_table_.clear();
@@ -332,7 +337,7 @@ void TimelineWriter::WriterLoop() {
         SetTimelineFile(PendingTimelineFile());
       if (active_ && !file_.good()) {
         LOG(ERROR) << "Error writing to the Horovod Timeline after it was "
-                      "successfully opened, will stop writing the timeline.";
+                      "successfully opened, will stop writing the timeline." << " eofbit:" << file_.eof() << " failbit:" << file_.fail() << " badbit"<< file_.bad() << "\n";
         active_ = false;
       }
     }

--- a/horovod/common/timeline.h
+++ b/horovod/common/timeline.h
@@ -47,7 +47,7 @@ struct TimelineRecord {
 
 class TimelineWriter {
 public:
-  void Initialize(std::string file_name);
+  void Initialize(std::string file_name, std::chrono::steady_clock::time_point start_time_);
   void Shutdown();
   inline bool IsHealthy() const { return healthy_; }
   inline bool Active() const { return active_; }
@@ -62,6 +62,7 @@ private:
   void DoWriteEvent(const TimelineRecord& r);
   void DoWriteMarker(const TimelineRecord& r);
   void WriterLoop();
+  void WriteAtFileStart();
   std::string PendingTimelineFile();
   void SetTimelineFile(std::string filename);
 
@@ -89,6 +90,8 @@ private:
   std::string cur_filename_;
   std::string new_pending_filename_;
   bool is_new_file_;
+  // stores actual wall clock when horovod timeline was initialized
+  long long start_time_since_epoch_utc_micros_;
   // mutex that protects timeline writer state
   std::recursive_mutex writer_mutex_;
 
@@ -135,8 +138,6 @@ private:
 
   // Time point when Horovod was started.
   std::chrono::steady_clock::time_point start_time_;
-  // stores actual wall clock when horovod timeline was initialized
-  long long start_time_since_epoch_utc_micros_;
 
   // A mutex that guards timeline state from concurrent access.
   std::recursive_mutex mutex_;

--- a/horovod/common/timeline.h
+++ b/horovod/common/timeline.h
@@ -75,7 +75,7 @@ private:
   // to false.
   std::atomic_bool active_{false};
 
-  std::atomic_bool pending_status_{false};
+  bool pending_status_;
 
   // Timeline file.
   std::ofstream file_;

--- a/horovod/common/timeline.h
+++ b/horovod/common/timeline.h
@@ -135,6 +135,8 @@ private:
 
   // Time point when Horovod was started.
   std::chrono::steady_clock::time_point start_time_;
+  // stores actual wall clock when horovod timeline was initialized
+  long long start_time_since_epoch_utc_micros_;
 
   // A mutex that guards timeline state from concurrent access.
   std::recursive_mutex mutex_;

--- a/horovod/common/timeline.h
+++ b/horovod/common/timeline.h
@@ -75,6 +75,8 @@ private:
   // to false.
   std::atomic_bool active_{false};
 
+  std::atomic_bool pending_status_{false};
+
   // Timeline file.
   std::ofstream file_;
 

--- a/horovod/common/timeline.h
+++ b/horovod/common/timeline.h
@@ -47,7 +47,8 @@ struct TimelineRecord {
 
 class TimelineWriter {
 public:
-  void Initialize(std::string file_name, std::chrono::steady_clock::time_point start_time_);
+  void Initialize(std::string file_name,
+                  std::chrono::steady_clock::time_point start_time_);
   void Shutdown();
   inline bool IsHealthy() const { return healthy_; }
   inline bool Active() const { return active_; }
@@ -66,12 +67,12 @@ private:
   std::string PendingTimelineFile();
   void SetTimelineFile(std::string filename);
 
-
-
-  // Are we healthy?  Queue no longer accepts new work items and stops draining immediately when false.
+  // Are we healthy?  Queue no longer accepts new work items and stops draining
+  // immediately when false.
   std::atomic_bool healthy_{false};
 
-  // Similar to healthy, but allows queue to be drained before closing when set to false.
+  // Similar to healthy, but allows queue to be drained before closing when set
+  // to false.
   std::atomic_bool active_{false};
 
   // Timeline file.
@@ -94,7 +95,6 @@ private:
   long long start_time_since_epoch_utc_micros_;
   // mutex that protects timeline writer state
   std::recursive_mutex writer_mutex_;
-
 };
 
 enum TimelineState { UNKNOWN, NEGOTIATING, TOP_LEVEL, ACTIVITY };

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -19,6 +19,7 @@ import keras.backend as K
 from horovod.tensorflow import init
 from horovod.tensorflow import shutdown
 from horovod.tensorflow import size
+from horovod.tensorflow import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow import local_size
 from horovod.tensorflow import rank
 from horovod.tensorflow import local_rank

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -24,6 +24,7 @@ from horovod.mxnet.mpi_ops import allreduce, allreduce_
 from horovod.mxnet.mpi_ops import alltoall
 from horovod.mxnet.mpi_ops import broadcast, broadcast_
 from horovod.mxnet.mpi_ops import init, shutdown
+from horovod.mxnet.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.mxnet.mpi_ops import size, local_size, rank, local_rank
 from horovod.mxnet.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.mxnet.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -28,6 +28,9 @@ _basics = _HorovodBasics(__file__, 'mpi_lib')
 # import basic methods
 init = _basics.init
 shutdown = _basics.shutdown
+is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -28,6 +28,7 @@ from horovod.tensorflow.compression import Compression
 from horovod.tensorflow.functions import allgather_object, broadcast_object, broadcast_object_fn, broadcast_variables
 from horovod.tensorflow.mpi_ops import allgather, broadcast, _allreduce, alltoall
 from horovod.tensorflow.mpi_ops import init, shutdown
+from horovod.tensorflow.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow.mpi_ops import size, local_size, rank, local_rank, is_homogeneous
 from horovod.tensorflow.mpi_ops import rank_op, local_rank_op, size_op, local_size_op
 from horovod.tensorflow.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -22,6 +22,7 @@ from tensorflow.python.keras import backend as K
 
 from horovod.tensorflow import init
 from horovod.tensorflow import shutdown
+from horovod.tensorflow import is_initialized, start_timeline, stop_timeline
 from horovod.tensorflow import size
 from horovod.tensorflow import local_size
 from horovod.tensorflow import rank

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -50,6 +50,9 @@ _basics = _HorovodBasics(__file__, 'mpi_lib')
 # import basic methods
 init = _basics.init
 shutdown = _basics.shutdown
+is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -32,7 +32,8 @@ from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadc
 from horovod.torch.mpi_ops import alltoall, alltoall_async
 from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
-from horovod.torch.mpi_ops import init, shutdown, is_initialized, start_timeline, stop_timeline
+from horovod.torch.mpi_ops import init, shutdown
+from horovod.torch.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank
 from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -32,7 +32,7 @@ from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadc
 from horovod.torch.mpi_ops import alltoall, alltoall_async
 from horovod.torch.mpi_ops import join
 from horovod.torch.mpi_ops import poll, synchronize
-from horovod.torch.mpi_ops import init, shutdown, is_initialized
+from horovod.torch.mpi_ops import init, shutdown, is_initialized, start_timeline, stop_timeline
 from horovod.torch.mpi_ops import size, local_size, rank, local_rank
 from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.torch.mpi_ops import gloo_enabled, gloo_built

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -33,6 +33,8 @@ from horovod.torch.compression import Compression
 # import basic methods
 init = _basics.init
 is_initialized = _basics.is_initialized
+start_timeline = _basics.start_timeline
+stop_timeline = _basics.stop_timeline
 size = _basics.size
 local_size = _basics.local_size
 rank = _basics.rank

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -42,7 +42,7 @@ class TimelineTests(unittest.TestCase):
                 hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
 
                 # Wait for it to register in the timeline.
-                time.sleep(0.1)
+                hvd.stop_timeline()
 
                 if hvd.rank() == 0:
                     with open(t, 'r') as tf:

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -42,13 +42,11 @@ class TimelineTests(unittest.TestCase):
                 hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
 
                 # Wait for it to register in the timeline.
-                time.sleep(0.2)
+                time.sleep(0.1)
 
                 if hvd.rank() == 0:
                     with open(t, 'r') as tf:
                         timeline_text = tf.read()
-                        print("Timeline text is : ")
-                        print(timeline_text + "\n")
                         assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                         assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                         assert 'ALLREDUCE' in timeline_text, timeline_text

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
 import torch
 import unittest
 import warnings

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -16,6 +16,7 @@
 import torch
 import unittest
 import warnings
+import time
 
 import horovod.torch as hvd
 from horovod.common.util import env
@@ -41,11 +42,13 @@ class TimelineTests(unittest.TestCase):
                 hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
 
                 # Wait for it to register in the timeline.
-                hvd.stop_timeline()
+                time.sleep(0.2)
 
                 if hvd.rank() == 0:
                     with open(t, 'r') as tf:
                         timeline_text = tf.read()
+                        print("Timeline text is : ")
+                        print(timeline_text + "\n")
                         assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                         assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                         assert 'ALLREDUCE' in timeline_text, timeline_text

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2139,6 +2139,7 @@ class TorchTests(unittest.TestCase):
             if hvd.rank() == 0:
                 with open(fname, 'r') as timeline_file:
                     timeline_text = timeline_file.read()
+                    print(timeline_text)
                     assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text
@@ -2194,7 +2195,7 @@ class TorchTests(unittest.TestCase):
             # again start timeline with same file
             hvd.start_timeline(fname5, mark_cycles=False)
             hvd.start_timeline(fname5, mark_cycles=False)
-            hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            summed = hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             hvd.stop_timeline()
             check_file(fname5, check_cycle=False)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2152,7 +2152,7 @@ class TorchTests(unittest.TestCase):
             hvd.start_timeline(fname1, mark_cycles=True)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
-            # before calling stop so that events can be registered in timeline file.
+            # before calling stop so that mark_cycle events can be registered in timeline file.
             time.sleep(0.2)
             hvd.stop_timeline()
 
@@ -2171,25 +2171,20 @@ class TorchTests(unittest.TestCase):
         # Test resuming with a different filename, but mark_cycles=False
         with temppath() as fname3:
             # Make sure that last stop timeline has been processed.
-            time.sleep(0.2)
             hvd.start_timeline(fname3, mark_cycles=False)
-            time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname3, check_cycle=False)
 
         # Test resuming with a different filename, but mark_cycles=True
         with temppath() as fname4:
             # Make sure that last stop timeline has been processed.
-            time.sleep(0.2)
             hvd.start_timeline(fname4, mark_cycles=True)
-            time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
-            # before calling stop so that events can be registered in timeline file.
+            # before calling stop so that mark_cycle events can be registered in timeline file.
             time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname4, check_cycle=True)
@@ -2197,16 +2192,11 @@ class TorchTests(unittest.TestCase):
         # Do 2 continous start
         with temppath() as fname5:
             # again start timeline with same file
-            time.sleep(0.2)
-            hvd.start_timeline(fname5, mark_cycles=True)
-            hvd.start_timeline(fname5, mark_cycles=True)
-            time.sleep(0.2)
+            hvd.start_timeline(fname5, mark_cycles=False)
+            hvd.start_timeline(fname5, mark_cycles=False)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
-            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
-            # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
             hvd.stop_timeline()
-            check_file(fname5, check_cycle=True)
+            check_file(fname5, check_cycle=False)
 
         hvd.shutdown()
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2194,7 +2194,7 @@ class TorchTests(unittest.TestCase):
         with temppath() as fname5:
             # again start timeline with same file
             hvd.start_timeline(fname5, mark_cycles=False)
-            #hvd.start_timeline(fname5, mark_cycles=False)
+            hvd.start_timeline(fname5, mark_cycles=False)
             summed = hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             hvd.stop_timeline()
             check_file(fname5, check_cycle=False)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2153,7 +2153,7 @@ class TorchTests(unittest.TestCase):
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.stop_timeline()
 
             check_file(fname1)
@@ -2164,47 +2164,47 @@ class TorchTests(unittest.TestCase):
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname2)
 
         # Test resuming with a different filename, but mark_cycles=False
         with temppath() as fname3:
             # Make sure that last stop timeline has been processed.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.start_timeline(fname3, mark_cycles=False)
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname3, check_cycle=False)
 
         # Test resuming with a different filename, but mark_cycles=True
         with temppath() as fname4:
             # Make sure that last stop timeline has been processed.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.start_timeline(fname4, mark_cycles=True)
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname4, check_cycle=True)
 
         # Do 2 continous start
         with temppath() as fname5:
             # again start timeline with same file
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.start_timeline(fname5, mark_cycles=True)
             hvd.start_timeline(fname5, mark_cycles=True)
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            #time.sleep(0.2)
+            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname5, check_cycle=True)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2153,7 +2153,7 @@ class TorchTests(unittest.TestCase):
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.stop_timeline()
 
             check_file(fname1)
@@ -2164,47 +2164,47 @@ class TorchTests(unittest.TestCase):
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname2)
 
         # Test resuming with a different filename, but mark_cycles=False
         with temppath() as fname3:
             # Make sure that last stop timeline has been processed.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.start_timeline(fname3, mark_cycles=False)
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname3, check_cycle=False)
 
         # Test resuming with a different filename, but mark_cycles=True
         with temppath() as fname4:
             # Make sure that last stop timeline has been processed.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.start_timeline(fname4, mark_cycles=True)
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname4, check_cycle=True)
 
         # Do 2 continous start
         with temppath() as fname5:
             # again start timeline with same file
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.start_timeline(fname5, mark_cycles=True)
             hvd.start_timeline(fname5, mark_cycles=True)
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
-            time.sleep(0.2)
+            #time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname5, check_cycle=True)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2139,7 +2139,6 @@ class TorchTests(unittest.TestCase):
             if hvd.rank() == 0:
                 with open(fname, 'r') as timeline_file:
                     timeline_text = timeline_file.read()
-                    print(timeline_text)
                     assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2139,22 +2139,18 @@ class TorchTests(unittest.TestCase):
             if hvd.rank() == 0:
                 with open(fname, 'r') as timeline_file:
                     timeline_text = timeline_file.read()
-                    print("Timeline text is : ")
-                    print(timeline_text + "\n")
                     assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text
                     assert 'start_time_since_epoch_in_micros' in timeline_text, timeline_text
                     json_obj = json.loads(timeline_text)
                     assert json_obj is not None
-                    if check_cycle is True:
+                    if check_cycle:
                         assert 'CYCLE_START' in timeline_text, timeline_text
 
         with temppath() as fname1:
             hvd.start_timeline(fname1, mark_cycles=True)
-            print("Calling all reduce\n")
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
-            print("Calling stop timeline\n")
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
             # before calling stop so that events can be registered in timeline file.
             time.sleep(0.2)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -22,6 +22,7 @@ import itertools
 import os
 import unittest
 import warnings
+import time
 
 from collections.abc import Iterable
 
@@ -2133,22 +2134,26 @@ class TorchTests(unittest.TestCase):
     def test_timeline_api(self):
         hvd.init()
 
-        def check_file(fname):
+        def check_file(fname, check_cycle=True):
             if hvd.rank() == 0:
                 with open(fname, 'r') as timeline_file:
                     timeline_text = timeline_file.read()
+                    print("Timeline text is : ")
+                    print(timeline_text + "\n")
                     assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text
-                    assert 'CYCLE_START' in timeline_text, timeline_text
+                    if check_cycle is True:
+                        assert 'CYCLE_START' in timeline_text, timeline_text
 
         with temppath() as fname1:
             hvd.start_timeline(fname1, mark_cycles=True)
-
-            # Perform a simple allreduce operation
+            print("Calling all reduce\n")
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
-
-            # Wait for timeline to drain before reading it
+            print("Calling stop timeline\n")
+            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
+            # before calling stop so that events can be registered in timeline file.
+            time.sleep(0.2)
             hvd.stop_timeline()
 
             check_file(fname1)
@@ -2157,8 +2162,53 @@ class TorchTests(unittest.TestCase):
         with temppath() as fname2:
             hvd.start_timeline(fname2, mark_cycles=True)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
+            # before calling stop so that events can be registered in timeline file.
+            time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname2)
+
+        # Test resuming with a different filename, but mark_cycles=False
+        with temppath() as fname3:
+            # Make sure that last stop timeline has been processed.
+            time.sleep(0.2)
+            hvd.start_timeline(fname3, mark_cycles=False)
+            time.sleep(0.2)
+            hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
+            # before calling stop so that events can be registered in timeline file.
+            time.sleep(0.2)
+            hvd.stop_timeline()
+            check_file(fname3, check_cycle=False)
+
+        # Test resuming with a different filename, but mark_cycles=True
+        with temppath() as fname4:
+            # Make sure that last stop timeline has been processed.
+            time.sleep(0.2)
+            hvd.start_timeline(fname4, mark_cycles=True)
+            time.sleep(0.2)
+            hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
+            # before calling stop so that events can be registered in timeline file.
+            time.sleep(0.2)
+            hvd.stop_timeline()
+            check_file(fname4, check_cycle=True)
+
+        # Do 2 continous start
+        with temppath() as fname5:
+            # again start timeline with same file
+            time.sleep(0.2)
+            hvd.start_timeline(fname5, mark_cycles=True)
+            hvd.start_timeline(fname5, mark_cycles=True)
+            time.sleep(0.2)
+            hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            # stop timeline will immediately stop events to be registered in timeline. We are providing some time
+            # before calling stop so that events can be registered in timeline file.
+            time.sleep(0.2)
+            hvd.stop_timeline()
+            check_file(fname5, check_cycle=True)
+
+        hvd.shutdown()
 
 
 if __name__ == "__main__":

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2164,7 +2164,7 @@ class TorchTests(unittest.TestCase):
             hvd.start_timeline(fname2, mark_cycles=True)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
-            # before calling stop so that events can be registered in timeline file.
+            # before calling stop so that cycle events can be registered in timeline file.
             time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname2)
@@ -2185,19 +2185,10 @@ class TorchTests(unittest.TestCase):
             hvd.start_timeline(fname4, mark_cycles=True)
             hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             # stop timeline will immediately stop events to be registered in timeline. We are providing some time
-            # before calling stop so that mark_cycle events can be registered in timeline file.
+            # before calling stop so that cycle events can be registered in timeline file.
             time.sleep(0.2)
             hvd.stop_timeline()
             check_file(fname4, check_cycle=True)
-
-        # Do 2 continous start
-        with temppath() as fname5:
-            # again start timeline with same file
-            hvd.start_timeline(fname5, mark_cycles=False)
-            hvd.start_timeline(fname5, mark_cycles=False)
-            summed = hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
-            hvd.stop_timeline()
-            check_file(fname5, check_cycle=False)
 
         hvd.shutdown()
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2194,7 +2194,7 @@ class TorchTests(unittest.TestCase):
         with temppath() as fname5:
             # again start timeline with same file
             hvd.start_timeline(fname5, mark_cycles=False)
-            hvd.start_timeline(fname5, mark_cycles=False)
+            #hvd.start_timeline(fname5, mark_cycles=False)
             summed = hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
             hvd.stop_timeline()
             check_file(fname5, check_cycle=False)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2145,7 +2145,7 @@ class TorchTests(unittest.TestCase):
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text
                     assert 'start_time_since_epoch_in_micros' in timeline_text, timeline_text
-                    json_obj = json.load(timeline_file)
+                    json_obj = json.loads(timeline_text)
                     assert json_obj is not None
                     if check_cycle is True:
                         assert 'CYCLE_START' in timeline_text, timeline_text

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2190,6 +2190,14 @@ class TorchTests(unittest.TestCase):
             hvd.stop_timeline()
             check_file(fname4, check_cycle=True)
 
+        with temppath() as fname5:
+            # Make sure that last stop timeline has been processed.
+            hvd.start_timeline(fname5, mark_cycles=False)
+            hvd.start_timeline(fname5, mark_cycles=False)
+            hvd.allreduce(torch.tensor([1, 2, 3], dtype=torch.float32), name='test_allreduce')
+            hvd.stop_timeline()
+            check_file(fname5, check_cycle=False)
+
         hvd.shutdown()
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -23,6 +23,7 @@ import os
 import unittest
 import warnings
 import time
+import json
 
 from collections.abc import Iterable
 
@@ -2143,6 +2144,9 @@ class TorchTests(unittest.TestCase):
                     assert 'allreduce.test_allreduce' in timeline_text, timeline_text
                     assert 'NEGOTIATE_ALLREDUCE' in timeline_text, timeline_text
                     assert 'ALLREDUCE' in timeline_text, timeline_text
+                    assert 'start_time_since_epoch_in_micros' in timeline_text, timeline_text
+                    json_obj = json.load(timeline_file)
+                    assert json_obj is not None
                     if check_cycle is True:
                         assert 'CYCLE_START' in timeline_text, timeline_text
 


### PR DESCRIPTION
This PR 
1)introduces a new Python API for starting and stopping the timeline:

```
hvd.start_timeline('/path/to/timeline.json', mark_cycles=True)
...
hvd.stop_timeline()
```
2) Makes sure that timeline json file is valid json. 
3) Including starttime as metadata in timeline.

TODO
 1/ thread detach() re-introduce. 


Fixes #2008.
This is followup from this PR: https://github.com/horovod/horovod/pull/2129 and addresses concurrent access. 
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
