### PR TITLE
Let hvd.alltoall return the received splits if non-uniform splits are sent (TensorFlow, PyTorch, MXNet) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed `alltoall` to return the received splits as a second return value if non-uniform splits are sent ([#2631](https://github.com/horovod/horovod/pull/2631))
+
 ### Deprecated
 
 ### Removed

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -267,6 +267,7 @@ struct TensorTableEntry {
   // storage complexity of collecting all worker split arrays
   // on coordinator rank.
   std::vector<int32_t> splits;
+  std::shared_ptr<Tensor> received_splits;
 };
 using TensorTable = std::unordered_map<std::string, TensorTableEntry>;
 

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -223,6 +223,14 @@ public:
                      std::shared_ptr<PersistentBuffer>* tensor) = 0;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) = 0;
+  virtual Status AllocateOutput(int output_index, TensorShape shape,
+                                std::shared_ptr<Tensor>* tensor) {
+    if (output_index == 0) {
+      return AllocateOutput(shape, tensor);
+    } else {
+      throw std::logic_error("output_index != 0 not supported");
+    }
+  }
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                 std::shared_ptr<Tensor>* tensor) = 0;
   virtual Framework framework() const = 0;

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -253,19 +253,16 @@ protected:
     }
 
     // Allocate and fill received_splits output
-    if (e.context->framework() == Framework::TENSORFLOW ||
-        e.context->framework() == Framework::PYTORCH) {
-      TensorShape received_splits_shape;
-      received_splits_shape.AddDim(recvsplits.size());
-      Status rstatus = e.context->AllocateOutput(1, received_splits_shape,
-                                                 &e.received_splits);
-      if (!rstatus.ok()) {
-        return rstatus;
-      }
-      auto* target_pointer = reinterpret_cast<int32_t*>(
-          const_cast<void*>(e.received_splits->data()));
-      std::copy(recvsplits.cbegin(), recvsplits.cend(), target_pointer);
+    TensorShape received_splits_shape;
+    received_splits_shape.AddDim(recvsplits.size());
+    Status rstatus = e.context->AllocateOutput(1, received_splits_shape,
+                                               &e.received_splits);
+    if (!rstatus.ok()) {
+      return rstatus;
     }
+    auto* target_pointer = reinterpret_cast<int32_t*>(
+        const_cast<void*>(e.received_splits->data()));
+    std::copy(recvsplits.cbegin(), recvsplits.cend(), target_pointer);
 
     return Status::OK();
   }

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -213,7 +213,7 @@ protected:
 
     const auto& splits = e.splits;
     std::vector<int32_t> recvsplits;
-    // Perform alltoall of splits to get expeceted receive splits
+    // Perform alltoall of splits to get expected receive splits
     global_state_->controller->AlltoallGetRecvSplits(splits, recvsplits);
 
     // Every tensor participating in Alltoall operation may have different
@@ -250,6 +250,20 @@ protected:
     Status status = e.context->AllocateOutput(output_shape, &e.output);
     if (!status.ok()) {
       return status;
+    }
+
+    // Allocate and fill received_splits output
+    if (e.context->framework() == Framework::TENSORFLOW) {
+      TensorShape received_splits_shape;
+      received_splits_shape.AddDim(recvsplits.size());
+      Status rstatus = e.context->AllocateOutput(1, received_splits_shape,
+                                                 &e.received_splits);
+      if (!rstatus.ok()) {
+        return rstatus;
+      }
+      auto* target_pointer = reinterpret_cast<int32_t*>(
+          const_cast<void*>(e.received_splits->data()));
+      std::copy(recvsplits.cbegin(), recvsplits.cend(), target_pointer);
     }
 
     return Status::OK();

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -253,7 +253,8 @@ protected:
     }
 
     // Allocate and fill received_splits output
