### PR TITLE
Avoid overwriting methods in the super class of DBFSLocalStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove ssh reliance for Ray elastic training ([#2528](https://github.com/horovod/horovod/pull/2528))
 
+- Fixed "Intermediate path does not exist" error with DBFSLocalStore. ([#2526](https://github.com/horovod/horovod/pull/2526))
+
 ## [v0.21.0] - 2020-11-23
 
 ### Added

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -144,7 +144,7 @@ class Store(object):
     def create(prefix_path, *args, **kwargs):
         if HDFSStore.matches(prefix_path):
             return HDFSStore(prefix_path, *args, **kwargs)
-        elif is_databricks() and DBFSLocalStore.matches(prefix_path):
+        elif is_databricks() and DBFSLocalStore.matches_dbfs(prefix_path):
             return DBFSLocalStore(prefix_path, *args, **kwargs)
         else:
             return LocalStore(prefix_path, *args, **kwargs)
@@ -461,17 +461,18 @@ class DBFSLocalStore(LocalStore):
     https://docs.databricks.com/data/databricks-file-system.html#local-file-apis.
     """
     def __init__(self, prefix_path, *args, **kwargs):
-        prefix_path = self.get_localized_path(prefix_path)
+        prefix_path = self.normalize_path(prefix_path)
         if not prefix_path.startswith("/dbfs/"):
             warnings.warn("The provided prefix_path might be ephemeral: {} Please provide a "
                           "`prefix_path` starting with `/dbfs/...`".format(prefix_path))
         super(DBFSLocalStore, self).__init__(prefix_path, *args, **kwargs)
 
     @classmethod
-    def matches(cls, path):
+    def matches_dbfs(cls, path):
         return path.startswith("dbfs:/") or path.startswith("/dbfs/") or path.startswith("file:///dbfs/")
 
-    def get_localized_path(self, path):
+    @staticmethod
+    def normalize_path(path):
         """
         Normalize the path to the form `/dbfs/...`
         """


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

The issue is that on Databricks, DBFSLocalStore cannot correctly write intermediate files due to the previous PR #2376. I updated DBFSLocalStore to avoid overwriting the methods in the superclass: `matches` and `get_localized_path`, because those are needed for the underlying LocalStore to work correctly. The dbfs parsing logic should be defined in dedicated methods.

I manually tested the change on Databricks and it works well.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
