### PR TITLE
Set HOROVOD_GLOO_IFACE correctly for multiple interfaces (#2431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `HOROVOD_GLOO_IFACE` for each host when setting --network-interface. ([#2482](https://github.com/horovod/horovod/pull/2482))
+
 ## [v0.21.0] - 2020-11-23
 
 ### Added

--- a/horovod/runner/common/util/settings.py
+++ b/horovod/runner/common/util/settings.py
@@ -62,6 +62,7 @@ class BaseSettings(object):
         self.nics = nics
         self.elastic = elastic
         self.prefix_output_with_timestamp = prefix_output_with_timestamp
+        self.host_nic_dict = None
 
 
 class Settings(BaseSettings):

--- a/horovod/runner/gloo_run.py
+++ b/horovod/runner/gloo_run.py
@@ -76,7 +76,7 @@ def create_slot_env_vars(slot_info):
     return horovod_rendez_env
 
 
-def _slot_info_to_command_fn(run_command, env):
+def _slot_info_to_command_fn(run_command, env, host_nic_dict):
     # TODO: Workaround for over-buffered outputs. Investigate how mpirun avoids this problem.
     env = copy.copy(env)  # copy env so we do not leak env modifications
     env['PYTHONUNBUFFERED'] = '1'
@@ -89,20 +89,25 @@ def _slot_info_to_command_fn(run_command, env):
         :return:
         """
         env_vars = create_slot_env_vars(slot_info)
+        # HOROVOD_GLOO_IFACE selects first available nic on current host
+        # TODO: add multiple ifaces in future
+        iface = list(host_nic_dict[slot_info.hostname])[0]
+        gloo_iface_env = f"HOROVOD_GLOO_IFACE={iface}"
         horovod_rendez_env = " ".join(
             [f"{k}={str(v)}" for k, v in env_vars.items()])
 
-        return '{horovod_env} {env} {run_command}' .format(
+        return '{horovod_env} {env} {iface_env} {run_command}' .format(
             horovod_env=horovod_rendez_env,
             env=' '.join(['%s=%s' % (key, quote(value)) for key, value in env.items()
                           if env_util.is_exportable(key)]),
+            iface_env=gloo_iface_env,
             run_command=run_command)
 
     return slot_info_to_command
 
 
-def _create_elastic_worker_fn(exec_command, run_command, env, event):
-    get_command_with_env = _slot_info_to_command_fn(run_command, env)
+def _create_elastic_worker_fn(exec_command, run_command, env, event, host_nic_dict):
+    get_command_with_env = _slot_info_to_command_fn(run_command, env, host_nic_dict)
 
     def create_worker(slot_info, events):
         command = get_command_with_env(slot_info)
@@ -190,7 +195,6 @@ def create_run_env_vars(server_ip, nics, port, elastic=False):
         'HOROVOD_GLOO_RENDEZVOUS_PORT': port,
         'HOROVOD_CONTROLLER': "gloo",
         'HOROVOD_CPU_OPERATIONS': "gloo",
-        'HOROVOD_GLOO_IFACE': list(nics)[0],   # TODO: add multiple ifaces in future
         'NCCL_SOCKET_IFNAME': ','.join(nics),
     }
     if elastic:
@@ -246,12 +250,15 @@ def launch_gloo(command, exec_command, settings, nics, env, server_ip):
     hosts = parse_hosts(settings.hosts)
     host_alloc_plan = get_host_assignments(hosts, settings.num_proc)
 
+    # Get hostname-to-interfaces dict
+    host_nic_dict = settings.host_nic_dict
+
     # start global rendezvous server and get port that it is listening on
     global_rendezv_port = rendezvous.start()
     rendezvous.init(host_alloc_plan)
     run_command = get_run_command(command, server_ip, nics, global_rendezv_port)
 
-    slot_info_to_command = _slot_info_to_command_fn(run_command, env)
+    slot_info_to_command = _slot_info_to_command_fn(run_command, env, host_nic_dict)
     event = register_shutdown_event()
     args_list = [[slot_info_to_command(slot_info), slot_info, [event]]
                  for slot_info in host_alloc_plan]
@@ -305,7 +312,10 @@ def launch_gloo_elastic(command, exec_command, settings, env, get_common_interfa
     event = register_shutdown_event()
     run_command = get_run_command(command, server_ip, nics, global_rendezv_port, elastic=True)
 
-    create_worker = _create_elastic_worker_fn(exec_command, run_command, env, event)
+    # Get hostname-to-interfaces dict
+    host_nic_dict = settings.host_nic_dict
+
+    create_worker = _create_elastic_worker_fn(exec_command, run_command, env, event, host_nic_dict)
 
     driver.start(settings.num_proc, create_worker)
     res = driver.get_results()

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -87,7 +87,8 @@ def gloo_run_elastic(settings, driver, env):
     env[secret.HOROVOD_SECRET_KEY] = codec.dumps_base64(settings.key)
 
     # get common interfaces from driver
-    nics = driver.get_common_interfaces()
+    nics,host_nic_dict = driver.get_common_interfaces()
+    settings.host_nic_dict = host_nic_dict
 
     exec_command = _exec_command_fn(driver, settings.key, settings, env)
     rendezvous = SparkRendezvousServer(driver, settings.verbose)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -148,7 +148,8 @@ def _make_spark_thread(spark_context, spark_job_group, driver, result_queue,
 
 
 def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=None):
-    nics = driver.get_common_interfaces()
+    nics,host_nic_dict = driver.get_common_interfaces()
+    settings.host_nic_dict = host_nic_dict
     run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env),
                    use_mpi, lambda: mpi_run(settings, nics, driver, env, stdout, stderr),
                    False, lambda: None,

--- a/test/integration/test_spark.py
+++ b/test/integration/test_spark.py
@@ -138,7 +138,7 @@ class SparkTests(unittest.TestCase):
             client.register_task_to_task_addresses(0, {'lo': [('127.0.0.1', 31321)], 'eth0': [('192.168.0.1', 31321)]})
             client.register_task_to_task_addresses(1, {'eth1': [('10.0.0.1', 31322)], 'eth0': [('192.168.0.2', 31322)]})
 
-            nics = driver.get_common_interfaces()
+            nics,_ = driver.get_common_interfaces()
             self.assertEqual({'eth0'}, nics)
 
     def test_driver_common_interfaces_from_settings(self):
@@ -151,7 +151,7 @@ class SparkTests(unittest.TestCase):
             client.register_task_to_task_addresses(0, {'eth0': [('192.168.0.1', 31321)]})
             client.register_task_to_task_addresses(1, {'eth1': [('10.0.0.1', 31322)]})
 
-            nics = driver.get_common_interfaces()
+            nics,_ = driver.get_common_interfaces()
             self.assertEqual({nic}, nics)
 
     def test_driver_common_interfaces_fails(self):

--- a/test/integration/test_spark.py
+++ b/test/integration/test_spark.py
@@ -791,11 +791,11 @@ class SparkTests(unittest.TestCase):
                                 'HOROVOD_CROSS_RANK=0 '
                                 'HOROVOD_CROSS_SIZE=1 '
                                 'PYTHONUNBUFFERED=1 '
+                                'HOROVOD_GLOO_IFACE=[^ ]+ '
                                 'HOROVOD_GLOO_RENDEZVOUS_ADDR=[^ ]+ '
                                 'HOROVOD_GLOO_RENDEZVOUS_PORT=[0-9]+ '
                                 'HOROVOD_CONTROLLER=gloo '
                                 'HOROVOD_CPU_OPERATIONS=gloo '
-                                'HOROVOD_GLOO_IFACE=[^ ]+ '
                                 'NCCL_SOCKET_IFNAME=[^ ]+ '
                                 '[^ ]+python[0-9.]* -m horovod.spark.task.gloo_exec_fn '
                                 '[^ ]+ [^ ]+$'.format(rank=alloc_info.rank,
@@ -814,9 +814,9 @@ class SparkTests(unittest.TestCase):
             # for better comparison replace sections in actual_command that change across runs / hosts
             for replacement in ['_HOROVOD_SECRET_KEY=[^ ]+',
                                 'HOROVOD_HOSTNAME=[^ ]+',
+                                'HOROVOD_GLOO_IFACE=[^ ]+',
                                 'HOROVOD_GLOO_RENDEZVOUS_ADDR=[^ ]+',
                                 'HOROVOD_GLOO_RENDEZVOUS_PORT=[0-9]+',
-                                'HOROVOD_GLOO_IFACE=[^ ]+',
                                 'NCCL_SOCKET_IFNAME=[^ ]+',
                                 '[^ ]+python[0-9.]*',
                                 '[^ ]+ [^ ]+$']:


### PR DESCRIPTION
Add a hostname-to-interfaces dict for all hostnames and connected
interfaces on them. When setting HOROVOD_GLOO_IFACE, only select first
available interface for current hostname.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
