### PR TITLE
Make counter for local gradient aggregation a local variable.

### DIFF
--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -73,6 +73,7 @@ class LocalGradientAggregationHelper:
             self.counter = tf.compat.v1.get_variable(
                 "aggregation_counter", shape=(), dtype=tf.int32,
                 trainable=False, initializer=tf.compat.v1.zeros_initializer(),
+                collections=[tf.compat.v1.GraphKeys.LOCAL_VARIABLES],
             )
             for idx, grad in enumerate(grads):
                 # Handle IndexedSlices.

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -2675,6 +2675,7 @@ class TensorFlowTests(tf.test.TestCase):
             grads_and_vars = opt.compute_gradients()
             update_op = opt.apply_gradients(grads_and_vars)
             sess.run(tf.compat.v1.global_variables_initializer())
+            sess.run(tf.compat.v1.local_variables_initializer())
 
             def compute_expected_value(batch_id):
                 sum_per_aggregation = 0.0


### PR DESCRIPTION
## Description
When using a an Estimator.RunHook to broadcast variables we broadcast all 
global variables. This PR marks the counter used for local gradient aggregation
as a local variable to avoid having it broadcasted as part of this callback.

Fixes issue raised in comments of #2401.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
