### PR TITLE
Use latest actions

### DIFF
--- a/.github/workflows/buildkite_unit_tests.yml
+++ b/.github/workflows/buildkite_unit_tests.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Download Buildkite Artifacts
       id: download
-      uses: docker://ghcr.io/enricomi/download-buildkite-artifact-action:v1.6
+      uses: docker://ghcr.io/enricomi/download-buildkite-artifact-action:latest
       if: steps.commit-changes.outputs.changed-code-files != ''
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Unit Test Results
       id: results
-      uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+      uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:latest
       if: >
         steps.download.outcome != 'skipped' &&
         ! contains(fromJSON('[''blocked'', ''canceled'', ''skipped'', ''not_run'']'), steps.download.outputs.build-state)


### PR DESCRIPTION
Use latest version of these github actions to stay up-to-date. This also upgrades publish-unit-test-result-action to v1.7.