-    if (e.context->framework() == Framework::TENSORFLOW) {
+    if (e.context->framework() == Framework::TENSORFLOW ||
+        e.context->framework() == Framework::PYTORCH) {
       TensorShape received_splits_shape;
       received_splits_shape.AddDim(recvsplits.size());
       Status rstatus = e.context->AllocateOutput(1, received_splits_shape,

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -51,11 +51,14 @@ protected:
 
 class MXOpContext : public OpContext {
 public:
-  MXOpContext(int device, NDArray* output);
+  MXOpContext(int device, NDArray* principal_output);
+  void AddOutput(NDArray* output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
+                                std::shared_ptr<Tensor>* tensor) override;
+  virtual Status AllocateOutput(int output_index, TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                std::shared_ptr<Tensor>* tensor) override;
@@ -63,7 +66,7 @@ public:
 
 private:
   int device_;
-  NDArray* output_;
+  std::vector<NDArray*> outputs_;
 };
 
 void ThrowIfError(const Status& status);

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -47,6 +47,7 @@ struct MpiOpsParam {
   std::vector<std::string> op_names;
   int root_rank;
   NDArraySharedPtr splits_tensor;
+  NDArraySharedPtr received_splits_tensor;
   bool average;
   double prescale_factor;
   double postscale_factor;
@@ -61,6 +62,7 @@ struct MpiOpsParam {
               std::vector<std::string>&& op_names,
               int root_rank, bool average,
               NDArraySharedPtr splits_tensor,
+              NDArraySharedPtr received_splits_tensor,
               double prescale_factor,
               double postscale_factor)
       : input_tensors(std::move(input_tensors)),
@@ -72,6 +74,7 @@ struct MpiOpsParam {
         op_names(std::move(op_names)),
         root_rank(root_rank),
         splits_tensor(splits_tensor),
+        received_splits_tensor(received_splits_tensor),
         average(average),
         prescale_factor(prescale_factor),
         postscale_factor(postscale_factor) {
@@ -87,11 +90,12 @@ inline MpiOpsParam* CreateMpiOpsParam(std::vector<NDArraySharedPtr>&& input_tens
                                       std::vector<std::string>&& op_names,
                                       int root_rank, bool average,
                                       NDArraySharedPtr splits_tensor,
+                                      NDArraySharedPtr received_splits_tensor,
                                       double prescale_factor,
                                       double postscale_factor) {
   return new MpiOpsParam(std::move(input_tensors), std::move(output_tensors), std::move(outputs),
     cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names), root_rank, average,
-    splits_tensor, prescale_factor, postscale_factor);
+    splits_tensor, received_splits_tensor, prescale_factor, postscale_factor);
 }
 
 void DeleteMpiOpsParam(void* param) {
@@ -117,6 +121,7 @@ extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
                                             NDArray* output,
                                             const char* name,
                                             NDArray* splits,
+                                            NDArray* output_received_splits,
                                             int priority);
 
 } // namespace mxnet

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -163,6 +163,9 @@ public:
   AllocateOutput(common::TensorShape shape,
                  std::shared_ptr<common::Tensor>* tensor) override;
   virtual common::Status
+  AllocateOutput(int output_index, common::TensorShape shape,
+                 std::shared_ptr<common::Tensor>* tensor) override;
+  virtual common::Status
   AllocateZeros(int64_t num_elements, common::DataType dtype,
                 std::shared_ptr<common::Tensor>* tensor) override;
   virtual common::Framework framework() const override;
@@ -276,12 +279,18 @@ common::Status TFOpContext::AllocatePersistent(
 common::Status
 TFOpContext::AllocateOutput(common::TensorShape shape,
                             std::shared_ptr<common::Tensor>* tensor) {
+  return TFOpContext::AllocateOutput(0, shape, tensor);
+}
+
+common::Status
+TFOpContext::AllocateOutput(int output_index, common::TensorShape shape,
+                            std::shared_ptr<common::Tensor>* tensor) {
   TensorShape tf_shape;
   for (int idx = 0; idx < shape.dims(); ++idx) {
     tf_shape.AddDim(shape.dim_size(idx));
   }
   Tensor* tf_tensor;
-  Status status = context_->allocate_output(0, tf_shape, &tf_tensor);
+  Status status = context_->allocate_output(output_index, tf_shape, &tf_tensor);
   if (status.ok()) {
     *tensor = std::make_shared<TFTensor>(*tf_tensor);
   }

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -291,26 +291,31 @@ def alltoall(tensor, splits=None, name=None, ignore_name_scope=False):
                            TensorFlow in the name used by the Horovod operation.
 
     Returns:
-      A tensor of the same type as `tensor`, concatenated on dimension zero
+      1) A tensor of the same type as `tensor`, concatenated on dimension zero
       across all processes. The shape is identical to the input shape, except for
       the first dimension, which may be greater and is the sum of all first
       dimensions of the gathered tensor slices from different Horovod processes.
+      2) If `splits` has been provided: A tensor of integers in rank order
+      describing how many elements in the output tensor have been received
+      from each worker.
     """
     # If splits not provided, create empty tensor as placeholder
     splits_ = tf.convert_to_tensor(splits) if splits is not None else tf.constant([], dtype=tf.int32)
 
     if name is None and not _executing_eagerly():
         name = 'HorovodAlltoall_%s' % _normalize_name(tensor.name)
-    return MPI_LIB.horovod_alltoall(tensor, splits=splits_, name=name,
-                                    ignore_name_scope=ignore_name_scope)
+    output, rsplits = MPI_LIB.horovod_alltoall(tensor, splits=splits_, name=name,
+                                               ignore_name_scope=ignore_name_scope)
+    return (output, rsplits) if splits is not None else output
 
 @ops.RegisterGradient('HorovodAlltoall')
-def _alltoall_grad(op, grad):
+def _alltoall_grad(op, grad_wrt_output, grad_wrt_received_splits):
     """Gradient for alltoall op.
 
     Args:
-      op: An operation.
-      grad: `Tensor` gradient with respect to the output of the op.
+      op: Original operation.
+      grad_wrt_output: `Tensor` gradient with respect to the output of the op.
+      grad_wrt_received_splits: dead argument (integer output)
 
     Returns:
       The gradient with respect to the input of the op.
@@ -322,9 +327,12 @@ def _alltoall_grad(op, grad):
     splits = tf.cond(tf.equal(tf.size(splits), 0),
                      lambda : tf.ones([size()], dtype=tf.int32) * (tf.shape(tensor)[0] // size()),
                      lambda : splits)
-    recvsplits = alltoall(splits, splits=[1 for _ in range(size())],
-                          ignore_name_scope=ignore_name_scope)
-    return [alltoall(grad, splits=recvsplits, ignore_name_scope=ignore_name_scope), None]
+    recvsplits = op.outputs[1]
+
+    grad_wrt_tensor, _ = alltoall(grad_wrt_output, splits=recvsplits, ignore_name_scope=ignore_name_scope)
+    grad_wrt_splits = None # not differentiable (integer variable)
+
+    return [grad_wrt_tensor, grad_wrt_splits]
 
 def join():
     return MPI_LIB.horovod_join()

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -292,12 +292,12 @@ def alltoall(tensor, splits=None, name=None, ignore_name_scope=False):
 
     Returns:
       1) A tensor of the same type as `tensor`, concatenated on dimension zero
-      across all processes. The shape is identical to the input shape, except for
-      the first dimension, which may be greater and is the sum of all first
-      dimensions of the gathered tensor slices from different Horovod processes.
+         across all processes. The shape is identical to the input shape, except for
+         the first dimension, which may be greater and is the sum of all first
+         dimensions of the gathered tensor slices from different Horovod processes.
       2) If `splits` has been provided: A tensor of integers in rank order
-      describing how many elements in the output tensor have been received
-      from each worker.
+         describing how many elements in the output tensor have been received
+         from each worker.
     """
     # If splits not provided, create empty tensor as placeholder
     splits_ = tf.convert_to_tensor(splits) if splits is not None else tf.constant([], dtype=tf.int32)

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -320,13 +320,7 @@ def _alltoall_grad(op, grad_wrt_output, grad_wrt_received_splits):
     Returns:
       The gradient with respect to the input of the op.
     """
-    tensor = op.inputs[0]
-    splits = op.inputs[1]
     ignore_name_scope = op.get_attr('ignore_name_scope')
-
-    splits = tf.cond(tf.equal(tf.size(splits), 0),
-                     lambda : tf.ones([size()], dtype=tf.int32) * (tf.shape(tensor)[0] // size()),
-                     lambda : splits)
     recvsplits = op.outputs[1]
 
     grad_wrt_tensor, _ = alltoall(grad_wrt_output, splits=recvsplits, ignore_name_scope=ignore_name_scope)

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -96,8 +96,13 @@ int64_t TorchTensor::size() const {
   return tensor_.element_size() * tensor_.numel();
 }
 
-TorchOpContext::TorchOpContext(int device, ::torch::Tensor output)
-    : device_(device), output_(output) {}
+TorchOpContext::TorchOpContext(int device, ::torch::Tensor principal_output)
+    : device_(device), output_devices_{device}, outputs_{principal_output} {}
+
+void TorchOpContext::AddOutput(int device, ::torch::Tensor output) {
+  output_devices_.push_back(device);
+  outputs_.push_back(output);
+}
 
 Status
 TorchOpContext::AllocatePersistent(int64_t size,
@@ -109,14 +114,19 @@ TorchOpContext::AllocatePersistent(int64_t size,
 
 Status TorchOpContext::AllocateOutput(TensorShape shape,
                                       std::shared_ptr<Tensor>* tensor) {
+  return TorchOpContext::AllocateOutput(0, shape, tensor);
+}
+
+Status TorchOpContext::AllocateOutput(int output_index, TensorShape shape,
+                                      std::shared_ptr<Tensor>* tensor) {
   std::vector<int64_t> shape_vector;
   shape_vector.reserve(shape.dims());
   for (int idx = 0; idx < shape.dims(); ++idx) {
     shape_vector.push_back(shape.dim_size(idx));
   }
-  with_device device_context(device_);
-  output_.resize_(shape_vector);
-  *tensor = std::make_shared<TorchTensor>(output_);
+  with_device device_context(output_devices_.at(output_index));
+  outputs_.at(output_index).resize_(shape_vector);
+  *tensor = std::make_shared<TorchTensor>(outputs_.at(output_index));
   return Status::OK();
 }
 

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -53,19 +53,23 @@ protected:
 
 class TorchOpContext : public OpContext {
 public:
-  TorchOpContext(int device, ::torch::Tensor output);
+  TorchOpContext(int device, ::torch::Tensor principal_output);
+  void AddOutput(int device, ::torch::Tensor output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
-  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
+  virtual Status AllocateOutput(int output_index, TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor) override;
+  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
+                               std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;
 
 private:
   int device_ = CPU_DEVICE_ID;
-  ::torch::Tensor output_;
+  std::vector<int> output_devices_;
+  std::vector<::torch::Tensor> outputs_;
 };
 
 void ThrowIfError(Status status);

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -758,7 +758,10 @@ def alltoall_async(tensor, splits=None, name=None):
         `synchronize()`.
     """
     output = tensor.new()
-    output_received_splits = torch.empty(size(), dtype=torch.int32, device='cpu')
+    if isinstance(splits, torch.Tensor):
+        output_received_splits = splits.new()
+    else:
+        output_received_splits = torch.empty(size(), dtype=torch.int32, device='cpu')
     return _alltoall_async(tensor, splits, output, output_received_splits, name)
 
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -809,9 +809,9 @@ def alltoall(tensor, splits=None, name=None):
     Returns:
         1) A tensor containing the gathered tensor data from all workers.
         2) If `splits` has been provided: A tensor of integers in rank order
-        describing how many elements in the output tensor have been received
-        from each worker.
-    """
+           describing how many elements in the output tensor have been received
+           from each worker.
+     """
     return HorovodAlltoall.apply(tensor, splits, name)
 
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -718,20 +718,19 @@ def broadcast_(tensor, root_rank, name=None):
 def _alltoall_function_factory(tensor):
     return 'horovod_torch_alltoall_async_' + tensor.type().replace('.', '_')
 
-def _alltoall_async(tensor, splits, output, name):
+def _alltoall_async(tensor, splits, output, output_received_splits, name):
     if splits is None:
         # If splits not provided, create empty tensor as placeholder
         splits = torch.tensor([], dtype=torch.int32, device='cpu')
     elif not isinstance(splits, torch.Tensor):
         splits = torch.tensor(splits, dtype=torch.int32, device='cpu')
-
     function = _check_function(_alltoall_function_factory, tensor)
     try:
         handle = getattr(mpi_lib, function)(
-            tensor, splits, output, name.encode() if name is not None else _NULL)
+            tensor, splits, output, output_received_splits, name.encode() if name is not None else _NULL)
     except RuntimeError as e:
         raise HorovodInternalError(e)
-    _handle_map[handle] = (tensor, splits, output)
+    _handle_map[handle] = (tensor, splits, (output, output_received_splits))
     return handle
 
 
@@ -759,7 +758,8 @@ def alltoall_async(tensor, splits=None, name=None):
         `synchronize()`.
     """
     output = tensor.new()
-    return _alltoall_async(tensor, splits, output, name)
+    output_received_splits = torch.empty(size(), dtype=torch.int32, device='cpu')
+    return _alltoall_async(tensor, splits, output, output_received_splits, name)
 
 
 class HorovodAlltoall(torch.autograd.Function):
@@ -767,20 +767,20 @@ class HorovodAlltoall(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, tensor, splits, name):
-        ctx.tensor = tensor
-        ctx.splits = splits
         handle = alltoall_async(tensor, splits, name)
-        return synchronize(handle)
+        output, received_splits = synchronize(handle)
+
+        ctx.recvsplits = received_splits
+        if splits is None:
+            return output
+        else:
+            ctx.mark_non_differentiable(received_splits)
+            return output, received_splits
 
     @staticmethod
-    def backward(ctx, grad_output):
-        recvsplits = None
-        if ctx.splits is not None:
-            recvsplits = alltoall(ctx.splits, splits=torch.ones(size(), dtype=torch.int32, device='cpu'))
-        else:
-            splits_equal = torch.ones(size(), dtype=torch.int32, device='cpu') * (ctx.tensor.size()[0] // size())
-            recvsplits = alltoall(splits_equal, splits=torch.ones(size(), dtype=torch.int32, device='cpu'))
-        return alltoall(grad_output, splits=recvsplits), None, None
+    def backward(ctx, grad_output, *dead_gradients):
+        grad_wrt_tensor, _ = alltoall(grad_output, splits=ctx.recvsplits)
+        return grad_wrt_tensor, None, None
 
 
 def alltoall(tensor, splits=None, name=None):
@@ -807,7 +807,10 @@ def alltoall(tensor, splits=None, name=None):
         name: A name of the alltoall operation.
 
     Returns:
-        A tensor containing the gathered tensor data from all workers.
+        1) A tensor containing the gathered tensor data from all workers.
+        2) If `splits` has been provided: A tensor of integers in rank order
+        describing how many elements in the output tensor have been received
+        from each worker.
     """
     return HorovodAlltoall.apply(tensor, splits, name)
 
@@ -830,15 +833,15 @@ def poll(handle):
 
 def synchronize(handle):
     """
-    Synchronizes an asynchronous allreduce, allgather or broadcast operation until
+    Synchronizes an asynchronous allreduce, allgather, alltoall or broadcast operation until
     it's completed. Returns the result of the operation.
 
     Arguments:
-        handle: A handle returned by an allreduce, allgather or broadcast asynchronous
+        handle: A handle returned by an allreduce, allgather, alltoall or broadcast asynchronous
                 operation.
 
     Returns:
-        An output tensor of the operation.
+        A single output tensor of the operation or a tuple of multiple output tensors.
     """
     if handle not in _handle_map:
         return

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -380,38 +380,51 @@ int DoAlltoall(::torch::Tensor tensor, ::torch::Tensor splits,
   auto device = GetDeviceID(tensor);
   auto ready_event = RecordReadyEvent(device);
   auto hvd_tensor = std::make_shared<TorchTensor>(tensor);
-  auto hvd_context = std::make_shared<TorchOpContext>(device, output);
-  assert(GetDeviceID(output_received_splits) == CPU_DEVICE_ID);
-  hvd_context->AddOutput(CPU_DEVICE_ID, output_received_splits);
 
   // Make sync copy of splits tensor to CPU if needed
-  auto splits_cpu = (GetDeviceID(splits) != CPU_DEVICE_ID) ?
+  auto cpu_splits = (GetDeviceID(splits) != CPU_DEVICE_ID) ?
       splits.to(::torch::Device(::torch::kCPU), /*non_blocking=*/false) :
       splits;
-  auto splits_tensor = std::make_shared<TorchTensor>(splits_cpu);
+  auto hvd_cpu_splits = std::make_shared<TorchTensor>(cpu_splits);
+
+  // Deal with possibility of output_received_splits being on GPU
+  auto received_splits_device = GetDeviceID(output_received_splits);
+  auto cpu_received_splits = (received_splits_device != CPU_DEVICE_ID)
+                                 ? ::torch::empty_like(cpu_splits)
+                                 : output_received_splits;
+  auto hvd_context = std::make_shared<TorchOpContext>(device, output);
+  hvd_context->AddOutput(CPU_DEVICE_ID, cpu_received_splits);
 
   auto handle = handle_manager.AllocateHandle();
-  auto enqueue_result =
-      EnqueueTensorAlltoall(hvd_context, hvd_tensor, splits_tensor, ready_event,
-                             GetOpName("alltoall", name, handle), device,
-                             [handle](const Status& status) {
-                               handle_manager.MarkDone(handle, status);
-                             });
+  auto enqueue_result = EnqueueTensorAlltoall(
+      hvd_context, hvd_tensor, hvd_cpu_splits, ready_event,
+      GetOpName("alltoall", name, handle), device,
+      [handle, cpu_received_splits, output_received_splits,
+       received_splits_device](const Status& status) {
+        if (received_splits_device != CPU_DEVICE_ID) {
+          with_device device_guard(received_splits_device);
+          output_received_splits.resize_(cpu_received_splits.sizes());
+          output_received_splits.copy_(cpu_received_splits);
+        }
+        handle_manager.MarkDone(handle, status); 
+      });
   ThrowIfError(enqueue_result);
 
   return handle;
 }
 
 int DoAlltoallCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor splits,
-                        ::torch::Tensor output, ::torch::Tensor output_received_splits,
+                        ::torch::Tensor output,
+                        ::torch::Tensor output_received_splits,
                         const std::string& name) {
   ThrowIfError(common::CheckInitialized());
 
   // Make sync copy of splits tensor to CPU if needed
-  auto splits_cpu = (GetDeviceID(splits) != CPU_DEVICE_ID) ?
-      splits.to(::torch::Device(::torch::kCPU), /*non_blocking=*/false) :
-      splits;
-  auto splits_tensor = std::make_shared<TorchTensor>(splits_cpu);
+  auto cpu_splits =
+      (GetDeviceID(splits) != CPU_DEVICE_ID)
+          ? splits.to(::torch::Device(::torch::kCPU), /*non_blocking=*/false)
+          : splits;
+  auto hvd_cpu_splits = std::make_shared<TorchTensor>(cpu_splits);
 
   // Make async copy of input tensor to CPU tensor and record completion event.
   auto device = GetDeviceID(tensor);
@@ -422,22 +435,35 @@ int DoAlltoallCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor splits,
 
   auto cpu_output = ::torch::empty_like(cpu_tensor);
   auto hvd_cpu_output = std::make_shared<TorchTensor>(cpu_output);
+
+  // Deal with possibility of output_received_splits being on GPU
+  auto received_splits_device = GetDeviceID(output_received_splits);
+  auto cpu_received_splits = (received_splits_device != CPU_DEVICE_ID)
+                                 ? ::torch::empty_like(cpu_splits)
+                                 : output_received_splits;
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
-  assert(GetDeviceID(output_received_splits) == CPU_DEVICE_ID);
-  hvd_context->AddOutput(CPU_DEVICE_ID, output_received_splits);
+  hvd_context->AddOutput(CPU_DEVICE_ID, cpu_received_splits);
 
   auto handle = handle_manager.AllocateHandle();
   auto enqueue_result = EnqueueTensorAlltoall(
-      hvd_context, hvd_cpu_tensor, splits_tensor, ready_event,
+      hvd_context, hvd_cpu_tensor, hvd_cpu_splits, ready_event,
       GetOpName("alltoall", name, handle), CPU_DEVICE_ID,
-      [handle, cpu_output, output, device](const Status& status) mutable {
-        // Since the operation was on CPU, need to perform copy with the GPU
-        // device guard.
-        with_device device_guard(device);
-        // output needs to be resized before copying in the CPU tensor.
-        output.resize_(cpu_output.sizes());
-        output.copy_(cpu_output);
+      [handle, cpu_output, output, device, cpu_received_splits,
+       output_received_splits,
+       received_splits_device](const Status& status) mutable {
+        { // Since the operation was on CPU, need to perform copy with the GPU
+          // device guard.
+          with_device device_guard(device);
+          // output needs to be resized before copying in the CPU tensor.
+          output.resize_(cpu_output.sizes());
+          output.copy_(cpu_output);
+        }
+        if (received_splits_device != CPU_DEVICE_ID) {
+          with_device device_guard(received_splits_device);
+          output_received_splits.resize_(cpu_received_splits.sizes());
+          output_received_splits.copy_(cpu_received_splits);
+        }
         handle_manager.MarkDone(handle, status);
       });
   ThrowIfError(enqueue_result);

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -400,7 +400,7 @@ int DoAlltoall(::torch::Tensor tensor, ::torch::Tensor splits,
       hvd_context, hvd_tensor, hvd_cpu_splits, ready_event,
       GetOpName("alltoall", name, handle), device,
       [handle, cpu_received_splits, output_received_splits,
-       received_splits_device](const Status& status) {
+       received_splits_device](const Status& status) mutable {
         if (received_splits_device != CPU_DEVICE_ID) {
           with_device device_guard(received_splits_device);
           output_received_splits.resize_(cpu_received_splits.sizes());

--- a/test/parallel/test_mxnet.py
+++ b/test/parallel/test_mxnet.py
@@ -909,11 +909,14 @@ class MXTests(unittest.TestCase):
               tensor = mx.ndarray.concat(tensor, tensor, dim=1)
 
             splits = mx.ndarray.array([rank + 1] * size, dtype='int32', ctx=ctx)
-            collected = hvd.alltoall(tensor, splits)
+            collected, received_splits = hvd.alltoall(tensor, splits)
 
             assert collected.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
             assert collected.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
             assert collected.size == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+            self.assertSequenceEqual(received_splits.asnumpy().tolist(), [rk + 1 for rk in range(size)],
+                                     "hvd.alltoall returned incorrect received_splits")
+
 
     def test_horovod_alltoall_equal_split(self):
         """Test that the alltoall correctly distributes 1D tensors with default splitting."""

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -1772,7 +1772,7 @@ class TensorFlowTests(tf.test.TestCase):
                   tensor = tf.expand_dims(tensor, axis=1)
                   tensor = tf.concat([tensor, tensor], axis=1)
                 splits = tf.convert_to_tensor([rank+1] * size, dtype=tf.int32)
-                collected = hvd.alltoall(tensor, splits)
+                collected, received_splits = hvd.alltoall(tensor, splits)
 
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
@@ -1783,11 +1783,14 @@ class TensorFlowTests(tf.test.TestCase):
                     self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
                     "hvd.alltoall collected wrong number of values")
 
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(), [rk + 1 for rk in range(size)],
+                                         "hvd.alltoall returned incorrect received_splits")
+
     def test_horovod_alltoall_gpu(self):
         """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            self.skipTest(("No GPUs available"))
+            self.skipTest("No GPUs available")
 
         if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
@@ -1816,7 +1819,7 @@ class TensorFlowTests(tf.test.TestCase):
                   tensor = tf.expand_dims(tensor, axis=1)
                   tensor = tf.concat([tensor, tensor], axis=1)
                 splits = tf.convert_to_tensor([rank+1] * size, dtype=tf.int32)
-                collected = hvd.alltoall(tensor, splits)
+                collected, received_splits = hvd.alltoall(tensor, splits)
 
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
@@ -1826,6 +1829,9 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertTrue(
                     self.evaluate(tf.equal(tf.size(collected), size * (size + 1) // 2 * 2**(dim - 1))),
                     "hvd.alltoall collected wrong number of values")
+
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(), [rk + 1 for rk in range(size)],
+                                         "hvd.alltoall returned incorrect received_splits")
 
     def test_horovod_alltoall_equal_split_cpu(self):
         """Test that the alltoall correctly distributes 1D tensors with default splitting."""
@@ -1980,7 +1986,7 @@ class TensorFlowTests(tf.test.TestCase):
                         tensor = tf.expand_dims(tensor, axis=1)
                         tensor = tf.concat([tensor, tensor], axis=1)
 
-                collected = hvd.alltoall(tensor, splits, name="a2a")
+                collected, received_splits = hvd.alltoall(tensor, splits, name="a2a")
 
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
@@ -1992,6 +1998,11 @@ class TensorFlowTests(tf.test.TestCase):
                                                                - (1+1) * 2 ** (dim-1)  # subtract missing rank 1 contributions
                                            )),
                     "hvd.alltoall collected wrong number of values")
+
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(),
+                                         [rk + 1 if rk != 1 else 0 for rk in range(size)],
+                                         "hvd.alltoall returned incorrect received_splits")
+
 
     def test_horovod_alltoall_one_rank_sends_nothing_gpu(self):
         """Test where one rank sends nothing in an alltoall."""
@@ -2036,7 +2047,7 @@ class TensorFlowTests(tf.test.TestCase):
                         tensor = tf.expand_dims(tensor, axis=1)
                         tensor = tf.concat([tensor, tensor], axis=1)
 
-                collected = hvd.alltoall(tensor, splits, name="a2a")
+                collected, received_splits = hvd.alltoall(tensor, splits, name="a2a")
 
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
@@ -2048,6 +2059,10 @@ class TensorFlowTests(tf.test.TestCase):
                                                                - (1+1) * 2 ** (dim-1)  # subtract missing rank 1 contributions
                                            )),
                     "hvd.alltoall collected wrong number of values")
