### PR TITLE
Remove typing from test Dockerfiles

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -133,7 +133,6 @@ RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 
 # Install PyTorch.
-RUN pip install future typing
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
     else \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -107,7 +107,6 @@ RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     ldconfig
 
 # Install PyTorch.
-RUN pip install future typing
 RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
     if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 	    pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \


### PR DESCRIPTION
Installing `typing` with Python 3.8 (which already includes it) is resulting in build errors. 
 
See: https://github.com/psf/black/issues/1707