### PR TITLE
Set model.eval() in TorchEstimator before return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed building Horovod for ROCm PyTorch with newer hipify script. ([#2360](https://github.com/horovod/horovod/pull/2360))
+- Fixed TorchEstimator returning model without switching to eval mode. ([#2517](https://github.com/horovod/horovod/pull/2517))
 
 ## [v0.21.0] - 2020-11-23
 

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -289,6 +289,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         optimizer = copy.deepcopy(self.getOptimizer())
 
         model.load_state_dict(best_checkpoint['model'])
+        model.eval()
         optimizer.load_state_dict(best_checkpoint['optimizer'])
 
         return self.get_model_class()(**self._get_model_kwargs(
@@ -396,8 +397,6 @@ class TorchModel(HorovodModel, TorchEstimatorParamsWritable, TorchEstimatorParam
     # To run locally on OS X, need export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     def _transform(self, df):
         model_pre_predict = self.getModel()
-        model_pre_predict.eval()
-
         deserialize = deserialize_fn()
         serialize = serialize_fn()
         serialized_model = serialize(model_pre_predict)


### PR DESCRIPTION
## Checklist before submitting

- [X] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [X] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

TorchEstimator currently returns a model without switching to eval mode. This PR fixes that.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