+
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(),
+                                         [rk + 1 if rk != 1 else 0 for rk in range(size)],
+                                         "hvd.alltoall returned incorrect received_splits")
 
     def test_horovod_alltoall_one_rank_receives_nothing_cpu(self):
         """Test where one rank receives nothing in an alltoall."""
@@ -2074,18 +2089,22 @@ class TensorFlowTests(tf.test.TestCase):
                     tensor = tf.expand_dims(tensor, axis=1)
                     tensor = tf.concat([tensor, tensor], axis=1)
 
-                collected = hvd.alltoall(tensor, splits, name="a2a")
+                collected, received_splits = hvd.alltoall(tensor, splits, name="a2a")
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
                         tf.equal(tf.cast(collected, tf.int32), rank))),
                     "hvd.alltoall produces incorrect collected tensor")
                 if rank == 0:
                     expected_size = 0
+                    expected_rsplits = [0] * size
                 else:
                     expected_size = size * (size + 1) // 2 * 2**(dim - 1)
+                    expected_rsplits = [rk + 1 for rk in range(size)]
                 self.assertTrue(
                     self.evaluate(tf.equal(tf.size(collected), expected_size)),
                     "hvd.alltoall collected wrong number of values")
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(), expected_rsplits,
+                                         "hvd.alltoall returned incorrect received_splits")
 
     def test_horovod_alltoall_one_rank_receives_nothing_gpu(self):
         """Test where one rank receives nothing in an alltoall."""
