### PR TITLE
Remove -j8 default when installing Horovod due to race condition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class custom_build_ext(build_ext):
                       '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(config.upper(), build_dir),
                       '-DPYTHON_EXECUTABLE:FILEPATH=' + sys.executable]
 
-        make_args = ['-j8'] if not os.environ.get('MAKEFLAGS') else []
+        make_args = []
         if self.verbose:
             make_args.append('VERBOSE=1')
 


### PR DESCRIPTION
See #2543.  We may revert this / replace with dynamic parallelism strategy once this issue is resolved.