### PR TITLE
Don't run the Unit Tests workflow on master or tags

### DIFF
--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
-on: [push]
+on:
+  push:
+    branches-ignore: master
+    tags-ignore: '**'
 
 jobs:
   buildkite:


### PR DESCRIPTION
Buildkite does not run on master push event but on schedule, the download action will not be able to pick this up in a timely manner. Buildkite does not run on tags either. No need to run the workflow for those.