### PR TITLE
Pin mxnet-nightly following missing file oneapi/dnnl/dnnl_config.h

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -145,7 +145,7 @@ RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet==2.0.0b20201214 -f https://dist.mxnet.io/python/all; \
+        pip install --pre mxnet==2.0.0b20201213 -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \
     fi

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -145,7 +145,7 @@ RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet -f https://dist.mxnet.io/python/all; \
+        pip install --pre mxnet==2.0.0b20201214 -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -119,7 +119,7 @@ RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet-cu101==2.0.0b20201214 -f https://dist.mxnet.io/python/all; \
+        pip install --pre mxnet-cu101==2.0.0b20201213 -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \
     fi

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -119,7 +119,7 @@ RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet.
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet-cu101 -f https://dist.mxnet.io/python/all; \
+        pip install --pre mxnet-cu101==2.0.0b20201214 -f https://dist.mxnet.io/python/all; \
     else \
         pip install ${MXNET_PACKAGE} ; \
     fi


### PR DESCRIPTION
Temporary workaround for the following install error:

```

In file included from /usr/local/lib/python3.6/dist-packages/mxnet/include/mkldnn/dnnl.hpp:20:0,
from /usr/local/lib/python3.6/dist-packages/mxnet/include/mkldnn/mkldnn.hpp:24,
from /usr/local/lib/python3.6/dist-packages/mxnet/include/mxnet/ndarray.h:41,
from /tmp/pip-req-build-gm88s5we/horovod/mxnet/mpi_ops.h:24,
from /tmp/pip-req-build-gm88s5we/horovod/mxnet/mpi_ops.cc:21:
/usr/local/lib/python3.6/dist-packages/mxnet/include/mkldnn/oneapi/dnnl/dnnl.hpp:23:10: fatal error: oneapi/dnnl/dnnl_config.h: No such file or directory
#include "oneapi/dnnl/dnnl_config.h"
^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
horovod/mxnet/CMakeFiles/mxnet.dir/build.make:758: recipe for target 'horovod/mxnet/CMakeFiles/mxnet.dir/mpi_ops.cc.o' failed
```

See: https://buildkite.com/horovod/horovod/builds/4506#a6769f7e-8d94-4fbe-9635-bc38139bc3d3/6-1727