### PR TITLE
Make tests that use commons work on their own

### DIFF
--- a/test/parallel/test_keras.py
+++ b/test/parallel/test_keras.py
@@ -16,6 +16,8 @@
 """Tests for horovod.keras."""
 
 from distutils.version import LooseVersion
+import os
+import sys
 
 import keras
 from keras import backend as K
@@ -26,6 +28,8 @@ import tensorflow as tf
 import warnings
 
 import horovod.keras as hvd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import temppath
 

--- a/test/parallel/test_mxnet.py
+++ b/test/parallel/test_mxnet.py
@@ -15,12 +15,15 @@
 # ==============================================================================
 
 import os
+import sys
 import itertools
 import unittest
 from distutils.version import LooseVersion
 
 import pytest
 import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import skip_or_fail_gpu_test
 

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -25,12 +25,15 @@ import numpy as np
 import os
 import math
 import pytest
+import sys
 import tensorflow as tf
 from horovod.tensorflow.util import _executing_eagerly
 from tensorflow.python.framework import ops
 import warnings
 
 import horovod.tensorflow as hvd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import mpi_env_rank_and_size, skip_or_fail_gpu_test
 

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -17,7 +17,9 @@
 
 import math
 import numpy as np
+import os
 import pytest
+import sys
 import tensorflow as tf
 import warnings
 
@@ -27,6 +29,8 @@ from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.optimizer_v2 import optimizer_v2
 
 import horovod.tensorflow.keras as hvd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import temppath
 

--- a/test/parallel/test_timeline.py
+++ b/test/parallel/test_timeline.py
@@ -16,10 +16,14 @@
 import torch
 import unittest
 import warnings
+import os
+import sys
 import time
 
 import horovod.torch as hvd
 from horovod.common.util import env
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import temppath
 

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -21,6 +21,7 @@ import inspect
 import itertools
 import os
 import platform
+import sys
 import unittest
 import warnings
 import time
@@ -35,6 +36,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import horovod.torch as hvd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import mpi_env_rank_and_size, skip_or_fail_gpu_test, temppath
 

--- a/test/single/test_buildkite.py
+++ b/test/single/test_buildkite.py
@@ -20,6 +20,8 @@ import unittest
 import warnings
 from shutil import copy
 
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
+
 from common import tempdir
 from horovod.runner.common.util import safe_shell_exec
 

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -29,7 +29,6 @@ import warnings
 import mock
 import psutil
 import pytest
-from common import is_built, lsf_and_jsrun, override_args, override_env, temppath, delay, wait
 from mock import MagicMock
 
 import horovod
@@ -45,6 +44,10 @@ from horovod.runner.mpi_run import _get_mpi_implementation, _get_mpi_implementat
     _LARGE_CLUSTER_THRESHOLD as large_cluster_threshold, mpi_available, mpi_run, \
     _OMPI_IMPL, _SMPI_IMPL, _MPICH_IMPL, _UNKNOWN_IMPL, _MISSING_IMPL
 from horovod.runner.util.threads import in_thread, on_event
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
+
+from common import is_built, lsf_and_jsrun, override_args, override_env, temppath, delay, wait
 
 
 class RunTests(unittest.TestCase):

--- a/test/utils/spark_common.py
+++ b/test/utils/spark_common.py
@@ -17,9 +17,8 @@ import contextlib
 import os
 import platform
 import stat
-import uuid
+import sys
 
-from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from pyspark.ml import Pipeline
@@ -31,6 +30,8 @@ from horovod.runner.common.util import secret
 from horovod.spark.common.store import LocalStore
 from horovod.spark.driver.driver_service import SparkDriverService, SparkDriverClient
 from horovod.spark.task.task_service import SparkTaskService, SparkTaskClient
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import tempdir, temppath
 


### PR DESCRIPTION
Some tests import `test/utils/commons.py` but are missing the required `sys.path` modification. Those tests only work when run after other test that perform this modification. This makes them work on their own.