### PR TITLE
add support to check supported frameworks versions (#2518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove ssh reliance for Ray elastic training ([#2528](https://github.com/horovod/horovod/pull/2528))
 
+- Fixed error handling for changing framework without reinstalling horovod ([#2529](https://github.com/horovod/horovod/pull/2529))
+
 ## [v0.21.0] - 2020-11-23
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 include(cmake/Utilities.cmake)
 
+create_metadata()
+
 # 3rd-parties
 include_directories("third_party/HTTPRequest/include"
         "third_party/boost/assert/include"
@@ -293,6 +295,9 @@ add_subdirectory(horovod/tensorflow)
 add_subdirectory(horovod/torch)
 #MXNet
 add_subdirectory(horovod/mxnet)
+
+# Correctly wrap up json format
+file(APPEND "${CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT}/metadata.json" "\"dummy\": \"none\"\n}")
 
 # CUDA kernels
 if(HAVE_CUDA OR HAVE_SUB_PROJECT_CUDA)

--- a/cmake/Utilities.cmake
+++ b/cmake/Utilities.cmake
@@ -28,6 +28,16 @@ macro(SET_OUTPUT_DIR)
     endforeach()
 endmacro()
 
+# Create metadata file to store frameworks versions
+macro(CREATE_METADATA)
+    foreach( _VAR in ITEMS CMAKE_LIBRARY_OUTPUT_DIRECTORY CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO)
+        if(DEFINED ${_VAR})
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT "${${_VAR}}/horovod")
+            file(WRITE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT}/metadata.json" "{\n")
+        endif()
+    endforeach()
+endmacro()
+
 # Set build architecture flags
 macro(SET_BUILD_ARCH_FLAGS FLAGS)
     set(HOROVOD_BUILD_ARCH_FLAGS $ENV{HOROVOD_BUILD_ARCH_FLAGS})

--- a/horovod/common/exceptions.py
+++ b/horovod/common/exceptions.py
@@ -29,3 +29,20 @@ class HostsUpdatedInterrupt(RuntimeError):
     In elastic mode, this will result in a reset event without a restore to committed state.
     """
     pass
+
+
+def get_version_mismatch_message(name, version, installed_version):
+    return f'Framework {name} installed with version {installed_version} but found version {version}.\n\
+             This can result in unexpected behavior including runtime errors.\n\
+             Reinstall Horovod using `pip install --no-cache-dir` to build with the new version.'
+
+
+class HorovodVersionMismatchError(Exception):
+    """Internal error raised when the runtime version of a framework mismatches its version at
+    Horovod installation time.
+    """
+    def __init__(self, name, version, installed_version):
+        super().__init__(get_version_mismatch_message(name, version, installed_version))
+        self.name = name
+        self.version = version
+        self.installed_version = installed_version

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 # =============================================================================
 
+import json
 import multiprocessing
 import os
 import sys
@@ -22,6 +23,8 @@ import sysconfig
 import warnings
 
 from contextlib import contextmanager
+
+from horovod.common.exceptions import get_version_mismatch_message, HorovodVersionMismatchError
 
 
 EXTENSIONS = ['tensorflow', 'torch', 'mxnet']
@@ -251,3 +254,15 @@ def split_list(l, n):
     """
     d, r = divmod(len(l), n)
     return [l[i * d + min(i, r):(i + 1) * d + min(i + 1, r)] for i in range(n)]
+
+
+def check_installed_version(name, version, exception=None):
+    file_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),\
+        os.pardir, "metadata.json"))
+    with open(file_path) as f:
+        installed_version = json.load(f).get(name)
+        if installed_version != version:
+            if exception is None:
+                warnings.warn(get_version_mismatch_message(name, version, installed_version))
+            else:
+                raise HorovodVersionMismatchError(name, version, installed_version) from exception

--- a/horovod/mxnet/CMakeLists.txt
+++ b/horovod/mxnet/CMakeLists.txt
@@ -15,6 +15,9 @@ if(NOT MXNET_FOUND)
 endif()
 set(Mxnet_CXX11 ${Mxnet_CXX11} PARENT_SCOPE)
 
+# Append version number into metadata
+file(APPEND "${CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT}/metadata.json" "\"mxnet\": \"${Mxnet_VERSION}\",\n")
+
 if (HAVE_CUDA AND NOT Mxnet_USE_CUDA)
     message(FATAL_ERROR "Horovod build with GPU support was requested but this MXNet installation does not support CUDA.")
 elseif (Mxnet_USE_CUDA AND NOT HAVE_CUDA)

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -23,9 +23,17 @@ import os
 import mxnet as mx
 from mxnet.base import c_handle_array, c_str, c_str_array, check_call, string_types
 
-from horovod.common.util import get_ext_suffix
+from horovod.common.util import check_installed_version, get_ext_suffix
 from horovod.common.basics import HorovodBasics as _HorovodBasics
-_basics = _HorovodBasics(__file__, 'mpi_lib')
+
+# Check possible symbol not found error from mxnet version mismatch
+try:
+    _basics = _HorovodBasics(__file__, 'mpi_lib')
+except Exception as e:
+    check_installed_version('mxnet', mx.__version__, e)
+    raise e
+else:
+    check_installed_version('mxnet', mx.__version__)
 
 # import basic methods
 init = _basics.init

--- a/horovod/tensorflow/CMakeLists.txt
+++ b/horovod/tensorflow/CMakeLists.txt
@@ -14,6 +14,9 @@ if(NOT TENSORFLOW_FOUND)
     return()
 endif()
 
+# Append version number into metadata
+file(APPEND "${CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT}/metadata.json" "\"tensorflow\": \"${Tensorflow_VERSION}\",\n")
+
 # Overwite Eigen and Flatbuffers headers path if provided in tensorflow or system
 # Search tensorflow path
 find_path(TF_EIGEN_INCLUDE_PATH Eigen/src/Core/EigenBase.h PATHS ${Tensorflow_INCLUDE_DIRS} NO_DEFAULT_PATH)

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -23,8 +23,8 @@ from tensorflow.python.framework import load_library
 from tensorflow.python.framework import ops
 from tensorflow.python.platform import resource_loader
 
-from horovod.common.util import get_ext_suffix, get_average_backwards_compatibility_fun, gpu_available, \
-    num_rank_is_power_2
+from horovod.common.util import check_installed_version, get_ext_suffix, \
+    get_average_backwards_compatibility_fun, gpu_available, num_rank_is_power_2
 from horovod.common.basics import HorovodBasics as _HorovodBasics
 from horovod.tensorflow.util import _executing_eagerly
 
@@ -42,8 +42,14 @@ def _load_library(name):
     library = load_library.load_op_library(filename)
     return library
 
-
-MPI_LIB = _load_library('mpi_lib' + get_ext_suffix())
+# Check possible symbol not found error from tensorflow version mismatch
+try:
+    MPI_LIB = _load_library('mpi_lib' + get_ext_suffix())
+except Exception as e:
+    check_installed_version('tensorflow', tf.__version__, e)
+    raise e
+else:
+    check_installed_version('tensorflow', tf.__version__)
 
 _basics = _HorovodBasics(__file__, 'mpi_lib')
 

--- a/horovod/torch/CMakeLists.txt
+++ b/horovod/torch/CMakeLists.txt
@@ -14,6 +14,9 @@ if(NOT PYTORCH_FOUND)
     return()
 endif()
 
+# Append version number into metadata
+file(APPEND "${CMAKE_LIBRARY_OUTPUT_DIRECTORY_ROOT}/metadata.json" "\"pytorch\": \"${Pytorch_VERSION}\",\n")
+
 if (HAVE_CUDA AND NOT Pytorch_CUDA)
     message(FATAL_ERROR "Horovod build with GPU support was requested but this PyTorch installation does not support CUDA.")
 elseif (Pytorch_CUDA AND NOT HAVE_CUDA)

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -20,16 +20,24 @@ import torch
 
 import warnings
 
-from horovod.torch import mpi_lib_v2 as mpi_lib
 from horovod.common.basics import HorovodBasics as _HorovodBasics
-_NULL = ""
-_basics = _HorovodBasics(__file__, 'mpi_lib_v2')
-
 from horovod.common.exceptions import HorovodInternalError
-from horovod.common.util import get_average_backwards_compatibility_fun, gpu_available, num_rank_is_power_2
+from horovod.common.util import check_installed_version, get_average_backwards_compatibility_fun, gpu_available, num_rank_is_power_2
 
 from horovod.torch.compression import Compression
 
+# Check possible symbol not found error from pytorch version mismatch
+try:
+    from horovod.torch import mpi_lib_v2 as mpi_lib
+except Exception as e:
+    check_installed_version('pytorch', torch.__version__, e)
+    raise e
+else:
+    check_installed_version('pytorch', torch.__version__)
+
+_NULL = ""
+
+_basics = _HorovodBasics(__file__, 'mpi_lib_v2')
 # import basic methods
 init = _basics.init
 is_initialized = _basics.is_initialized


### PR DESCRIPTION
Check if the versions of supported frameworks match with horovod
installation. Throw out a warning to let users know that version is
mismatched, which could result in a possible undefined-symbol error
when using the framework.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #2518 .

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
