### PR TITLE
Fix setting -D_GLIBCXX_USE_CXX11_ABI=0 when compiling CUDA kernels

### DIFF
--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -8,9 +8,7 @@ MESSAGE(STATUS "HVD_NVCC_COMPILE_FLAGS = ${HVD_NVCC_COMPILE_FLAGS}")
 
 list(APPEND CUDA_NVCC_FLAGS "${HVD_NVCC_COMPILE_FLAGS}")
 
-cuda_add_library(horovod_cuda_kernels cuda_kernels.cu)
-target_compile_definitions(horovod_cuda_kernels PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
+cuda_add_library(horovod_cuda_kernels cuda_kernels.cu OPTIONS -D_GLIBCXX_USE_CXX11_ABI=1)
 
 # if we need compatible c++ abi, build a compatible version
-cuda_add_library(compatible_horovod_cuda_kernels cuda_kernels.cu)
-target_compile_definitions(compatible_horovod_cuda_kernels PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
+cuda_add_library(compatible_horovod_cuda_kernels cuda_kernels.cu OPTIONS -D_GLIBCXX_USE_CXX11_ABI=0)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

If I build the current Horovod master with TF 1.15.2 on Ubuntu 16.04 (cmake version 3.5.1), `import horovod.tensorflow` fails with
```
NotFoundError: .../lib/python3.7/site-packages/horovod/tensorflow/mpi_lib.cpython-37m-x86_64-linux-gnu.so:
undefined symbol: _ZN7horovod6common13DataType_NameB5cxx11ENS0_8DataTypeE
```
(demangled: `horovod::common::DataType_Name[abi:cxx11](horovod::common::DataType)`)

I noticed that `-D_GLIBCXX_USE_CXX11_ABI=0` had not been passed to the compiler when building `compatible_horovod_cuda_kernels`, but this would have been necessary with the Tensorflow package from PyPI. This patch fixes that and the import works fine on my system now.



## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
