### PR TITLE
Always test master

### DIFF
--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -1,15 +1,21 @@
 name: Unit Tests
 on:
-  push:
-    # keep paths-ignore in-sync with .buildkite/gen-pipeline.sh
-    # buildkite does not run tests when there are no changes in paths other then these
-    paths-ignore:
-    - ".buildkite/get_commit_files.py"
-    - ".github/**"
-    - "docs/"
-    - "*.md"
-    - "*.rst"
-    tags-ignore: "**"
+  # pushing to master, always run this workflow
+  - push:
+      branches: master
+      tags-ignore: "**"
+  # pushing to non-master branches, ignore non-code changes
+  - push:
+      branches-ignore: master
+      tags-ignore: "**"
+      # keep paths-ignore in-sync with .buildkite/gen-pipeline.sh
+      # buildkite does not run tests when there are no changes in paths other then these
+      paths-ignore:
+      - ".buildkite/get_commit_files.py"
+      - ".github/**"
+      - "docs/"
+      - "*.md"
+      - "*.rst"
 
 jobs:
   buildkite:


### PR DESCRIPTION
My earlier change #2284 didn't consider the always-test-on-master-feature. You can see that the merge commit in master did kick off a full test run on Buildkite but the test workflow did not run. Not sure if this change fixes it. We can only test this in master.

With this merged into master, the test workflow should run on the merge commit though it is a non-code change.