### PR TITLE
Unit test workflow ignores more build states

### DIFF
--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
-        ignore_build_states: canceled
+        ignore_build_states: blocked,canceled,skipped,not_run
         ignore_job_states: timed_out
         output_path: test-results
         log_level: DEBUG

--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -77,7 +77,9 @@ jobs:
     - name: Unit Test Results
       id: results
       uses: EnricoMi/publish-unit-test-result-action@master
-      if: steps.download.outcome != 'skipped' && steps.download.outputs.build-state != 'canceled'
+      if: >
+        steps.download.outcome != 'skipped' &&
+        ! contains(fromJSON('[''blocked'', ''canceled'', ''skipped'', ''not_run'']'), steps.download.outputs.build-state)
       with:
         check_name: Unit Test Results
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are more Buildkite build states that we want to ignore than just skipped: `blocked`, `canceled`, `skipped` and `not_run`