### PR TITLE
Fixed missing run in tf keras elastic mode

### DIFF
--- a/horovod/keras/elastic.py
+++ b/horovod/keras/elastic.py
@@ -16,7 +16,7 @@
 import keras
 
 from horovod._keras import elastic as _impl
-from horovod.tensorflow.elastic import TensorFlowKerasState
+from horovod.tensorflow.elastic import TensorFlowKerasState, run
 
 
 class KerasState(TensorFlowKerasState):

--- a/horovod/tensorflow/keras/elastic.py
+++ b/horovod/tensorflow/keras/elastic.py
@@ -16,7 +16,7 @@
 import tensorflow as tf
 
 from horovod._keras import elastic as _impl
-from horovod.tensorflow.elastic import TensorFlowKerasState
+from horovod.tensorflow.elastic import TensorFlowKerasState, run
 
 
 class KerasState(TensorFlowKerasState):


### PR DESCRIPTION
## Checklist before submitting

- [ yes ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ N/A ] Did you update the docs?
- [ N/A ] Did you write any tests to validate this change?  
- [ N/A ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Can not run examples/elastic/tensorflow_keras_mnist_elastic.py in elastic mode.

Fixes # (issue).
1. missing run decorator in elastic.py file. Just import it and working well now.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
