### PR TITLE
Fix eager gradient aggregation for TF 2.4 nightly.

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -97,7 +97,7 @@ services:
         UBUNTU_VERSION: 18.04
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly==2.4.0.dev20201016
+        TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: keras==2.4.3
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision==0.6.0.dev20200413
@@ -227,7 +227,7 @@ services:
         NCCL_VERSION_OVERRIDE: 2.7.8-1+cuda10.1
         MPI_KIND: OpenMPI
         PYTHON_VERSION: 3.6
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.4.0.dev20201016
+        TENSORFLOW_PACKAGE: tf-nightly-gpu
         KERAS_PACKAGE: keras==2.4.3
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision==0.6.0.dev20200413

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -80,15 +80,23 @@ class LocalGradientAggregationHelperEager:
         # Increment counter.
         self.counter.assign_add(1)
 
-        if tf.equal(self.counter, self.backward_passes_per_step):
+        def _all_reduce_and_clear_aggregated_variables(aggregated_gradients):
             # Performs allreduce. If `average_aggregated_gradients` is
             # set to True divides result by `backward_passes_per_step`.
-            resulting_grads = self._allreduce_helper(resulting_grads)
-            assert len(resulting_grads) == len(grads)
+            reduced_gradients = self._allreduce_helper(aggregated_gradients)
+            assert len(reduced_gradients) == len(grads)
 
-            # Resets counter and the variables storing the locally
-            # aggregated gradients.
             self._clear_vars()
+            return reduced_gradients
+
+        def _do_nothing(aggregated_gradients):
+            return aggregated_gradients
+
+        resulting_grads = tf.cond(
+            pred=tf.equal(self.counter, self.backward_passes_per_step),
+            true_fn=lambda: _all_reduce_and_clear_aggregated_variables(resulting_grads),
+            false_fn=lambda: _do_nothing(resulting_grads),
+        )
 
         return resulting_grads
 


### PR DESCRIPTION
## Description
TF 2.4 nightly no longer supports using a `tf.Tensor` as a Python `bool` inside a
`@tf.function`.  

Fixes issue raised in: https://github.com/horovod/horovod/pull/2384

