### PR TITLE
Add tensor() in TFTensor class to get the TF tensor_'s pointer. (#2452)

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -148,6 +148,7 @@ public:
   virtual const common::TensorShape shape() const override;
   virtual const void* data() const override;
   virtual int64_t size() const override;
+  const ::tensorflow::Tensor* tensor() const;
 
 protected:
   ::tensorflow::Tensor tensor_;
@@ -257,6 +258,8 @@ const common::TensorShape TFTensor::shape() const {
 const void* TFTensor::data() const { return (const void*)tensor_.tensor_data().data(); }
 
 int64_t TFTensor::size() const { return (int64_t)tensor_.tensor_data().size(); }
+
+const ::tensorflow::Tensor*  TFTensor::tensor() const { return &tensor_; }
 
 TFOpContext::TFOpContext(OpKernelContext* context) : context_(context) {}
 


### PR DESCRIPTION
Signed-off-by: zhaoyuan.ye <zhaoyuan.ye@enflame-tech.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Add tensor() to get the TF tensor_‘s pointer  in TFTensor class.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
