### PR TITLE
Run these github workflows on push events

### DIFF
--- a/.github/workflows/docs-summary.yml
+++ b/.github/workflows/docs-summary.yml
@@ -1,6 +1,6 @@
 name: Docs Summary Sync
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
+
     - name: Diffing README.rst with docs/summary.rst
       run: |
         sed -e "s/docs\///g" README.rst > docs/README.rst

--- a/.github/workflows/examples-keras-spark3-rossmann.yml
+++ b/.github/workflows/examples-keras-spark3-rossmann.yml
@@ -1,6 +1,6 @@
 name: Examples Keras Spark3 Sync
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
+
     - name: Diffing examples/keras_spark_rossmann_run.py with examples/keras_spark3_rossmann.py
       run: |
         patch --quiet -p0 examples/keras_spark_rossmann_run.py examples/keras_spark3_rossmann.py.patch -o examples/keras_spark3_rossmann.py.from-keras_spark_rossmann_run


### PR DESCRIPTION
The `pull_request` is the wrong event, that triggers whenever a PR is modified (includes adding comments, reviews, ...), `push` is the right event.

Duplicates #2220.

Signed-off-by: Enrico Minack <github@enrico.minack.dev>