### PR TITLE
Databricks supports horovod.spark.estimator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added Databricks storage `DBFSLocalStore` and support for GPU-aware scheduling to horovod.spark Estimator. ([#2234](https://github.com/horovod/horovod/pull/2234))
+
 ### Changed
 
 ### Deprecated

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -300,4 +300,19 @@ and above. To run Horovod in Spark on Databricks, use `DBFSLocalStore` as the st
 
     store = DBFSLocalStore(prefix_path='/dbfs/...')
 
+The `DBFSLocalStore` uses `Databricks File System (DBFS) local file APIs <https://docs.databricks.com/data/databricks-file-system.html#local-file-apis>`__
+as a store of intermediate data and training artifacts.
+
+Databricks preconfigures GPU-aware scheduling for you on GPU clusters. See the
+`Databricks blog post <https://databricks.com/blog/2020/06/26/announcing-gpu-aware-scheduling-and-enhanced-deep-learning-capabilities.html>`__
+for details.
+
+With the Estimator API, horovod will launch # of tasks on each worker = # of GPUs on each worker, and each task will
+pin GPU to the assigned GPU from spark.
+
+With the Run API, the function `get_available_devices()` from `horovod.spark.task` will return a list of assigned GPUs
+for the spark task from which `get_available_devices()` is called.
+See `keras_spark3_rossmann.py <../examples/keras_spark3_rossmann.py>`__ for an example of using
+`get_available_devices()` with the Run API.
+
 .. inclusion-marker-end-do-not-remove

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -290,21 +290,22 @@ Environment knobs
 -----------------
 * ``HOROVOD_SPARK_START_TIMEOUT`` - sets the default timeout for Spark tasks to spawn, register, and start running the code.  If executors for Spark tasks are scheduled on-demand and can take a long time to start, it may be useful to increase this timeout on a system level.
 
-Horovod in Spark on Databricks
+Horovod on Databricks
 ------------------------------
-Horovod in Spark in supported on
-`Databricks Runtime 7.4 ML <https://docs.databricks.com/release-notes/runtime/releases.html>`__
-and above. To run Horovod in Spark on Databricks, use `DBFSLocalStore` as the store object:
+To run Horovod in Spark on Databricks, use `DBFSLocalStore` as the store object:
 
 .. code-block:: python
 
     store = DBFSLocalStore(prefix_path='/dbfs/...')
 
-The `DBFSLocalStore` uses `Databricks File System (DBFS) local file APIs <https://docs.databricks.com/data/databricks-file-system.html#local-file-apis>`__
+The `DBFSLocalStore` uses Databricks File System (DBFS) local file APIs
+(`AWS <https://docs.databricks.com/data/databricks-file-system.html#local-file-apis>`__ |
+`Azure <https://docs.microsoft.com/en-us/azure/databricks/data/databricks-file-system#--local-file-apis>`__)
 as a store of intermediate data and training artifacts.
 
-Databricks preconfigures GPU-aware scheduling for you on GPU clusters. See the
-`Databricks blog post <https://databricks.com/blog/2020/06/26/announcing-gpu-aware-scheduling-and-enhanced-deep-learning-capabilities.html>`__
+Databricks pre-configures GPU-aware scheduling on Databricks Runtime 7.0 ML GPU and above. See GPU scheduling instructions
+(`AWS <https://docs.databricks.com/clusters/gpu.html#gpu-scheduling-1>`__ |
+`Azure <https://docs.microsoft.com/en-us/azure/databricks/clusters/gpu#gpu-scheduling>`__)
 for details.
 
 With the Estimator API, horovod will launch # of tasks on each worker = # of GPUs on each worker, and each task will

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -290,5 +290,14 @@ Environment knobs
 -----------------
 * ``HOROVOD_SPARK_START_TIMEOUT`` - sets the default timeout for Spark tasks to spawn, register, and start running the code.  If executors for Spark tasks are scheduled on-demand and can take a long time to start, it may be useful to increase this timeout on a system level.
 
+Horovod in Spark on Databricks
+------------------------------
+Horovod in Spark in supported on
+`Databricks Runtime 7.4 ML <https://docs.databricks.com/release-notes/runtime/releases.html>`__
+and above. To run Horovod in Spark on Databricks, use `DBFSLocalStore` as the store object:
+
+.. code-block:: python
+
+    store = DBFSLocalStore(prefix_path='/dbfs/...')
 
 .. inclusion-marker-end-do-not-remove

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -165,9 +165,13 @@ class FilesystemStore(Store):
         with self.get_filesystem().open(self.get_localized_path(path), 'rb') as f:
             return f.read()
 
-    def read_serialized_keras_model(self, ckpt_path, model=None):
-        """
-        This function will be overridden by DBFSLocalStore.
+    def read_serialized_keras_model(self, ckpt_path, model):
+        """Reads the checkpoint file of the keras model into model bytes and returns the base 64
+        encoded model bytes.
+        :param ckpt_path: A string of path to the checkpoint file.
+        :param model: A keras model. This parameter will be used in DBFSLocalStore\
+            .read_serialized_keras_model() when the ckpt_path only contains model weights.
+        :return: the base 64 encoded model bytes of the checkpoint model.
         """
         from horovod.runner.common.util import codec
 
@@ -444,7 +448,8 @@ class HDFSStore(FilesystemStore):
 
 
 class DBFSLocalStore(LocalStore):
-    """Uses DBFS as a store of intermediate data and training artifacts.
+    """Uses Databricks File System (DBFS) local file APIs as a store of intermediate data and
+    training artifacts.
 
     Initialized from a `prefix_path` starts with `/dbfs/...`, see
     https://docs.databricks.com/data/databricks-file-system.html#local-file-apis.
@@ -463,7 +468,7 @@ class DBFSLocalStore(LocalStore):
         # is used by providing `save_weights_only=True` to the ModelCheckpoint() callback.
         return 'checkpoint.tf'
 
-    def read_serialized_keras_model(self, ckpt_path, model=None):
+    def read_serialized_keras_model(self, ckpt_path, model):
         """
         Returns serialized keras model. On Databricks, only TFKeras is supported, not BareKeras.
         The parameter `model` is for providing the model structure when the checkpoint file only

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import tempfile
+import warnings
 
 from distutils.version import LooseVersion
 
@@ -453,7 +454,8 @@ class DBFSLocalStore(LocalStore):
     """
     def __init__(self, prefix_path, *args, **kwargs):
         if not prefix_path.startswith("/dbfs/"):
-            raise ValueError("Please provide a `prefix_path` starts with `/dbfs/...`")
+            warnings.warn("The provided prefix_path might be ephemeral: {} Please provide a "
+                          "`prefix_path` starting with `/dbfs/...`".format(prefix_path))
         super(DBFSLocalStore, self).__init__(prefix_path, *args, **kwargs)
 
     def get_checkpoint_filename(self):

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -701,9 +701,10 @@ def _get_allocated_gpu(hvd):
     import warnings
     try:
         # if GPU-aware scheduling is available, pin to the assigned GPU index
-        from pyspark import TaskContext
-        warnings.warn(str(TaskContext.get().resources()['gpu'].addresses[0]))
-        return TaskContext.get().resources()['gpu'].addresses[0]
+        from horovod.spark.task import get_available_devices
+        assigned_gpus = get_available_devices()
+        warnings.warn(str(assigned_gpus))
+        return assigned_gpus[0]
     except Exception as e:
         # pin to local rank
         warnings.warn(str(e))

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -697,11 +697,11 @@ def to_list(var, length):
     return var
 
 
-def _get_allocated_gpu(hvd):
+def _get_assigned_gpu_or_default(default):
     try:
         # if GPU-aware scheduling is available, pin to the assigned GPU index
         from horovod.spark.task import get_available_devices
         return int(get_available_devices()[0])
     except:
-        # pin to local rank
-        return hvd.local_rank()
+        # pin to default GPU index (local rank)
+        return default

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -704,7 +704,7 @@ def _get_allocated_gpu(hvd):
         from horovod.spark.task import get_available_devices
         assigned_gpus = get_available_devices()
         warnings.warn(str(assigned_gpus))
-        return assigned_gpus[0]
+        return int(assigned_gpus[0])
     except Exception as e:
         # pin to local rank
         warnings.warn(str(e))

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -698,10 +698,13 @@ def to_list(var, length):
 
 
 def _get_allocated_gpu(hvd):
+    import warnings
     try:
         # if GPU-aware scheduling is available, pin to the assigned GPU index
         from pyspark import TaskContext
+        warnings.warn(str(TaskContext.get().resources()['gpu'].addresses[0]))
         return TaskContext.get().resources()['gpu'].addresses[0]
-    except:
+    except Exception as e:
         # pin to local rank
+        warnings.warn(str(e))
         return hvd.local_rank()

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -698,14 +698,10 @@ def to_list(var, length):
 
 
 def _get_allocated_gpu(hvd):
-    import warnings
     try:
         # if GPU-aware scheduling is available, pin to the assigned GPU index
         from horovod.spark.task import get_available_devices
-        assigned_gpus = get_available_devices()
-        warnings.warn(str(assigned_gpus))
-        return int(assigned_gpus[0])
-    except Exception as e:
+        return int(get_available_devices()[0])
+    except:
         # pin to local rank
-        warnings.warn(str(e))
         return hvd.local_rank()

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -695,3 +695,13 @@ def to_list(var, length):
                              "label_cols")
 
     return var
+
+
+def _get_allocated_gpu(hvd):
+    try:
+        # if GPU-aware scheduling is available, pin to the assigned GPU index
+        from pyspark import TaskContext
+        return TaskContext.get().resources()['gpu'].addresses[0]
+    except:
+        # pin to local rank
+        return hvd.local_rank()

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -698,10 +698,11 @@ def to_list(var, length):
 
 
 def _get_assigned_gpu_or_default(default):
-    try:
+    from horovod.spark.task import get_available_devices
+    available_devices = get_available_devices()
+    if available_devices:
         # if GPU-aware scheduling is available, pin to the assigned GPU index
-        from horovod.spark.task import get_available_devices
-        return int(get_available_devices()[0])
-    except:
+        return int(available_devices[0])
+    else:
         # pin to default GPU index (local rank)
         return default

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -306,7 +306,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         if self.getVerbose():
             print('Resuming training from last checkpoint: {}'.format(last_ckpt_path))
 
-        return store.read_serialized_keras_model(last_ckpt_path)
+        return store.read_serialized_keras_model(last_ckpt_path, self.getModel())
 
     def _compile_model(self, keras_utils):
         # Compile the model with all the parameters

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -306,8 +306,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         if self.getVerbose():
             print('Resuming training from last checkpoint: {}'.format(last_ckpt_path))
 
-        model_bytes = store.read(last_ckpt_path)
-        return codec.dumps_base64(model_bytes)
+        return store.read_serialized_keras_model(last_ckpt_path)
 
     def _compile_model(self, keras_utils):
         # Compile the model with all the parameters

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,13 +313,10 @@ def _pin_gpu_fn():
 
 def _pin_gpu_tensorflow2_fn():
     def fn(hvd, tf, keras):
-        import warnings
         gpus = tf.config.experimental.list_physical_devices('GPU')
-        warnings.warn(str(gpus))
         for gpu in gpus:
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
-            warnings.warn(str(_get_allocated_gpu(hvd)))
             tf.config.experimental.set_visible_devices(gpus[_get_allocated_gpu(hvd)], 'GPU')
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,10 +313,13 @@ def _pin_gpu_fn():
 
 def _pin_gpu_tensorflow2_fn():
     def fn(hvd, tf, keras):
+        import warnings
         gpus = tf.config.experimental.list_physical_devices('GPU')
+        warnings.warn(str(gpus))
         for gpu in gpus:
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
+            warnings.warn(str(_get_allocated_gpu(hvd)))
             tf.config.experimental.set_visible_devices(gpus[_get_allocated_gpu(hvd)], 'GPU')
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -233,8 +233,12 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
             globals()['_DATASET_FINALIZATION_HACK'] = model
 
             if hvd.rank() == 0:
-                with open(ckpt_file, 'rb') as f:
-                    return history.history, codec.dumps_base64(f.read()), hvd.size()
+                if ckpt_file.endswith(".tf"):
+                    model = k.models.load_model(ckpt_file)
+                    return history.history, keras_utils.serialize_model(model), hvd.size()
+                else:
+                    with open(ckpt_file, 'rb') as f:
+                        return history.history, codec.dumps_base64(f.read()), hvd.size()
     return train
 
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -22,7 +22,7 @@ import torch
 from torch.utils.tensorboard import SummaryWriter
 
 from horovod.spark.common import constants
-from horovod.spark.common.util import _get_allocated_gpu, to_list
+from horovod.spark.common.util import _get_assigned_gpu_or_default, to_list
 from horovod.spark.common.store import DBFSLocalStore
 from horovod.spark.torch.util import deserialize_fn
 
@@ -121,7 +121,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         cuda_available = torch.cuda.is_available()
         if cuda_available:
             # Horovod: pin GPU to local rank or the allocated GPU from spark.
-            torch.cuda.set_device(_get_allocated_gpu(hvd))
+            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -120,7 +120,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         cuda_available = torch.cuda.is_available()
         if cuda_available:
-            # Horovod: pin GPU to local rank or the allocated GPU from spark.
+            # Horovod: pin GPU to local rank or the assigned GPU from spark.
             torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
             # Move model to GPU.
             model.cuda()

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -119,7 +119,12 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         cuda_available = torch.cuda.is_available()
         if cuda_available:
             # Horovod: pin GPU to local rank.
-            torch.cuda.set_device(hvd.local_rank())
+            if os.environ.get('CUDA_VISIBLE_DEVICES') is None:
+                torch.cuda.set_device(hvd.local_rank())
+            else:
+                # Databricks pyspark sets CUDA_VISIBLE_DEVICES for GPU scheduling.
+                # Pin the only visible GPU allocated to this task.
+                torch.cuda.set_device(0)
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -121,13 +121,11 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         cuda_available = torch.cuda.is_available()
         if cuda_available:
             # Horovod: pin GPU to local rank.
-            if os.environ.get('CUDA_VISIBLE_DEVICES') is None:
-                assert not is_dbfs
+            if not is_dbfs:
                 torch.cuda.set_device(hvd.local_rank())
             else:
                 # Databricks pyspark sets CUDA_VISIBLE_DEVICES for GPU scheduling.
                 # Pin the only visible GPU allocated to this task.
-                assert is_dbfs
                 torch.cuda.set_device(0)
             # Move model to GPU.
             model.cuda()

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -1708,6 +1708,7 @@ class SparkTests(unittest.TestCase):
         assert reconstructed_model_dbfs.get_config() == model.get_config()
 
         # test local_store.read_serialized_keras_model
+        local_store = Store.create("/tmp/test_local_dir")
         local_ckpt_path = local_store.prefix_path + "/" + local_store.get_checkpoint_filename()
         model.save(local_ckpt_path)
         serialized_model_local = local_store.read_serialized_keras_model(local_ckpt_path, model)

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -48,7 +48,7 @@ from horovod.runner.common.util import settings as hvd_settings
 from horovod.runner.mpi_run import is_open_mpi
 from horovod.runner.util.threads import in_thread
 from horovod.spark.common import constants, util
-from horovod.spark.common.store import HDFSStore
+from horovod.spark.common.store import DBFSLocalStore, HDFSStore, LocalStore, Store
 from horovod.spark.driver.host_discovery import SparkDriverHostDiscovery
 from horovod.spark.driver.rsh import rsh
 from horovod.spark.task import get_available_devices, gloo_exec_fn, mpirun_exec_fn
@@ -1671,3 +1671,46 @@ class SparkTests(unittest.TestCase):
 
         with pytest.raises(ValueError):
             util.to_list(['item1', 'item2'], 4)
+
+    def test_dbfs_local_store(self):
+        import h5py
+        import io
+
+        from tensorflow import keras
+
+        # test Store.create will not automatically create DBFSLocalStore
+        local_store = Store.create("/dbfs/tmp/test_local_dir")
+        assert isinstance(local_store, LocalStore)
+
+        # test get_checkpoint_filename suffix
+        dbfs_store = DBFSLocalStore("/dbfs/tmp/test_dbfs_dir")
+        dbfs_ckpt_name = dbfs_store.get_checkpoint_filename()
+        assert dbfs_ckpt_name.endswith(".tf")
+
+        # prepare for testing read_serialized_keras_model
+        model = keras.Sequential([keras.Input((32,)), keras.layers.Dense(1)])
+
+        def deserialize_keras_model(serialized_model):
+            model_bytes = codec.loads_base64(serialized_model)
+            bio = io.BytesIO(model_bytes)
+            with h5py.File(bio, 'r') as f:
+                return keras.models.load_model(f)
+
+        # test dbfs_store.read_serialized_keras_model
+        dbfs_ckpt_path = dbfs_store.prefix_path + "/" + dbfs_ckpt_name
+        model.save(dbfs_ckpt_path)
+        serialized_model_dbfs = dbfs_store.read_serialized_keras_model(dbfs_ckpt_path)
+        reconstructed_model_dbfs = deserialize_keras_model(serialized_model_dbfs)
+        assert reconstructed_model_dbfs.get_config() == model.get_config()
+        assert reconstructed_model_dbfs.get_weights() == model.get_weights()
+
+        # test local_store.read_serialized_keras_model
+        local_ckpt_path = local_store.prefix_path + "/" + local_store.get_checkpoint_filename()
+        model.save(local_ckpt_path)
+        serialized_model_local = local_store.read_serialized_keras_model(local_ckpt_path)
+        reconstructed_model_local = deserialize_keras_model(serialized_model_local)
+        assert reconstructed_model_local.get_config() == model.get_config()
+        assert reconstructed_model_local.layers[0].get_weights()[0] == \
+               model.layers[0].get_weights()[0]
+        assert reconstructed_model_local.layers[0].get_weights()[1] == \
+               model.layers[0].get_weights()[1]

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -1706,10 +1706,6 @@ class SparkTests(unittest.TestCase):
         serialized_model_dbfs = dbfs_store.read_serialized_keras_model(dbfs_ckpt_path, model)
         reconstructed_model_dbfs = deserialize_keras_model(serialized_model_dbfs)
         assert reconstructed_model_dbfs.get_config() == model.get_config()
-        assert reconstructed_model_dbfs.layers[0].get_weights()[0] == \
-               model.layers[0].get_weights()[0]
-        assert reconstructed_model_dbfs.layers[0].get_weights()[1] == \
-               model.layers[0].get_weights()[1]
 
         # test local_store.read_serialized_keras_model
         local_ckpt_path = local_store.prefix_path + "/" + local_store.get_checkpoint_filename()
@@ -1717,7 +1713,3 @@ class SparkTests(unittest.TestCase):
         serialized_model_local = local_store.read_serialized_keras_model(local_ckpt_path, model)
         reconstructed_model_local = deserialize_keras_model(serialized_model_local)
         assert reconstructed_model_local.get_config() == model.get_config()
-        assert reconstructed_model_local.layers[0].get_weights()[0] == \
-               model.layers[0].get_weights()[0]
-        assert reconstructed_model_local.layers[0].get_weights()[1] == \
-               model.layers[0].get_weights()[1]

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -1690,7 +1690,7 @@ class SparkTests(unittest.TestCase):
         assert dbfs_ckpt_name.endswith(".tf")
 
         # prepare for testing read_serialized_keras_model
-        model = keras.Sequential([keras.Input((32,)), keras.layers.Dense(1)])
+        model = keras.Sequential([keras.Input([32]), keras.layers.Dense(1)])
 
         def deserialize_keras_model(serialized_model):
             model_bytes = codec.loads_base64(serialized_model)
@@ -1708,7 +1708,8 @@ class SparkTests(unittest.TestCase):
                 model.save(dbfs_ckpt_path)
             serialized_model_dbfs = dbfs_store.read_serialized_keras_model(dbfs_ckpt_path, model)
             reconstructed_model_dbfs = deserialize_keras_model(serialized_model_dbfs)
-            assert reconstructed_model_dbfs.get_config() == model.get_config()
+            if LooseVersion(tensorflow.__version__) >= LooseVersion("2.3.0"):
+                assert reconstructed_model_dbfs.get_config() == model.get_config()
 
         # test local_store.read_serialized_keras_model
         with tempdir() as tmp:
@@ -1720,4 +1721,5 @@ class SparkTests(unittest.TestCase):
                 serialized_model_local = \
                     local_store.read_serialized_keras_model(local_ckpt_path, model)
                 reconstructed_model_local = deserialize_keras_model(serialized_model_local)
-                assert reconstructed_model_local.get_config() == model.get_config()
+                if LooseVersion(tensorflow.__version__) >= LooseVersion("2.3.0"):
+                    assert reconstructed_model_local.get_config() == model.get_config()

--- a/test/test_spark.py
+++ b/test/test_spark.py
@@ -1708,9 +1708,11 @@ class SparkTests(unittest.TestCase):
         assert reconstructed_model_dbfs.get_config() == model.get_config()
 
         # test local_store.read_serialized_keras_model
-        local_store = Store.create("/tmp/test_local_dir")
-        local_ckpt_path = local_store.prefix_path + "/" + local_store.get_checkpoint_filename()
-        model.save(local_ckpt_path)
-        serialized_model_local = local_store.read_serialized_keras_model(local_ckpt_path, model)
-        reconstructed_model_local = deserialize_keras_model(serialized_model_local)
-        assert reconstructed_model_local.get_config() == model.get_config()
+        with tempdir() as tmp:
+            local_store = Store.create(tmp)
+            local_ckpt_path = local_store.prefix_path + "/" + local_store.get_checkpoint_filename()
+            model.save(local_ckpt_path)
+            serialized_model_local = \
+                local_store.read_serialized_keras_model(local_ckpt_path, model)
+            reconstructed_model_local = deserialize_keras_model(serialized_model_local)
+            assert reconstructed_model_local.get_config() == model.get_config()


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

* Add `DBFSLocalStore` that allows horovod.spark Estimator to use Databricks Filesystem local files API to persist intermediate data and training artifacts.
* Update the ways to pin GPU: when GPU-aware scheduling is available, pin GPU to the assigned GPU index from spark; otherwise, pin GPU to `hvd.local_rank()`.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
