### PR TITLE
Download all BuildKite artifacts

### DIFF
--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Download Buildkite Artifacts
-      uses: EnricoMi/download-buildkite-artifact-action@v1.4
+      uses: EnricoMi/download-buildkite-artifact-action@branch-fix-new-artifact-detection
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Download Buildkite Artifacts
-      uses: EnricoMi/download-buildkite-artifact-action@branch-fix-pagination
+      uses: EnricoMi/download-buildkite-artifact-action@v1.4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -19,21 +19,23 @@ jobs:
 
     steps:
     - name: Download Buildkite Artifacts
-      uses: EnricoMi/download-buildkite-artifact-action@branch-fix-new-artifact-detection
+      uses: EnricoMi/download-buildkite-artifact-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
         output_path: test-results
         log_level: DEBUG
+      continue-on-error: true
 
     - name: Unit Test Results
       if: always()
-      uses: EnricoMi/publish-unit-test-result-action@v1.1
+      uses: EnricoMi/publish-unit-test-result-action@master
       with:
         check_name: Unit Test Results
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: "test-results/**/*.xml"
         log_level: DEBUG
+      continue-on-error: true
 
     - name: Upload Test Results
       if: always()

--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Download Buildkite Artifacts
-      uses: EnricoMi/download-buildkite-artifact-action@v1.3
+      uses: EnricoMi/download-buildkite-artifact-action@branch-fix-pagination
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}


### PR DESCRIPTION
The Buildkite artifact download action did only download the first 100 artifacts, but Horovod has 483 (!). Move to the latest version of the action that fixes this.

Further, to avoid more disruptions, this moves to master so in case there is another bug in the actions I can fix them in actions' master and rerun the workflow without rerunning Buildkite (and waiting hours and raising the AWS bill).

With `continue-on-error: true`, those workflows won't fail on these actions. I keep an eye on them. Thanks for letting me test these actions here, if they work for Horovod, they work everywhere.