@@ -2127,18 +2146,22 @@ class TensorFlowTests(tf.test.TestCase):
                     tensor = tf.expand_dims(tensor, axis=1)
                     tensor = tf.concat([tensor, tensor], axis=1)
 
-                collected = hvd.alltoall(tensor, splits, name="a2a")
+                collected, received_splits = hvd.alltoall(tensor, splits, name="a2a")
                 self.assertTrue(
                     self.evaluate(tf.reduce_all(
                         tf.equal(tf.cast(collected, tf.int32), rank))),
                     "hvd.alltoall produces incorrect collected tensor")
                 if rank == 0:
                     expected_size = 0
+                    expected_rsplits = [0] * size
                 else:
                     expected_size = size * (size + 1) // 2 * 2**(dim - 1)
+                    expected_rsplits = [rk + 1 for rk in range(size)]
                 self.assertTrue(
                     self.evaluate(tf.equal(tf.size(collected), expected_size)),
                     "hvd.alltoall collected wrong number of values")
+                self.assertSequenceEqual(self.evaluate(received_splits).tolist(), expected_rsplits,
+                                         "hvd.alltoall returned incorrect received_splits")
 
 
     def test_horovod_alltoall_zero_splits_cpu(self):
@@ -2163,11 +2186,9 @@ class TensorFlowTests(tf.test.TestCase):
             else:
                 source_tensor = tf.fill(silent_shape, value=tf.cast(hvd.rank(), tf.int32))
                 splits = tf.convert_to_tensor(silent_splits)
