### PR TITLE
Enabling in-memory caching for TorchEstimator

### DIFF
--- a/horovod/spark/common/constants.py
+++ b/horovod/spark/common/constants.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 PETASTORM_HDFS_DRIVER = 'libhdfs'
-METRIC_PRINT_FREQUENCY = 1000  # to print metric every 1000 steps in verbose mode
+METRIC_PRINT_FREQUENCY = 100  # to print metric every 1000 steps in verbose mode
 
 ARRAY = 'array'
 CUSTOM_SPARSE = 'custom_sparse_format'

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -21,7 +21,7 @@ import numbers
 import time
 
 from pyspark import keyword_only
-from pyspark.ml.param.shared import Param, Params
+from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.util import MLWritable, MLReadable
 from pyspark.sql import SparkSession
 
@@ -150,6 +150,10 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
     train_minibatch_fn = Param(Params._dummy(), 'train_minibatch_fn',
                                'functions that construct the minibatch train function for torch')
 
+    inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
+                               'Cache the data in memory for training and validation.',
+                               typeConverter=TypeConverters.toBoolean)
+
     @keyword_only
     def __init__(self,
                  num_proc=None,
@@ -181,13 +185,15 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  transformation_fn=None,
                  train_reader_num_workers=None,
                  val_reader_num_workers=None,
-                 label_shapes=None):
+                 label_shapes=None,
+                 inmemory_cache_all=False):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,
                          input_shapes=None,
                          train_minibatch_fn=None,
-                         transformation_fn=None)
+                         transformation_fn=None,
+                         inmemory_cache_all=False)
 
         kwargs = self._input_kwargs
 
@@ -213,6 +219,12 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getLossConstructors(self):
         return self.getOrDefault(self.loss_constructors)
+
+    def setInMemoryCacheAll(self, value):
+        return self._set(inmemory_cache_all=value)
+
+    def getInMemoryCacheAll(self):
+        return self.getOrDefault(self.inmemory_cache_all)
 
     def _get_optimizer(self):
         return self.getOrDefault(self.optimizer)

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.0,!=0.9.3', 'pyarrow>=0.15.0'] + \
+spark_require_list = ['h5py<3', 'numpy', 'petastorm==0.9.8rc0', 'pyarrow>=0.15.0'] + \
                      pyspark_require_list
 ray_require_list = ['ray']
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm==0.9.8rc0', 'pyarrow>=0.15.0'] + \
+spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8', 'pyarrow>=0.15.0'] + \
                      pyspark_require_list
 ray_require_list = ['ray']
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This diff enables in-memory caching for TorchEstimator using Petastorm. It is blocked until https://github.com/uber/petastorm/pull/555 is landed and a new petastorm is released. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.


