### PR TITLE
Add support for backward_passes_per_step > 1 for LegacyOptimizers (TF) in Graph Mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added support for backward_passes_per_step > 1 for TF Keras eager execution. ([#2371](https://github.com/horovod/horovod/pull/2371))
 
+- Added support for backward_passes_per_step > 1 for TF LegacyOptimizer in graph mode. ([#2401](https://github.com/horovod/horovod/pull/2401))
+
 ### Changed
 
 ### Deprecated

--- a/examples/tensorflow/tensorflow_mnist_estimator.py
+++ b/examples/tensorflow/tensorflow_mnist_estimator.py
@@ -111,7 +111,7 @@ def cnn_model_fn(features, labels, mode):
             learning_rate=0.001 * hvd.size(), momentum=0.9)
 
         # Horovod: add Horovod Distributed Optimizer.
-        optimizer = hvd.DistributedOptimizer(optimizer)
+        optimizer = hvd.DistributedOptimizer(optimizer, backward_passes_per_step=1)
 
         train_op = optimizer.minimize(
             loss=loss,

--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -21,6 +21,7 @@ class LocalGradientAggregationHelper:
     """
 
     _OPTIMIZER_TYPE_KERAS = "optimizer_type_keras"
+    _OPTIMIZER_TYPE_LEGACY = "optimizer_type_legacy"
 
     def __init__(
             self,


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR is a follow up #2346. This PR adds support for backward_passes_per_step > 1 for TF legacy optimizers (tf.train.Optimizer) executing in graph(non-eager) mode. This is one of the features that we have built into[ Determined AI's](https://determined.ai/) fork of Horovod that we would like to upstream.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