-            collected = hvd.alltoall(source_tensor, splits, name="alltoall_zero_splits")
+            collected, received_splits = hvd.alltoall(source_tensor, splits, name="alltoall_zero_splits")
             result = self.evaluate(collected)
 
-        print(hvd.rank(), "result.shape", result.shape)
-        print(hvd.rank(), "result", result)
         if hvd.rank() in active_ranks:
             expected_result_shape = active_shape
         else:
@@ -2178,6 +2199,12 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertTrue(np.all(result[r_idx, ...] == r))
         else:
             self.assertLen(result, 0)
+        if hvd.rank() in active_ranks:
+            expected_rsplits = active_splits
+        else:
+            expected_rsplits = silent_splits
+        self.assertSequenceEqual(self.evaluate(received_splits).tolist(), expected_rsplits,
+                                 "hvd.alltoall returned incorrect received_splits")
 
     def test_horovod_alltoall_zero_splits_gpu(self):
         """Test alltoall with some ranks not participating / splits set to zero."""
@@ -2214,11 +2241,9 @@ class TensorFlowTests(tf.test.TestCase):
             else:
                 source_tensor = tf.fill(silent_shape, value=tf.cast(hvd.rank(), tf.int32))
                 splits = tf.convert_to_tensor(silent_splits)
