### PR TITLE
Make 'pip install -e .[dev]' work with Python3.8

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -131,8 +131,8 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-# Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} "h5py<3" "scipy<1.4.0" "pandas<1.1.0"
+# Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
+RUN pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"
 RUN mkdir -p ~/.keras
 RUN python -c "from keras.datasets import mnist; mnist.load_data()"
 

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -101,8 +101,8 @@ RUN pip install ${TENSORFLOW_PACKAGE}
 
 # Install Keras.
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-# Pin scipy<1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN pip install ${KERAS_PACKAGE} "h5py<3" "scipy<1.4.0" "pandas<1.1.0"
+# Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
+RUN pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"
 RUN mkdir -p ~/.keras
 RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     python -c "from keras.datasets import mnist; mnist.load_data()" && \

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -32,7 +32,7 @@ The versions with CPU support can be installed through the provided :code:`setup
 
 .. code-block:: bash
 
-    pip install -e .[dev]
+    pip install -e .[dev,test]
 
 You can find all other non-Python packages that need to be installed on your system for Horovod to build
 in the `Dockerfile.test.cpu <https://github.com/horovod/horovod/blob/master/Dockerfile.test.cpu>`__ and

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8', 'pyarrow>=0.15.0'] + \
-                     pyspark_require_list
+spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8', 'pyarrow>=0.15.0']
 ray_require_list = ['ray']
 
 # all frameworks' dependencies
@@ -116,7 +115,8 @@ all_frameworks_require_list = tensorflow_require_list + \
                               keras_require_list + \
                               pytorch_require_list + \
                               mxnet_require_list + \
-                              spark_require_list
+                              spark_require_list + \
+                              pyspark_require_list
 
 # python packages required / recommended to develop horovod
 # e.g., set of framework versions pinned for development, keep in sync with Dockerfile.test.cpu
@@ -180,7 +180,7 @@ setup(name='horovod',
           'keras': keras_require_list,
           'pytorch': pytorch_require_list,
           'mxnet': mxnet_require_list,
-          'spark': spark_require_list,
+          'spark': spark_require_list + pyspark_require_list,
           'ray': ray_require_list,
           'dev': dev_require_list,
           'test': test_require_list,

--- a/setup.py
+++ b/setup.py
@@ -121,12 +121,18 @@ all_frameworks_require_list = tensorflow_require_list + \
 # python packages required / recommended to develop horovod
 # e.g., set of framework versions pinned for development, keep in sync with Dockerfile.test.cpu
 # NOTE: do not use versions with +cpu or +gpu here as users would need to add --find-links to pip
-dev_require_list = ['tensorflow-cpu==1.15.0',
-                    'keras==2.2.4',
-                    'torch==1.2.0',
-                    'torchvision==0.4.0',
-                    'mxnet==1.5.0',
-                    'pyspark==2.4.7'] + spark_require_list
+dev_require_list = ['tensorflow-cpu==1.15.0;python_version<"3.8"',
+                    'tensorflow-cpu==2.2.0;python_version>="3.8"',
+                    'keras==2.3.1',
+                    'torch==1.2.0;python_version<"3.8"',
+                    'torch==1.4.0;python_version>="3.8"',
+                    'torchvision==0.4.0;python_version<"3.8"',
+                    'torchvision==0.5.0;python_version>="3.8"',
+                    'mxnet==1.4.1;python_version<"3.8"',
+                    'mxnet==1.5.0;python_version<="3.8"',
+                    'pyspark==2.4.7;python_version<"3.8"',
+                    'pyspark==3.0.1;python_version>="3.8"'] + spark_require_list
+# torchvision 0.5.0 depends on torch==1.4.0
 
 # python packages required only to run tests
 # Pin h5py: https://github.com/h5py/h5py/issues/1732

--- a/setup.py
+++ b/setup.py
@@ -119,19 +119,15 @@ all_frameworks_require_list = tensorflow_require_list + \
                               pyspark_require_list
 
 # python packages required / recommended to develop horovod
-# e.g., set of framework versions pinned for development, keep in sync with Dockerfile.test.cpu
+# these are the earliest versions to work with Python 3.8
+# keep in sync with Dockerfile.test.cpu
 # NOTE: do not use versions with +cpu or +gpu here as users would need to add --find-links to pip
-dev_require_list = ['tensorflow-cpu==1.15.0;python_version<"3.8"',
-                    'tensorflow-cpu==2.2.0;python_version>="3.8"',
+dev_require_list = ['tensorflow-cpu==2.2.0',
                     'keras==2.3.1',
-                    'torch==1.2.0;python_version<"3.8"',
-                    'torch==1.4.0;python_version>="3.8"',
-                    'torchvision==0.4.0;python_version<"3.8"',
-                    'torchvision==0.5.0;python_version>="3.8"',
-                    'mxnet==1.4.1;python_version<"3.8"',
-                    'mxnet==1.5.0;python_version<="3.8"',
-                    'pyspark==2.4.7;python_version<"3.8"',
-                    'pyspark==3.0.1;python_version>="3.8"'] + spark_require_list
+                    'torch==1.4.0',
+                    'torchvision==0.5.0',
+                    'mxnet==1.5.0',
+                    'pyspark==3.0.1'] + spark_require_list
 # torchvision 0.5.0 depends on torch==1.4.0
 
 # python packages required only to run tests


### PR DESCRIPTION
Versions of some packages in [dev] do not exist for Python 3.8, moving to the first version that supports 3.8 for those.