### PR TITLE
Update use of tf.cond in TF alltoall gradient.

### DIFF
--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -252,9 +252,11 @@ def _alltoall_grad(op, grad):
     """
     tensor = op.inputs[0]
     splits = op.inputs[1]
-    recvsplits = tf.cond(tf.equal(tf.size(splits), 0),
-                         lambda : alltoall(tf.ones([size()], dtype=tf.int32) * (tf.shape(tensor)[0] // size()), splits=[1 for _ in range(size())]),
-                         lambda : alltoall(splits, splits=[1 for _ in range(size())]))
+
+    splits = tf.cond(tf.equal(tf.size(splits), 0),
+                     lambda : tf.ones([size()], dtype=tf.int32) * (tf.shape(tensor)[0] // size()),
+                     lambda : splits)
+    recvsplits = alltoall(splits, splits=[1 for _ in range(size())])
     return [alltoall(grad, splits=recvsplits), None]
 
 def join():


### PR DESCRIPTION
## Description
This PR addresses an issue that arose with the TF `alltoall` gradient in a model parallel script (where workers may potentially building different graphs by rank). In that context, the current use of `tf.cond` would yield name mismatches in the first `alltoall` causing deadlocking. Solution is to not call `alltoall` inside the `tf.cond`, but instead use the conditional to determine the input and call the `alltoall` outside. 