-            collected = hvd.alltoall(source_tensor, splits, name="alltoall_zero_splits")
+            collected, received_splits = hvd.alltoall(source_tensor, splits, name="alltoall_zero_splits")
             result = self.evaluate(collected)
 
-        print(hvd.rank(), "result.shape", result.shape)
-        print(hvd.rank(), "result", result)
         if hvd.rank() in active_ranks:
             expected_result_shape = active_shape
         else:
@@ -2229,6 +2254,12 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertTrue(np.all(result[r_idx, ...] == r))
         else:
             self.assertLen(result, 0)
+        if hvd.rank() in active_ranks:
+            expected_rsplits = active_splits
+        else:
+            expected_rsplits = silent_splits
+        self.assertSequenceEqual(self.evaluate(received_splits).tolist(), expected_rsplits,
+                                 "hvd.alltoall returned incorrect received_splits")
 
     def test_horovod_alltoall_type_error(self):
         """Test that the alltoall returns an error if the tensor types differ
@@ -2328,10 +2359,10 @@ class TensorFlowTests(tf.test.TestCase):
                     tensor = self.tfe.Variable(tensor)
                     splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
                     with tf.GradientTape() as tape:
-                        collected = hvd.alltoall(tensor, splits)
+                        collected, received_splits = hvd.alltoall(tensor, splits)
                 else:
                     splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
-                    collected = hvd.alltoall(tensor, splits)
+                    collected, received_splits = hvd.alltoall(tensor, splits)
 
                 grad_ys = tf.ones(tf.shape(collected))
                 if _executing_eagerly():
@@ -2383,10 +2414,10 @@ class TensorFlowTests(tf.test.TestCase):
                     tensor = self.tfe.Variable(tensor)
                     splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
                     with tf.GradientTape() as tape:
-                        collected = hvd.alltoall(tensor, splits)
+                        collected, received_splits = hvd.alltoall(tensor, splits)
                 else:
                     splits = tf.convert_to_tensor([rank + 1] * size, dtype=tf.int32)
-                    collected = hvd.alltoall(tensor, splits)
+                    collected, received_splits = hvd.alltoall(tensor, splits)
 
                 grad_ys = tf.ones(tf.shape(collected))
                 if _executing_eagerly():
@@ -2445,7 +2476,7 @@ class TensorFlowTests(tf.test.TestCase):
         """Test the correctness of the alltoall gradient with default splitting on GPU."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            self.skipTest(("No GPUs available"))
