### PR TITLE
Bump version to 0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added Elastic Ray integration. ([#2291](https://github.com/horovod/horovod/pull/2291))
-
 ### Changed
-
-- Removed dependency on SSH access for Ray. ([#2275](https://github.com/horovod/horovod/pull/2275))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+## [0.20.3] - 2020-10-01
+
+### Added
+
+- Added Elastic Ray integration. ([#2291](https://github.com/horovod/horovod/pull/2291))
+
+### Changed
+
+- Removed dependency on SSH access for Ray. ([#2275](https://github.com/horovod/horovod/pull/2275))
 
 ## [0.20.2] - 2020-09-25
 

--- a/horovod/__init__.py
+++ b/horovod/__init__.py
@@ -1,3 +1,3 @@
 from horovod.runner import run
 
-__version__ = '0.20.2'
+__version__ = '0.20.3'


### PR DESCRIPTION
This release adds Ray support for Elastic Horovod and removes dependency on SSH for Ray NIC discovery.