### PR TITLE
Use mxnet==1.5.0 for CPU Dockerfile until issues with 1.6.0 and 1.7.0 are resolved

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ENV TENSORFLOW_VERSION=2.3.0
 ENV PYTORCH_VERSION=1.6.0
 ENV TORCHVISION_VERSION=0.7.0
-ENV MXNET_VERSION=1.6.0
+ENV MXNET_VERSION=1.5.0
 
 # Python 3.7 is supported by Ubuntu Bionic out of the box
 ARG python=3.7
@@ -57,7 +57,7 @@ RUN mkdir /tmp/openmpi && \
     rm -rf /tmp/openmpi
 
 # Install Horovod
-RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 \
+RUN MAKEFLAGS="-j1" HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 \
     pip install --no-cache-dir horovod
 
 # Install OpenSSH for MPI to communicate between containers

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -19,7 +19,7 @@ function build_one()
     fi
 
     tag=horovod-build-py${py}-${device}:$(date +%Y%m%d-%H%M%S)
-    docker build -f Dockerfile.${device} -t ${tag} --build-arg python=${py} --no-cache .
+    docker build -f Dockerfile.${device} -t ${tag} --build-arg python=${py} .
     horovod_version=$(docker run --rm ${tag} pip show horovod | grep Version | awk '{print $2}')
     tensorflow_version=$(docker run --rm ${tag} pip show ${tensorflow_pkg} | grep Version | awk '{print $2}')
     pytorch_version=$(docker run --rm ${tag} pip show torch | grep Version | sed 's/+/ /g' | awk '{print $2}')
@@ -30,12 +30,12 @@ function build_one()
 }
 
 # clear upstream images, ok to fail if images do not exist
-docker rmi $(cat Dockerfile.cpu | grep FROM | awk '{print $2}') || true
-docker rmi $(cat Dockerfile.gpu | grep FROM | awk '{print $2}') || true
+# docker rmi $(cat Dockerfile.cpu | grep FROM | awk '{print $2}') || true
+# docker rmi $(cat Dockerfile.gpu | grep FROM | awk '{print $2}') || true
 
 # build for cpu and gpu
 build_one 3.7 cpu
-build_one 3.7 gpu
+# build_one 3.7 gpu
 
 # print recent images
 docker images horovod/horovod


### PR DESCRIPTION
Fixes #2425.

Was able to reproduce locally.  Using v1.7.0.post1 had a separate error, but 1.5.0 worked fine.