### PR TITLE
Correctly handle grads_and_vars passed in as zips for TF Keras 2.4 w/  local gradient aggregation

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -97,6 +97,15 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
 
         def apply_gradients(self, *args, **kwargs):
             if self._agg_helper:
+                if isinstance(args[0], zip):
+                    # If grad_and_vars are passed in as a zip object
+                    # convert to a list. This is necessary for TF2.4+
+                    # b/c args[0] is used in both conditional branches
+                    # inside _agg_helper.apply_gradients().
+                    args = list(args)
+                    args[0] = list(args[0])
+                    args = tuple(args)
+
                 results = self._agg_helper.apply_gradients(
                     lambda: super(self.__class__, self).apply_gradients(*args, **kwargs),
                     self,


### PR DESCRIPTION
## Checklist before submitting
- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
When users subclass `tf.keras.Model` and implement a custom `train_step()` it is possible
that the gradients and variables  passed into `apply_gradients()` are a zip object instead 
of a list. Starting with TF 2.4, we use the `grads_and_vars` object in both conditional loops inside
`apply_gradients()` when doing local gradient aggregation, which means that by the time that
the false condition was executed, the zip iterator would have gone through the list and the updates
were empty. This issue was not previously detected in out tests, because they were not executed
inside a `tf.function()`. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
