### PR TITLE
Fix the search order of Eigen/Flatbuffers path (#2429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the search order of Eigen and Flatbuffers paths. ([#2473](https://github.com/horovod/horovod/pull/2473))
+
 ## [0.20.3] - 2020-10-01
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,11 @@ include_directories("third_party/HTTPRequest/include"
         "third_party/boost/static_assert/include"
         "third_party/boost/type_traits/include"
         "third_party/boost/utility/include"
-        "third_party/eigen"
-        "third_party/flatbuffers/include"
         "third_party/lbfgs/include")
+
+# Predefined Eign and Flatbuffers headers path, they could be replaced by tensorflow headers path
+set(EIGEN_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/third_party/eigen")
+set(FLATBUFFERS_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/third_party/flatbuffers/include")
 
 # Sources
 list(APPEND SOURCES "${PROJECT_SOURCE_DIR}/horovod/common/common.cc"

--- a/horovod/mxnet/CMakeLists.txt
+++ b/horovod/mxnet/CMakeLists.txt
@@ -48,6 +48,8 @@ list(APPEND Mxnet_SOURCES "${PROJECT_SOURCE_DIR}/horovod/mxnet/mpi_ops.cc"
 # Create library
 set_output_dir()
 add_library(${Mxnet_TARGET_LIB} SHARED ${SOURCES} ${Mxnet_SOURCES})
+target_include_directories(${Mxnet_TARGET_LIB} PRIVATE "${EIGEN_INCLUDE_PATH}")
+target_include_directories(${Mxnet_TARGET_LIB} PRIVATE "${FLATBUFFERS_INCLUDE_PATH}")
 target_link_libraries(${Mxnet_TARGET_LIB} ${LINKER_LIBS} ${Mxnet_LINKER_LIBS})
 set_target_properties(${Mxnet_TARGET_LIB} PROPERTIES SUFFIX "${Python_SUFFIX}")
 set_target_properties(${Mxnet_TARGET_LIB} PROPERTIES PREFIX "")

--- a/horovod/tensorflow/CMakeLists.txt
+++ b/horovod/tensorflow/CMakeLists.txt
@@ -14,6 +14,25 @@ if(NOT TENSORFLOW_FOUND)
     return()
 endif()
 
+# Overwite Eigen and Flatbuffers headers path if provided in tensorflow or system
+# Search tensorflow path
+find_path(TF_EIGEN_INCLUDE_PATH Eigen/src/Core/EigenBase.h PATHS ${Tensorflow_INCLUDE_DIRS} NO_DEFAULT_PATH)
+if (TF_EIGEN_INCLUDE_PATH STREQUAL "TF_EIGEN_INCLUDE_PATH-NOTFOUND")
+    # If not found, search system path and submodule path
+    find_path(TF_EIGEN_INCLUDE_PATH Eigen/src/Core/EigenBase.h PATHS ${EIGEN_INCLUDE_PATH} REQUIRED)
+endif()
+set(EIGEN_INCLUDE_PATH "${TF_EIGEN_INCLUDE_PATH}" PARENT_SCOPE)
+set(EIGEN_INCLUDE_PATH "${TF_EIGEN_INCLUDE_PATH}")
+
+# Search tensorflow path
+find_path(TF_FLATBUFFERS_INCLUDE_PATH flatbuffers/flatbuffers.h PATHS ${Tensorflow_INCLUDE_DIRS} NO_DEFAULT_PATH)
+if (TF_FLATBUFFERS_INCLUDE_PATH STREQUAL "TF_FLATBUFFERS_INCLUDE_PATH-NOTFOUND")
+    # If not found, search system path and submodule path
+    find_path(TF_FLATBUFFERS_INCLUDE_PATH flatbuffers/flatbuffers.h PATHS ${FLATBUFFERS_INCLUDE_PATH} REQUIRED)
+endif()
+set(FLATBUFFERS_INCLUDE_PATH "${TF_FLATBUFFERS_INCLUDE_PATH}" PARENT_SCOPE)
+set(FLATBUFFERS_INCLUDE_PATH "${TF_FLATBUFFERS_INCLUDE_PATH}")
+
 include_directories(SYSTEM ${Tensorflow_INCLUDE_DIRS})
 list(APPEND TF_LINKER_LIBS ${Tensorflow_LIBRARIES})
 if(HAVE_GLOO)
@@ -41,6 +60,10 @@ list(APPEND TF_SOURCES "${PROJECT_SOURCE_DIR}/horovod/tensorflow/mpi_ops.cc")
 # Create library
 set_output_dir()
 add_library(${TF_TARGET_LIB} SHARED ${SOURCES} ${TF_SOURCES})
+if (NOT EIGEN_INCLUDE_PATH STREQUAL Tensorflow_INCLUDE_DIRS)
+    target_include_directories(${TF_TARGET_LIB} PRIVATE ${EIGEN_INCLUDE_PATH})
+endif()
+target_include_directories(${TF_TARGET_LIB} PRIVATE ${FLATBUFFERS_INCLUDE_PATH})
 target_link_libraries(${TF_TARGET_LIB} ${LINKER_LIBS} ${TF_LINKER_LIBS})
 set_target_properties(${TF_TARGET_LIB} PROPERTIES SUFFIX "${Python_SUFFIX}")
 set_target_properties(${TF_TARGET_LIB} PROPERTIES PREFIX "")

--- a/horovod/torch/CMakeLists.txt
+++ b/horovod/torch/CMakeLists.txt
@@ -66,6 +66,8 @@ list(APPEND PYTORCH_SOURCES "${PROJECT_SOURCE_DIR}/horovod/torch/handle_manager.
 # Create library
 set_output_dir()
 add_library(${PYTORCH_TARGET_LIB} SHARED ${SOURCES} ${PYTORCH_SOURCES})
+target_include_directories(${PYTORCH_TARGET_LIB} PRIVATE "${EIGEN_INCLUDE_PATH}")
+target_include_directories(${PYTORCH_TARGET_LIB} PRIVATE "${FLATBUFFERS_INCLUDE_PATH}")
 target_link_libraries(${PYTORCH_TARGET_LIB} ${LINKER_LIBS} ${PYTORCH_LINKER_LIBS})
 set_target_properties(${PYTORCH_TARGET_LIB} PROPERTIES SUFFIX "${Python_SUFFIX}")
 set_target_properties(${PYTORCH_TARGET_LIB} PROPERTIES PREFIX "")


### PR DESCRIPTION
Search a Tensorflow-provided or system installed version of
Eigen/Flatbuffers if it exists. Otherwise use Eigen/Flatbuffers from
submodules.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #2429 .

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
