### PR TITLE
Fix flaky buildkite test

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -9,11 +9,12 @@ repository=823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
 # don't build and test any code if there are no code changes
 # keep in-sync with .github/workflows/buildkite_unit_test.yml
 non_code_files=("^.buildkite/get_commit_files.py$" "^.github/" "^docs/" "^.*.md" "^.*.rst")
-printf "%s\n" "${non_code_files[@]}" > gen-pipeline.sh.grep-patterns
+dir="$(dirname "$0")"
+printf "%s\n" "${non_code_files[@]}" > "$dir/gen-pipeline.sh.grep-patterns"
 # shellcheck disable=SC2046
-python $(dirname "$0")/get_commit_files.py > gen-pipeline.sh.commit-files
-commit_files="$(cat gen-pipeline.sh.commit-files)"
-code_files=$(grep -v -f gen-pipeline.sh.grep-patterns gen-pipeline.sh.commit-files || true)
+python "$dir/get_commit_files.py" > "$dir/gen-pipeline.sh.commit-files"
+commit_files="$(cat "$dir/gen-pipeline.sh.commit-files")"
+code_files=$(grep -v -f "$dir/gen-pipeline.sh.grep-patterns" "$dir/gen-pipeline.sh.commit-files" || true)
 tests=$(if [[ -z "$commit_files" || "${BUILDKITE_BRANCH:-}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-}" ]] || [[ -n "$code_files" ]]; then
   echo test-cpu-openmpi-py3_6-tf1_15_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_3_2 \
        test-cpu-gloo-py3_6-tf1_15_0-keras2_2_4-torch1_2_0-mxnet1_4_1-pyspark2_3_2 \

--- a/test/test_buildkite.py
+++ b/test/test_buildkite.py
@@ -64,11 +64,11 @@ class BuildKiteTests(unittest.TestCase):
         exit_code, actual_pipeline, gen_pipeline_log = self._run(gen_pipeline_cmd, gen_pipeline_env)
 
         self.assertEqual(0, exit_code)
-        self.assertEqual(expected_pipeline, actual_pipeline)
         self.assertEqual('DEBUG:root:commit = None\n'
                          'DEBUG:root:pr number = None\n'
                          'DEBUG:root:branch = BRANCH\n'
                          'DEBUG:root:default = None\n', gen_pipeline_log)
+        self.assertEqual(expected_pipeline, actual_pipeline)
 
     """
     Tests .buildkite/gen-pipeline.sh with a commit that has no code changes.
@@ -92,6 +92,7 @@ class BuildKiteTests(unittest.TestCase):
             exit_code, actual_pipeline, gen_pipeline_log = self._run(tmp_gen_pipeline_sh, gen_pipeline_env)
 
             self.assertEqual(0, exit_code)
+            self.assertEqual('', gen_pipeline_log)
             self.assertEqual("steps:\n"
                              "- label: \':book: Build Docs\'\n"
                              "  command: 'cd /workdir/docs && pip install -r requirements.txt && make html'\n"
@@ -106,7 +107,6 @@ class BuildKiteTests(unittest.TestCase):
                              "- wait\n"
                              "- wait\n"
                              "- wait\n", actual_pipeline)
-            self.assertEqual('', gen_pipeline_log)
 
     def do_test_gen_full_pipeline(self, cmd, env=dict()):
         with open('data/expected_buildkite_pipeline.yaml', 'r') as f:
@@ -118,8 +118,8 @@ class BuildKiteTests(unittest.TestCase):
         exit_code, pipeline, log = self._run(cmd, cmd_env)
 
         self.assertEqual(0, exit_code)
-        self.assertEqual(expected_pipeline, pipeline)
         self.assertEqual('', log)
+        self.assertEqual(expected_pipeline, pipeline)
 
     def test_gen_pipeline_with_code_changes(self):
         with tempdir() as dir:


### PR DESCRIPTION
The `test_gen_pipeline_with_code_changes` test seems to be flaky: https://buildkite.com/horovod/horovod/builds/3759#3dbfa9f4-6965-4ca2-9245-44bf25918f8a and https://buildkite.com/horovod/horovod/builds/3759#abb99246-f4b4-4871-a471-2f7673efd7d1.