### PR TITLE
elastic: avoid sync if workers are only shrinked (#1876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed "Intermediate path does not exist" error with DBFSLocalStore. ([#2526](https://github.com/horovod/horovod/pull/2526))
 
+- Avoid synchronization if workers are only shrinked in elastic mode. ([#2514](https://github.com/horovod/horovod/pull/2514))
 
 ## [v0.21.0] - 2020-11-23
 

--- a/horovod/common/exceptions.py
+++ b/horovod/common/exceptions.py
@@ -28,7 +28,8 @@ class HostsUpdatedInterrupt(RuntimeError):
 
     In elastic mode, this will result in a reset event without a restore to committed state.
     """
-    pass
+    def __init__(self, skip_sync):
+        self.skip_sync = skip_sync
 
 
 def get_version_mismatch_message(name, version, installed_version):


### PR DESCRIPTION
During recovery, if horovod knows only known slots and hosts are removed,
and no new hosts and slots are joining, then the sync of training
parameters can be skipped. All the shrinked workers already have
up-to-date parameters.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes (https://github.com/horovod/horovod/issues/1876)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
