### PR TITLE
Fixed broadcast_optimizer_state to handle NoneType params

### DIFF
--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -102,6 +102,7 @@ def broadcast_optimizer_state(optimizer, root_rank):
         return
 
     params = []
+    scalars = {}
     callbacks = {}
     occurrences = collections.defaultdict(int)
 
@@ -122,18 +123,21 @@ def broadcast_optimizer_state(optimizer, root_rank):
             return dtype(x)
 
     # Some optimizer parameters may be represented as scalars instead of
-    # tensors.  In such cases, we need to wrap the scalar in a tensor, then
-    # broadcast, then update the appropriate value in the state_dict with the
-    # new unwrapped scalar value via a callback.
-    def _create_callback(pid, name, t, p):
-        def _from_tensor():
-            state_dict['state'][pid][name] = t(p.cpu().numpy()[0])
-        return _from_tensor
+    # tensors.  In such cases, we place the scalars into a single dict,
+    # then pickle and broadcast with broadcast_object (under the assumption
+    # that there are not many scalars, and so the overhead of pickling will
+    # be relatively low). Because broadcast_obect is performed out-of-place,
+    # we then use a callback to assign the new value to the correct element
+    # of the optimizer state.
+    def _create_state_callback(pid, name):
+        def _assign_state(v):
+            state_dict['state'][pid][name] = v
+        return _assign_state
 
-    def _create_option_callback(index, option_key, option_tensor, dtypes):
-        def _from_tensor():
-            optimizer.param_groups[index][option_key] = _recursive_cast(option_tensor.cpu().numpy()[0], dtypes)
-        return _from_tensor
+    def _create_option_callback(index, option_key):
+        def _assign_option(v):
+            optimizer.param_groups[index][option_key] = v
+        return _assign_option
 
     # Param groups are an ordered list, normally there is only one per model,
     # but users can add additional param groups for example to train
@@ -144,12 +148,10 @@ def broadcast_optimizer_state(optimizer, root_rank):
             if option_key == 'params':
                 continue
 
-            # Options like the learning rate are scalar, and need to be wrapped in tensors
+            # Options like the learning rate are scalar, and need to be broadcast separately
             key = '%s.%d' % (option_key, index)
-            dtypes = _get_types(option_value)
-            option_tensor = torch.Tensor([option_value])
-            callbacks[key] = _create_option_callback(index, option_key, option_tensor, dtypes)
-            params.append((key, option_tensor))
+            scalars[key] = option_value
+            callbacks[key] = _create_option_callback(index, option_key)
 
         # The params list here is ordered by the layers in the model
         for pid in group['params']:
@@ -165,22 +167,21 @@ def broadcast_optimizer_state(optimizer, root_rank):
                 occurrences[name] += 1
                 key = '%s.%d' % (str(name), occurrences[name])
 
-                if not torch.is_tensor(p):
-                    # Wrap the scalar in a FloatTensor, and remember its type
-                    # so we can cast it back after unwrapping
-                    t = type(p)
-                    p = torch.Tensor([p])
-                    callbacks[key] = _create_callback(pid, name, t, p)
+                if torch.is_tensor(p):
+                    # Tensor -> use broadcast_parameters
+                    params.append((key, p))
+                else:
+                    # Scalar -> use broadcast_object
+                    scalars[key] = p
+                    callbacks[key] = _create_state_callback(pid, name)
 
-                params.append((key, p))
-
-    # Synchronized broadcast of all parameters
+    # Synchronized broadcast of all tensor parameters
     broadcast_parameters(params, root_rank)
 
-    # Post-broadcast cleanup for non-tensor parameters
-    for key, p in params:
-        if key in callbacks:
-            callbacks[key]()
+    # Broadcast and cleanup for non-tensor parameters
+    scalars = broadcast_object(scalars)
+    for key, p in scalars.items():
+        callbacks[key](p)
 
 
 def broadcast_object(obj, root_rank=0, name=None):

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -1518,12 +1518,10 @@ class TorchTests(unittest.TestCase):
             opt_param_values = get_optimizer_param_values(optimizer)
             for name, opt_param_value in opt_param_values:
                 is_tensor = torch.is_tensor(opt_param_value)
-                if not is_tensor:
-                    t = type(opt_param_value)
-                    opt_param_value = torch.Tensor([opt_param_value])
-                hvd.broadcast_(opt_param_value, root_rank=0)
-                if not is_tensor:
-                    opt_param_value = t(opt_param_value.cpu().numpy()[0])
+                if is_tensor:
+                    hvd.broadcast_(opt_param_value, root_rank=0)
+                else:
+                    opt_param_value = hvd.broadcast_object(opt_param_value, name=name)
                 opt_param_values_updated.append((name, opt_param_value))
             opt_param_values = opt_param_values_updated
 
@@ -1553,13 +1551,8 @@ class TorchTests(unittest.TestCase):
                 self.assertTrue(
                     (model_param_value == model_param_value_after).all())
 
+            expected_tensors = hvd.broadcast_object(len(optimizer.state_dict()['state'].values()))
             hvd.broadcast_optimizer_state(optimizer, root_rank=0)
-
-            expected_tensors = 4
-            if 'momentum' not in opt_params and opt_class == torch.optim.SGD:
-                # SGD only maintains state when momentum is specified, otherwise
-                # it does not populate the state dict, so it will contain no tensors.
-                expected_tensors = 0
             self.assertEqual(len(optimizer.state_dict()['state'].values()), expected_tensors)
 
             opt_param_values_after = get_optimizer_param_values(optimizer)


### PR DESCRIPTION
In torch v1.8.0, some optimizer params are represented as None values, which cannot be converted to tensors.  This PR changes the handling of such scalars to use the `broadcast_object` function instead of converting to tensors.  

Because such scalars are small as compared to multi-dimensional tensor parameters, the overhead of pickling via `broadcast_object` should be relatively low. But it is likely that there will be a small drop in the performance of `broadcast_optimizer_state` by adding this increased stability.