### PR TITLE
Changed default cycle time from 5ms to 1ms and fusion threshold from 64MB to 128MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed default cycle time from 5ms to 1ms and fusion threshold from 64MB to 128MB. ([#2468](https://github.com/horovod/horovod/pull/2468))
+
 ### Deprecated
 
 ### Removed

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -439,7 +439,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   state.mark_cycles_in_timeline = mark_cycles;
 
   // Override Tensor Fusion threshold, if it's set.
-  state.parameter_manager.SetTensorFusionThresholdBytes(64 * 1024 * 1024);
+  state.parameter_manager.SetTensorFusionThresholdBytes(128 * 1024 * 1024);
   auto horovod_fusion_threshold = std::getenv(HOROVOD_FUSION_THRESHOLD);
   if (horovod_fusion_threshold != nullptr) {
     int64_t threshold = std::strtol(horovod_fusion_threshold, nullptr, 10);
@@ -447,7 +447,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
   }
 
   // Override the cycle time.
-  state.parameter_manager.SetCycleTimeMs(5);
+  state.parameter_manager.SetCycleTimeMs(1);
   auto horovod_cycle_time = std::getenv(HOROVOD_CYCLE_TIME);
   if (horovod_cycle_time != nullptr) {
     state.parameter_manager.SetCycleTimeMs(

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -306,12 +306,12 @@ def parse_args():
                               help='Fusion buffer threshold in MB. This is the maximum amount of '
                                    'tensor data that can be fused together into a single batch '
                                    'during allreduce / allgather. Setting 0 disables tensor fusion. '
-                                   '(default: 64)')
+                                   '(default: 128)')
     group_params.add_argument('--cycle-time-ms', action=make_override_action(override_args), type=float,
                               help='Cycle time in ms. This is the delay between each tensor fusion '
                                    'cycle. The larger the cycle time, the more batching, but the '
                                    'greater latency between each allreduce / allgather operations. '
-                                   '(default: 5')
+                                   '(default: 1')
     group_params.add_argument('--cache-capacity', action=make_override_action(override_args), type=int,
                               help='Maximum number of tensor names that will be cached to reduce amount '
                                    'of coordination required between workers before performing allreduce / '

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -209,11 +209,11 @@ class RunTests(unittest.TestCase):
     def test_config_file_override_args(self):
         config_filename = os.path.join(os.path.dirname(__file__), 'data/config.test.yaml')
         with override_args('horovodrun', '-np', '2',
-                           '--fusion-threshold-mb', '128',
+                           '--fusion-threshold-mb', '256',
                            '--config-file', config_filename,
                            '--cycle-time-ms', '20',):
             args = parse_args()
-            self.assertEqual(args.fusion_threshold_mb, 128)
+            self.assertEqual(args.fusion_threshold_mb, 256)
             self.assertEqual(args.cycle_time_ms, 20)
 
     def test_validate_config_args(self):


### PR DESCRIPTION
It's been observed empirically that the default cycle time of 5ms is too long, resulting in excessively long pauses between allreduce calls.

Similarly, the fusion buffer threshold of 64MB if often too small for models such as ResNet50 with fp32 gradients.