### PR TITLE
Add debug log in operation.cc

### DIFF
--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -273,6 +273,7 @@ void PerformOperation(Response response, HorovodGlobalState& state) {
           [&]() { timeline.ActivityStartAll(entries, INIT_FUSION_BUFFER); },
           [&]() { timeline.ActivityEndAll(entries); });
       if (!status.ok()) {
+        LOG(DEBUG, horovod_global.controller->GetRank()) << "InitializeBuffer Failed";
         for (auto& e : entries) {
           timeline.End(e.tensor_name, nullptr);
           // Callback can be null if the rank sent Join request.
@@ -315,6 +316,7 @@ void PerformOperation(Response response, HorovodGlobalState& state) {
   try {
     status = op_manager->ExecuteOperation(entries, response);
   } catch (const std::exception& ex) {
+    LOG(DEBUG, horovod_global.controller->GetRank()) << "ExecuteOperation Failed";
     status = Status::UnknownError(ex.what());
   }
 


### PR DESCRIPTION
I encountered a Nan problem during training when I modified part of the source code. However, the try-cache here makes everything go well, no warnings or errors raised. PerformOperation() just makes callback like normal.

I found it difficult to locate the error so I added logs line by line. Finally I found my problem occured in InitializeBuffer due to incorrect CUDA driver API useage, which led to failure in ExecuteOperation. Then I fixed it and continued my development.

I believe it would be a useful infomation for other developers.

Thx!