+            self.skipTest("No GPUs available")
 
         if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -1254,6 +1254,47 @@ class TorchTests(unittest.TestCase):
             assert collected.data.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
             assert collected.numel() == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
 
+    def test_horovod_alltoall_splits_on_gpu(self):
+        """Test that the alltoall works correctly when the splits argument is a tensor on GPU."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        if not torch.cuda.is_available():
+            self.skipTest("No GPUs available")
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        dtypes = self.filter_supported_types([torch.ByteTensor, torch.CharTensor, torch.ShortTensor,
+                                              torch.IntTensor, torch.LongTensor, torch.FloatTensor,
+                                              torch.DoubleTensor, torch.HalfTensor])
+        dtypes += [torch.cuda.ByteTensor, torch.cuda.CharTensor, torch.cuda.ShortTensor,
+                   torch.cuda.IntTensor, torch.cuda.LongTensor,
+                   torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                   torch.cuda.HalfTensor]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            vals = []
+            for i in range(size):
+              vals += [i] * (rank + 1)
+
+            tensor = torch.Tensor(vals)
+            for _ in range(dim - 1):
+              tensor = tensor.unsqueeze(1)
+              tensor = torch.cat((tensor, tensor), dim=1)
+
+            splits = torch.tensor([rank + 1] * size, dtype=torch.int32, device="cuda")
+            tensor = self.cast_and_place(tensor, dtype)
+            collected, received_splits = hvd.alltoall(tensor, splits)
+            tensor, collected = self.convert_cpu_fp16_to_fp32(tensor, collected)
+
+            assert collected.data.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.data.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.numel() == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+            self.assertEqual(received_splits.device.type, "cuda", "received_splits should be on GPU here")
+            self.assertSequenceEqual(received_splits.tolist(), [rk + 1 for rk in range(size)],
+                                     "hvd.alltoall returned incorrect received_splits")
+
     def test_horovod_alltoall_type_error(self):
         """Test that the alltoall returns an error if the tensor types differ
            across the processes."""


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Often alltoall graph nodes occur in pairs (as in `input->alltoall->[processing]->alltoall->output`). With non-uniform splits, one currently needs to add an extra hvd.alltoall() op just to know how much data was received from which workers in the first hvd.alltoall() so those can be targeted properly again in the second hvd.alltoall(). Since this information is already available internally, I propose to expose the received_splits as an extra output of the op.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
