### PR TITLE
Move sphinx to pypi

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/sphinx-doc/sphinx@2.x
+sphinx
 sphinxcontrib-napoleon
 alabaster
 nbsphinx


### PR DESCRIPTION
Moves to PyPi package for sphinx, also moves to latest version (3.x rather than 2.x), This also saves 40MB download per build.