### PR TITLE
Forward stdout/stderr capture to driver over gloo

### DIFF
--- a/examples/spark/keras/keras_spark3_rossmann.py
+++ b/examples/spark/keras/keras_spark3_rossmann.py
@@ -19,6 +19,8 @@ import datetime
 import h5py
 import io
 import os
+import sys
+
 import pyarrow as pa
 from pyspark import SparkConf, Row
 from pyspark.sql import SparkSession
@@ -536,7 +538,9 @@ if __name__ == '__main__':
 
     # Horovod: run training.
     history, best_model_bytes = \
-        horovod.spark.run(train_fn, args=(model_bytes,), num_proc=args.num_proc, verbose=2)[0]
+        horovod.spark.run(train_fn, args=(model_bytes,), num_proc=args.num_proc,
+                          stdout=sys.stdout, stderr=sys.stderr, verbose=2,
+                          prefix_output_with_timestamp=True)[0]
 
     best_val_rmspe = min(history['val_exp_rmspe'])
     print('Best RMSPE: %f' % best_val_rmspe)

--- a/examples/spark/keras/keras_spark_mnist.py
+++ b/examples/spark/keras/keras_spark_mnist.py
@@ -101,7 +101,9 @@ if __name__ == '__main__':
     loss = keras.losses.categorical_crossentropy
 
     # Train a Horovod Spark Estimator on the DataFrame
-    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    backend = SparkBackend(num_proc=args.num_proc,
+                           stdout=sys.stdout, stderr=sys.stderr,
+                           prefix_output_with_timestamp=True)
     keras_estimator = hvd.KerasEstimator(backend=backend,
                                          store=store,
                                          model=model,

--- a/examples/spark/keras/keras_spark_mnist.py
+++ b/examples/spark/keras/keras_spark_mnist.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+import sys
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -23,6 +24,7 @@ from tensorflow.keras.layers import Dense, Dropout, Flatten
 from tensorflow.keras.layers import Conv2D, MaxPooling2D
 
 import horovod.spark.keras as hvd
+from horovod.spark.common.backend import SparkBackend
 from horovod.spark.common.store import Store
 
 parser = argparse.ArgumentParser(description='Keras Spark MNIST Example',
@@ -99,7 +101,8 @@ if __name__ == '__main__':
     loss = keras.losses.categorical_crossentropy
 
     # Train a Horovod Spark Estimator on the DataFrame
-    keras_estimator = hvd.KerasEstimator(num_proc=args.num_proc,
+    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    keras_estimator = hvd.KerasEstimator(backend=backend,
                                          store=store,
                                          model=model,
                                          optimizer=optimizer,

--- a/examples/spark/keras/keras_spark_rossmann_estimator.py
+++ b/examples/spark/keras/keras_spark_rossmann_estimator.py
@@ -17,6 +17,7 @@
 import argparse
 import datetime
 import os
+import sys
 from distutils.version import LooseVersion
 
 import pyspark.sql.types as T
@@ -29,6 +30,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Input, Embedding, Concatenate, Dense, Flatten, Reshape, BatchNormalization, Dropout
 
 import horovod.spark.keras as hvd
+from horovod.spark.common.backend import SparkBackend
 from horovod.spark.common.store import Store
 from horovod.tensorflow.keras.callbacks import BestModelCheckpoint
 
@@ -368,7 +370,8 @@ if __name__ == '__main__':
 
     # Horovod: run training.
     store = Store.create(args.work_dir)
-    keras_estimator = hvd.KerasEstimator(num_proc=args.num_proc,
+    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    keras_estimator = hvd.KerasEstimator(backend=backend,
                                          store=store,
                                          model=model,
                                          optimizer=opt,

--- a/examples/spark/keras/keras_spark_rossmann_estimator.py
+++ b/examples/spark/keras/keras_spark_rossmann_estimator.py
@@ -370,7 +370,9 @@ if __name__ == '__main__':
 
     # Horovod: run training.
     store = Store.create(args.work_dir)
-    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    backend = SparkBackend(num_proc=args.num_proc,
+                           stdout=sys.stdout, stderr=sys.stderr,
+                           prefix_output_with_timestamp=True)
     keras_estimator = hvd.KerasEstimator(backend=backend,
                                          store=store,
                                          model=model,

--- a/examples/spark/keras/keras_spark_rossmann_run.py
+++ b/examples/spark/keras/keras_spark_rossmann_run.py
@@ -19,6 +19,8 @@ import datetime
 import h5py
 import io
 import os
+import sys
+
 import pyarrow as pa
 from pyspark import SparkConf, Row
 from pyspark.sql import SparkSession
@@ -499,7 +501,9 @@ if __name__ == '__main__':
 
     # Horovod: run training.
     history, best_model_bytes = \
-        horovod.spark.run(train_fn, args=(model_bytes,), num_proc=args.num_proc, verbose=2)[0]
+        horovod.spark.run(train_fn, args=(model_bytes,), num_proc=args.num_proc,
+                          stdout=sys.stdout, stderr=sys.stderr, verbose=2,
+                          prefix_output_with_timestamp=True)[0]
 
     best_val_rmspe = min(history['val_exp_rmspe'])
     print('Best RMSPE: %f' % best_val_rmspe)

--- a/examples/spark/pytorch/pytorch_spark_mnist.py
+++ b/examples/spark/pytorch/pytorch_spark_mnist.py
@@ -102,7 +102,9 @@ if __name__ == '__main__':
     loss = nn.NLLLoss()
 
     # Train a Horovod Spark Estimator on the DataFrame
-    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    backend = SparkBackend(num_proc=args.num_proc,
+                           stdout=sys.stdout, stderr=sys.stderr,
+                           prefix_output_with_timestamp=True)
     torch_estimator = hvd.TorchEstimator(backend=backend,
                                          store=store,
                                          model=model,

--- a/examples/spark/pytorch/pytorch_spark_mnist.py
+++ b/examples/spark/pytorch/pytorch_spark_mnist.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+import sys
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -21,6 +22,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 import horovod.spark.torch as hvd
+from horovod.spark.common.backend import SparkBackend
 from horovod.spark.common.store import Store
 
 parser = argparse.ArgumentParser(description='PyTorch Spark MNIST Example',
@@ -100,7 +102,8 @@ if __name__ == '__main__':
     loss = nn.NLLLoss()
 
     # Train a Horovod Spark Estimator on the DataFrame
-    torch_estimator = hvd.TorchEstimator(num_proc=args.num_proc,
+    backend = SparkBackend(num_proc=args.num_proc, stdout=sys.stdout, stderr=sys.stderr)
+    torch_estimator = hvd.TorchEstimator(backend=backend,
                                          store=store,
                                          model=model,
                                          optimizer=optimizer,

--- a/horovod/runner/common/service/task_service.py
+++ b/horovod/runner/common/service/task_service.py
@@ -18,7 +18,7 @@ import abc
 
 from horovod.runner.common import util
 from horovod.runner.common.util import network, safe_shell_exec, timeout
-from horovod.runner.util.stream import Pipe
+from horovod.runner.util.streams import Pipe
 from horovod.runner.util.threads import in_thread
 
 WAIT_FOR_COMMAND_MIN_DELAY = 0.1

--- a/horovod/runner/common/service/task_service.py
+++ b/horovod/runner/common/service/task_service.py
@@ -32,9 +32,9 @@ class RunCommandRequest(object):
         self.env = env
         """Environment to use."""
         self.capture_stdout = capture_stdout
-        """Captures stdout of command if True."""
+        """Captures stdout of command if True. Retrieve content via StreamCommandStdOutRequest."""
         self.capture_stderr = capture_stderr
-        """Captures stderr of command if True."""
+        """Captures stderr of command if True. Retrieve content via StreamCommandErrOutRequest."""
         self.prefix_output_with_timestamp = prefix_output_with_timestamp
 
 

--- a/horovod/runner/common/service/task_service.py
+++ b/horovod/runner/common/service/task_service.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
-import threading
 import abc
+import threading
 
 from horovod.runner.common import util
 from horovod.runner.common.util import network, safe_shell_exec, timeout

--- a/horovod/runner/common/service/task_service.py
+++ b/horovod/runner/common/service/task_service.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import threading
+import abc
 
 from horovod.runner.common import util
 from horovod.runner.common.util import network, safe_shell_exec, timeout
@@ -24,17 +25,30 @@ WAIT_FOR_COMMAND_MIN_DELAY = 0.1
 
 
 class RunCommandRequest(object):
-    def __init__(self, command, env, capture=False):
+    def __init__(self, command, env, capture_stdout=False, capture_stderr=False,
+                 prefix_output_with_timestamp=False):
         self.command = command
         """Command to run."""
         self.env = env
         """Environment to use."""
-        self.capture = capture
-        """Captures stdout and stderr of command if True."""
+        self.capture_stdout = capture_stdout
+        """Captures stdout of command if True."""
+        self.capture_stderr = capture_stderr
+        """Captures stderr of command if True."""
+        self.prefix_output_with_timestamp = prefix_output_with_timestamp
 
 
-class StreamCommandOutputRequest(object):
-    """Streams the command stdout and stderr to the client."""
+class StreamCommandOutputRequest(object, metaclass=abc.ABCMeta):
+    pass
+
+
+class StreamCommandStdOutRequest(StreamCommandOutputRequest):
+    """Streams the command stdout to the client."""
+    pass
+
+
+class StreamCommandStdErrRequest(StreamCommandOutputRequest):
+    """Streams the command stderr to the client."""
     pass
 
 
@@ -98,7 +112,8 @@ class BasicTaskService(network.BasicService):
         self._wait_cond = threading.Condition()
         self._index = index
         self._command_env = command_env
-        self._command_output = None
+        self._command_stdout = None
+        self._command_stderr = None
         self._command_abort = None
         self._command_exit_code = None
         self._verbose = verbose
@@ -106,12 +121,15 @@ class BasicTaskService(network.BasicService):
         self._command_thread = None
         self._fn_result = None
 
-    def _run_command(self, command, env, event, stdout=None, stderr=None, index=None):
+    def _run_command(self, command, env, event,
+                     stdout=None, stderr=None, index=None,
+                     prefix_output_with_timestamp=False):
         self._command_exit_code = safe_shell_exec.execute(
             command,
             env=env,
             stdout=stdout, stderr=stderr,
-            index=index, prefix_output_with_timestamp=index is not None,
+            index=index,
+            prefix_output_with_timestamp=prefix_output_with_timestamp,
             events=[event])
         if stdout:
             stdout.close()
@@ -153,14 +171,12 @@ class BasicTaskService(network.BasicService):
 
                     # We only permit executing exactly one command, so this is idempotent.
                     self._command_abort = threading.Event()
-                    if req.capture:
-                        self._command_output = Pipe()
-                        args = (req.command, req.env, self._command_abort,
-                                self._command_output, self._command_output,
-                                self._index)
-                    else:
-                        args = (req.command, req.env, self._command_abort)
-
+                    self._command_stdout = Pipe() if req.capture_stdout else None
+                    self._command_stderr = Pipe() if req.capture_stderr else None
+                    args = (req.command, req.env, self._command_abort,
+                            self._command_stdout, self._command_stderr,
+                            self._index,
+                            req.prefix_output_with_timestamp)
                     self._command_thread = in_thread(self._run_command, args)
             finally:
                 self._wait_cond.notify_all()
@@ -171,24 +187,23 @@ class BasicTaskService(network.BasicService):
             # Wait for command to start
             self.wait_for_command_start()
 
-            self._wait_cond.acquire()
-            try:
-                # Fail if command does not capture
-                if self._command_output is None:
-                    return CommandOutputNotCaptured()
-
-                # We only expect streaming the command output once concurrently
-                return network.AckStreamResponse(), self._command_output
-            finally:
-                self._wait_cond.release()
+            # We only expect streaming each command output stream once concurrently
+            if isinstance(req, StreamCommandStdOutRequest):
+                return self.stream_output(self._command_stdout)
+            elif isinstance(req, StreamCommandStdErrRequest):
+                return self.stream_output(self._command_stderr)
+            else:
+                return CommandOutputNotCaptured()
 
         if isinstance(req, AbortCommandRequest):
             self._wait_cond.acquire()
             try:
                 if self._command_thread is not None:
                     self._command_abort.set()
-                if self._command_output is not None:
-                    self._command_output.close()
+                if self._command_stdout is not None:
+                    self._command_stdout.close()
+                if self._command_stderr is not None:
+                    self._command_stderr.close()
             finally:
                 self._wait_cond.release()
             return network.AckResponse()
@@ -285,6 +300,16 @@ class BasicTaskService(network.BasicService):
     def command_exit_code(self):
         return self._command_exit_code
 
+    def stream_output(self, stream):
+        self._wait_cond.acquire()
+        try:
+            # Fail if command does not capture this stream
+            if stream is None:
+                return CommandOutputNotCaptured()
+            return network.AckStreamResponse(), stream
+        finally:
+            self._wait_cond.release()
+
 
 class BasicTaskClient(network.BasicClient):
     def __init__(self, service_name, task_addresses, key, verbose,
@@ -294,17 +319,23 @@ class BasicTaskClient(network.BasicClient):
                                               match_intf=match_intf,
                                               attempts=attempts)
 
-    def run_command(self, command, env, capture=False):
-        self._send(RunCommandRequest(command, env, capture))
+    def run_command(self, command, env,
+                    capture_stdout=False, capture_stderr=False,
+                    prefix_output_with_timestamp=False):
+        self._send(RunCommandRequest(command, env,
+                                     capture_stdout, capture_stderr,
+                                     prefix_output_with_timestamp))
 
-    def stream_command_output(self, stream):
-        def stream_output():
+    def stream_command_output(self, stdout=None, stderr=None):
+        def send(req, stream):
             try:
-                self._send(StreamCommandOutputRequest(), stream)
-            except:
+                self._send(req, stream)
+            except Exception as e:
                 self.abort_command()
+                raise e
 
-        return in_thread(stream_output)
+        return (in_thread(send, (StreamCommandStdOutRequest(), stdout)) if stdout else None,
+                in_thread(send, (StreamCommandStdErrRequest(), stderr)) if stderr else None)
 
     def abort_command(self):
         self._send(AbortCommandRequest())

--- a/horovod/runner/common/util/network.py
+++ b/horovod/runner/common/util/network.py
@@ -18,6 +18,7 @@ import queue
 import socket
 import socketserver
 import struct
+import shutil
 
 import cloudpickle
 
@@ -47,6 +48,11 @@ class AckResponse(object):
     pass
 
 
+class AckStreamResponse(object):
+    """Used for situations when the response is a stream of data."""
+    pass
+
+
 class Wire(object):
     """
     Used for serialization/deserialization of objects over the wire.
@@ -72,6 +78,13 @@ class Wire(object):
         # Pack message length into 4-byte integer.
         wfile.write(struct.pack('i', len(message)))
         wfile.write(message)
+        wfile.flush()
+
+    def stream(self, stream, wfile):
+        from encodings.utf_8 import StreamWriter
+        w = StreamWriter(wfile)
+        # do not handle exceptions or close the stream
+        shutil.copyfileobj(stream, w)
         wfile.flush()
 
     def read(self, rfile):
@@ -107,7 +120,12 @@ class BasicService(object):
                     resp = server._handle(req, self.client_address)
                     if not resp:
                         raise Exception('Handler did not return a response.')
-                    server._wire.write(resp, self.wfile)
+                    if type(resp) == tuple:
+                        (resp, stream) = resp
+                        server._wire.write(resp, self.wfile)
+                        server._wire.stream(stream, self.wfile)
+                    else:
+                        server._wire.write(resp, self.wfile)
                 except (EOFError, BrokenPipeError):
                     # Happens when client is abruptly terminated, don't want to pollute the logs.
                     pass
@@ -238,7 +256,7 @@ class BasicClient(object):
             finally:
                 sock.close()
 
-    def _send_one(self, addr, req):
+    def _send_one(self, addr, req, stream=None):
         for iter in range(self._attempts):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
@@ -248,21 +266,27 @@ class BasicClient(object):
                 try:
                     self._wire.write(req, wfile)
                     resp = self._wire.read(rfile)
+                    if stream and isinstance(resp, AckStreamResponse):
+                        from encodings.utf_8 import StreamReader
+                        r = StreamReader(rfile)
+                        shutil.copyfileobj(r, stream)
                     return resp
                 finally:
                     rfile.close()
                     wfile.close()
             except:
                 if iter == self._attempts - 1:
+                    if stream:
+                        stream.close()
                     # Raise exception on the last retry.
                     raise
             finally:
                 sock.close()
 
-    def _send(self, req):
+    def _send(self, req, stream=None):
         # Since all the addresses were vetted, use the first one.
         addr = list(self._addresses.values())[0][0]
-        return self._send_one(addr, req)
+        return self._send_one(addr, req, stream)
 
     def addresses(self):
         return self._addresses

--- a/horovod/runner/common/util/network.py
+++ b/horovod/runner/common/util/network.py
@@ -276,8 +276,6 @@ class BasicClient(object):
                     wfile.close()
             except:
                 if iter == self._attempts - 1:
-                    if stream:
-                        stream.close()
                     # Raise exception on the last retry.
                     raise
             finally:

--- a/horovod/runner/task/task_service.py
+++ b/horovod/runner/task/task_service.py
@@ -34,7 +34,7 @@ class HorovodRunTaskService(task_service.BasicTaskService):
     def __init__(self, index, key, nics):
         super(HorovodRunTaskService, self).__init__(
             HorovodRunTaskService.NAME_FORMAT % index,
-            key, nics)
+            index, key, nics)
         self.index = index
         self._task_to_task_address_check_completed = False
 

--- a/horovod/runner/util/stream.py
+++ b/horovod/runner/util/stream.py
@@ -1,0 +1,57 @@
+import threading
+
+
+class Pipe:
+    def __init__(self):
+        self._buf = None
+        self._offs = None
+        self._wait_cond = threading.Condition()
+        self._closed = False
+
+    def write(self, buf):
+        self._wait_cond.acquire()
+        try:
+            while self._buf is not None and not self._closed:
+                self._wait_cond.wait()
+
+            if self._closed:
+                raise RuntimeError('Pipe is closed')
+
+            self._buf = buf
+            self._offs = 0
+        finally:
+            self._wait_cond.notify_all()
+            self._wait_cond.release()
+
+    def read(self, length=-1):
+        self._wait_cond.acquire()
+        try:
+            while self._buf is None and not self._closed:
+                self._wait_cond.wait()
+
+            if self._buf is None:
+                return None
+
+            if 0 < length < len(self._buf) - self._offs:
+                end = self._offs + length
+                buf = self._buf[self._offs:end]
+                self._offs = end
+            else:
+                buf = self._buf[self._offs:]
+                self._buf = None
+
+            return buf
+        finally:
+            self._wait_cond.notify_all()
+            self._wait_cond.release()
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self._wait_cond.acquire()
+        try:
+            self._closed = True
+        finally:
+            self._wait_cond.notify_all()
+            self._wait_cond.release()

--- a/horovod/runner/util/streams.py
+++ b/horovod/runner/util/streams.py
@@ -2,6 +2,7 @@ import threading
 
 
 class Pipe:
+    """A pipe that can be written and read concurrently. Buffers the last written string only."""
     def __init__(self):
         self._buf = None
         self._offs = None

--- a/horovod/runner/util/streams.py
+++ b/horovod/runner/util/streams.py
@@ -1,3 +1,18 @@
+# Copyright 2021 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import threading
 
 

--- a/horovod/runner/util/streams.py
+++ b/horovod/runner/util/streams.py
@@ -17,7 +17,10 @@ import threading
 
 
 class Pipe:
-    """A pipe that can be written and read concurrently. Buffers the last written string only."""
+    """
+    A pipe that can be written and read concurrently.
+    Works with strings and bytes. Buffers the last written string/bytes only.
+    """
     def __init__(self):
         self._buf = None
         self._offs = None

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -22,17 +22,18 @@ from horovod.spark.driver.rsh import rsh
 from horovod.spark.driver.rendezvous import SparkRendezvousServer
 
 
-def _exec_command_fn(driver, key, settings, env):
+def _exec_command_fn(driver, key, settings, env, stdout, stderr, prefix_output_with_timestamp):
     def _exec_command(command, slot_info, events):
         host = slot_info.hostname
         local_rank = slot_info.local_rank
         verbose = settings.verbose
-        result = rsh(driver.addresses(), key, host, command, env, local_rank, verbose, False, events)
+        result = rsh(driver.addresses(), key, host, command, env, local_rank, verbose,
+                     stdout, stderr, prefix_output_with_timestamp, False, events)
         return result, time.time()
     return _exec_command
 
 
-def gloo_run(settings, nics, driver, env):
+def gloo_run(settings, nics, driver, env, stdout=None, stderr=None):
     """
     Run distributed gloo jobs.
 
@@ -41,6 +42,8 @@ def gloo_run(settings, nics, driver, env):
     :param nics: Interfaces to use by gloo.
     :param driver: The Spark driver service that tasks are connected to.
     :param env: Environment dictionary to use for running gloo jobs.  Can be None.
+    :param stdout: Horovod stdout is redirected to this stream.
+    :param stderr: Horovod stderr is redirected to this stream.
     """
     if env is None:
         env = {}
@@ -59,7 +62,7 @@ def gloo_run(settings, nics, driver, env):
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))
 
-    exec_command = _exec_command_fn(driver, key, settings, env)
+    exec_command = _exec_command_fn(driver, key, settings, env, stdout, stderr)
     launch_gloo(command, exec_command, settings, nics, {}, server_ip)
 
 

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -62,11 +62,12 @@ def gloo_run(settings, nics, driver, env, stdout=None, stderr=None):
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))
 
-    exec_command = _exec_command_fn(driver, key, settings, env, stdout, stderr)
+    exec_command = _exec_command_fn(driver, key, settings, env,
+                                    stdout, stderr, settings.prefix_output_with_timestamp)
     launch_gloo(command, exec_command, settings, nics, {}, server_ip)
 
 
-def gloo_run_elastic(settings, driver, env):
+def gloo_run_elastic(settings, driver, env, stdout=None, stderr=None):
     """
     Run distributed gloo jobs.
 
@@ -74,6 +75,8 @@ def gloo_run_elastic(settings, driver, env):
                      Note: settings.num_proc and settings.hosts must not be None.
     :param driver: The Spark driver service that tasks are connected to.
     :param env: Environment dictionary to use for running gloo jobs.  Can be None.
+    :param stdout: Horovod stdout is redirected to this stream.
+    :param stderr: Horovod stderr is redirected to this stream.
     """
     if env is None:
         env = {}
@@ -92,6 +95,7 @@ def gloo_run_elastic(settings, driver, env):
     # get common interfaces from driver
     nics = driver.get_common_interfaces()
 
-    exec_command = _exec_command_fn(driver, settings.key, settings, env)
+    exec_command = _exec_command_fn(driver, settings.key, settings, env,
+                                    stdout, stderr, settings.prefix_output_with_timestamp)
     rendezvous = SparkRendezvousServer(driver, settings.verbose)
     launch_gloo_elastic(command, exec_command, settings, env, lambda _: nics, rendezvous)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -209,8 +209,8 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
                        If it is not set as well, defaults to 600 seconds.
         extra_mpi_args: Extra arguments for mpi_run. Defaults to no extra args.
         env: Environment dictionary to use in Horovod run.
-        stdout: Horovod stdout is redirected to this stream. Defaults to sys.stdout when use_mpi=True.
-        stderr: Horovod stderr is redirected to this stream. Defaults to sys.stderr when use_mpi=True.
+        stdout: Horovod stdout is redirected to this stream. Defaults to sys.stdout when used with MPI.
+        stderr: Horovod stderr is redirected to this stream. Defaults to sys.stderr when used with MPI.
         verbose: Debug output verbosity (0-2). Defaults to 1.
         nics: List of NICs for tcp network communication.
         prefix_output_with_timestamp: shows timestamp in stdout/stderr forwarding on the driver

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -304,7 +304,9 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
 
 
 def run_elastic(fn, args=(), kwargs={}, num_proc=None, min_np=None, max_np=None,
-                start_timeout=None, elastic_timeout=None, reset_limit=None, env=None, verbose=1, nics=None):
+                start_timeout=None, elastic_timeout=None, reset_limit=None, env=None,
+                stdout=None, stderr=None, verbose=1, nics=None,
+                prefix_output_with_timestamp=False):
     """
     Runs Elastic Horovod on Spark.  Runs `num_proc` processes executing `fn` using the same amount of Spark tasks.
 
@@ -321,8 +323,11 @@ def run_elastic(fn, args=(), kwargs={}, num_proc=None, min_np=None, max_np=None,
                        If it is not set as well, defaults to 600 seconds.
         reset_limit: Maximum number of resets after which the job is terminated.
         env: Environment dictionary to use in Horovod run.  Defaults to `os.environ`.
+        stdout: Horovod stdout is redirected to this stream.
+        stderr: Horovod stderr is redirected to this stream.
         verbose: Debug output verbosity (0-2). Defaults to 1.
         nics: List of NICs for tcp network communication.
+        prefix_output_with_timestamp: shows timestamp in stdout/stderr forwarding on the driver
 
     Returns:
         List of results returned by running `fn` on each rank.
@@ -386,7 +391,8 @@ def run_elastic(fn, args=(), kwargs={}, num_proc=None, min_np=None, max_np=None,
                                                     key=key,
                                                     start_timeout=tmout,
                                                     nics=nics,
-                                                    run_func_mode=True)
+                                                    run_func_mode=True,
+                                                    prefix_output_with_timestamp=prefix_output_with_timestamp)
 
     result_queue = queue.Queue(1)
 
@@ -398,7 +404,7 @@ def run_elastic(fn, args=(), kwargs={}, num_proc=None, min_np=None, max_np=None,
         _register_task_addresses(driver, settings)
 
         # Run the job
-        gloo_run_elastic(settings, driver, env)
+        gloo_run_elastic(settings, driver, env, stdout, stderr)
     except:
         # Terminate Spark job.
         spark_context.cancelJobGroup(spark_job_group)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -149,7 +149,7 @@ def _make_spark_thread(spark_context, spark_job_group, driver, result_queue,
 
 def _launch_job(use_mpi, use_gloo, settings, driver, env, stdout=None, stderr=None):
     nics = driver.get_common_interfaces()
-    run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env),
+    run_controller(use_gloo, lambda: gloo_run(settings, nics, driver, env, stdout, stderr),
                    use_mpi, lambda: mpi_run(settings, nics, driver, env, stdout, stderr),
                    False, lambda: None,
                    settings.verbose)
@@ -194,7 +194,8 @@ def _get_indices_in_rank_order(driver):
 
 def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
         use_mpi=None, use_gloo=None, extra_mpi_args=None,
-        env=None, stdout=None, stderr=None, verbose=1, nics=None):
+        env=None, stdout=None, stderr=None, verbose=1, nics=None,
+        prefix_output_with_timestamp=False):
     """
     Runs Horovod on Spark.  Runs `num_proc` processes executing `fn` using the same amount of Spark tasks.
 
@@ -208,10 +209,11 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
                        If it is not set as well, defaults to 600 seconds.
         extra_mpi_args: Extra arguments for mpi_run. Defaults to no extra args.
         env: Environment dictionary to use in Horovod run.
-        stdout: Horovod stdout is redirected to this stream. Defaults to sys.stdout.
-        stderr: Horovod stderr is redirected to this stream. Defaults to sys.stderr.
+        stdout: Horovod stdout is redirected to this stream. Defaults to sys.stdout when use_mpi=True.
+        stderr: Horovod stderr is redirected to this stream. Defaults to sys.stderr when use_mpi=True.
         verbose: Debug output verbosity (0-2). Defaults to 1.
         nics: List of NICs for tcp network communication.
+        prefix_output_with_timestamp: shows timestamp in stdout/stderr forwarding on the driver
 
     Returns:
         List of results returned by running `fn` on each rank.
@@ -236,7 +238,8 @@ def run(fn, args=(), kwargs={}, num_proc=None, start_timeout=None,
                                      key=secret.make_secret_key(),
                                      start_timeout=tmout,
                                      nics=nics,
-                                     run_func_mode=True)
+                                     run_func_mode=True,
+                                     prefix_output_with_timestamp=prefix_output_with_timestamp)
 
     spark_context = pyspark.SparkContext._active_spark_context
     if spark_context is None:

--- a/horovod/spark/task/task_service.py
+++ b/horovod/spark/task/task_service.py
@@ -63,7 +63,7 @@ class SparkTaskService(task_service.BasicTaskService):
         env['HOROVOD_SPARK_WORK_DIR'] = os.getcwd()
 
         super(SparkTaskService, self).__init__(SparkTaskService.NAME_FORMAT % index,
-                                               key, nics, env, verbose)
+                                               index, key, nics, env, verbose)
         self._key = key
         self._minimum_command_lifetime_s = minimum_command_lifetime_s
         self._minimum_command_lifetime = None

--- a/horovod/spark/task/task_service.py
+++ b/horovod/spark/task/task_service.py
@@ -68,8 +68,11 @@ class SparkTaskService(task_service.BasicTaskService):
         self._minimum_command_lifetime_s = minimum_command_lifetime_s
         self._minimum_command_lifetime = None
 
-    def _run_command(self, command, env, event):
-        super(SparkTaskService, self)._run_command(command, env, event)
+    def _run_command(self, command, env, event,
+                     stdout=None, stderr=None, index=None,
+                     prefix_output_with_timestamp=False):
+        super(SparkTaskService, self)._run_command(command, env, event,
+                                                   stdout, stderr, prefix_output_with_timestamp)
 
         if self._minimum_command_lifetime_s is not None:
             self._minimum_command_lifetime = timeout.Timeout(self._minimum_command_lifetime_s,

--- a/horovod/spark/task/task_service.py
+++ b/horovod/spark/task/task_service.py
@@ -72,7 +72,8 @@ class SparkTaskService(task_service.BasicTaskService):
                      stdout=None, stderr=None, index=None,
                      prefix_output_with_timestamp=False):
         super(SparkTaskService, self)._run_command(command, env, event,
-                                                   stdout, stderr, prefix_output_with_timestamp)
+                                                   stdout, stderr, index,
+                                                   prefix_output_with_timestamp)
 
         if self._minimum_command_lifetime_s is not None:
             self._minimum_command_lifetime = timeout.Timeout(self._minimum_command_lifetime_s,

--- a/test/integration/elastic_spark_common.py
+++ b/test/integration/elastic_spark_common.py
@@ -381,7 +381,9 @@ class BaseElasticSparkTests(unittest.TestCase):
                 cmd = ' '.join(command)
                 run_elastic(self._exec, (cmd,), env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
                             num_proc=np, min_np=min_np, max_np=max_np,
-                            start_timeout=10, elastic_timeout=10, verbose=2)
+                            stdout=sys.stdout, stderr=sys.stderr,
+                            start_timeout=10, elastic_timeout=10, verbose=2,
+                            prefix_output_with_timestamp=True)
 
                 with open(logfile, 'r') as f:
                     lines = f.readlines()

--- a/test/integration/test_spark.py
+++ b/test/integration/test_spark.py
@@ -866,7 +866,9 @@ class SparkTests(unittest.TestCase):
                 settings = hvd_settings.Settings(verbose=2, key=key)
                 env = {}
 
-                res = rsh(driver.addresses(), key, host_hash, command, env, 0, settings.verbose, False, events=events)
+                res = rsh(driver.addresses(), key, host_hash, command, env, 0, settings.verbose,
+                          stdout=None, stderr=None, prefix_output_with_timestamp=False,
+                          background=False, events=events)
                 self.assertEqual(expected_result, res)
 
     def test_mpirun_exec_fn(self):

--- a/test/integration/test_spark.py
+++ b/test/integration/test_spark.py
@@ -19,25 +19,22 @@ import itertools
 import logging
 import os
 import platform
-import psutil
-import pytest
 import re
 import sys
 import threading
 import time
 import unittest
 import warnings
-
 from distutils.version import LooseVersion
 
 import mock
-
+import psutil
+import pytest
 from pyspark.ml.linalg import DenseVector, SparseVector, VectorUDT
 from pyspark.sql.types import ArrayType, BooleanType, DoubleType, FloatType, IntegerType, \
     NullType, StructField, StructType
 
 import horovod.spark
-
 from horovod.common.util import gloo_built, mpi_built
 from horovod.runner.common.util import codec, secret, safe_shell_exec, timeout
 from horovod.runner.common.util import settings as hvd_settings
@@ -47,17 +44,16 @@ from horovod.spark.common import constants, util
 from horovod.spark.common.store import DBFSLocalStore, HDFSStore, LocalStore, Store
 from horovod.spark.driver.host_discovery import SparkDriverHostDiscovery
 from horovod.spark.driver.rsh import rsh
+from horovod.spark.runner import _task_fn
 from horovod.spark.task import gloo_exec_fn, mpirun_exec_fn
 from horovod.spark.task.task_service import SparkTaskClient
-from horovod.spark.runner import _task_fn
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from spark_common import spark_driver_service, spark_session, spark_task_service, \
     create_test_data_from_schema, create_xor_data, local_store
 
-from common import is_built, mpi_implementation_flags, tempdir, override_env, undo, delay, spawn
-
+from common import is_built, mpi_implementation_flags, tempdir, override_env, undo, delay
 
 # Spark will fail to initialize correctly locally on Mac OS without this
 if platform.system() == 'Darwin':

--- a/test/integration/test_spark_torch.py
+++ b/test/integration/test_spark_torch.py
@@ -13,38 +13,35 @@
 # limitations under the License.
 # ==============================================================================
 
-import logging
 import io
+import logging
 import os
 import sys
 import unittest
 import warnings
-
 from distutils.version import LooseVersion
 
+import mock
 import numpy as np
-
 import pyspark
+import pytest
+import torch.nn as nn
+import torch.optim as optim
 from pyspark.ml.linalg import VectorUDT
 from pyspark.sql.types import FloatType, IntegerType
-
-import mock
-import pytest
-import torch
-import torch.nn as nn
 from torch.nn import functional as F
-import torch.optim as optim
 
 import horovod
-from horovod.torch.elastic import run
+import horovod.spark.torch as hvd_spark
+import horovod.torch as hvd
+import torch
 from horovod.common.util import gloo_built, mpi_built
 from horovod.runner.mpi_run import is_open_mpi
-import horovod.spark.torch as hvd_spark
 from horovod.spark.common import constants, util
+from horovod.spark.task import get_available_devices
 from horovod.spark.torch import remote
 from horovod.spark.torch.estimator import EstimatorParams, _torch_param_serialize
-from horovod.spark.task import get_available_devices
-import horovod.torch as hvd
+from horovod.torch.elastic import run
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 

--- a/test/integration/test_spark_torch.py
+++ b/test/integration/test_spark_torch.py
@@ -19,12 +19,9 @@ import os
 import sys
 import unittest
 import warnings
-from distutils.version import LooseVersion
 
 import mock
 import numpy as np
-import pyspark
-import pytest
 import torch.nn as nn
 import torch.optim as optim
 from pyspark.ml.linalg import VectorUDT
@@ -38,7 +35,6 @@ import torch
 from horovod.common.util import gloo_built, mpi_built
 from horovod.runner.mpi_run import is_open_mpi
 from horovod.spark.common import constants, util
-from horovod.spark.task import get_available_devices
 from horovod.spark.torch import remote
 from horovod.spark.torch.estimator import EstimatorParams, _torch_param_serialize
 from horovod.torch.elastic import run
@@ -68,79 +64,11 @@ def create_xor_model(input_dim=2, output_dim=1):
     return XOR(input_dim, output_dim)
 
 
-@spawn
-def run_get_available_devices():
-    # Run this test in an isolated "spawned" environment because creating a local-cluster
-    # leads to errors that cause downstream tests to stall:
-    # https://issues.apache.org/jira/browse/SPARK-31922
-    def fn():
-        hvd.init()
-        devices = get_available_devices()
-        return devices, hvd.local_rank()
-
-    with spark_session('test_get_available_devices', gpus=2):
-        return horovod.spark.run(fn, env={'PATH': os.environ.get('PATH')}, verbose=0)
-
-
 class SparkTorchTests(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(SparkTorchTests, self).__init__(*args, **kwargs)
         logging.getLogger('py4j.java_gateway').setLevel(logging.INFO)
         warnings.simplefilter('module')
-
-    """
-    Test that horovod.spark.run works properly in a simple setup using MPI.
-    """
-    def test_happy_run_with_mpi(self):
-        if not (mpi_built() and is_open_mpi()):
-            self.skipTest("Open MPI is not available")
-
-        self.do_test_happy_run(use_mpi=True, use_gloo=False)
-
-    """
-    Test that horovod.spark.run works properly in a simple setup using Gloo.
-    """
-    def test_happy_run_with_gloo(self):
-        if not gloo_built():
-            self.skipTest("Gloo is not available")
-
-        self.do_test_happy_run(use_mpi=False, use_gloo=True)
-
-    """
-    Actually tests that horovod.spark.run works properly in a simple setup.
-    """
-    def do_test_happy_run(self, use_mpi, use_gloo):
-        def fn():
-            hvd.init()
-            print(f'running fn {hvd.size()}')
-            print(f'error line', file=sys.stderr)
-            res = hvd.allgather(torch.tensor([hvd.rank()])).tolist()
-            return res, hvd.rank()
-
-        stdout = io.StringIO()
-        stderr = io.StringIO()
-        with spark_session('test_happy_run'):
-            with is_built(gloo_is_built=use_gloo, mpi_is_built=use_mpi):
-                res = horovod.spark.run(fn, start_timeout=10,
-                                        use_mpi=use_mpi, use_gloo=use_gloo,
-                                        stdout=stdout if use_gloo else None,
-                                        stderr=stderr if use_gloo else None,
-                                        verbose=2)
-                self.assertListEqual([([0, 1], 0), ([0, 1], 1)], res)
-
-                if use_gloo:
-                    self.assertRegex(stdout.getvalue(),
-                                     r'\[[01]\]<stdout>:running fn 2\n'
-                                     r'\[[01]\]<stdout>:running fn 2\n')
-                    self.assertRegex(stderr.getvalue(),
-                                     r'\[[01]\]<stderr>:error line\n'
-                                     r'\[[01]\]<stderr>:error line\n')
-
-    @pytest.mark.skipif(LooseVersion(pyspark.__version__) < LooseVersion('3.0.0'),
-                        reason='get_available_devices only supported in Spark 3.0 and above')
-    def test_get_available_devices(self):
-        res = run_get_available_devices()
-        self.assertListEqual([(['1'], 0), (['0'], 1)], res)
 
     def test_fit_model(self):
         model = create_xor_model()
@@ -510,17 +438,12 @@ class SparkTorchTests(unittest.TestCase):
         if not gloo_built():
             self.skipTest("Gloo is not available")
 
-        stdout = io.StringIO()
-        stderr = io.StringIO()
         with spark_session('test_happy_run_elastic'):
             res = horovod.spark.run_elastic(fn, args=(2, 5, 4),
                                             num_proc=2, min_np=2, max_np=2,
-                                            stdout=stdout, stderr=stderr,
                                             start_timeout=10, verbose=2)
             self.assertListEqual([([0, 3, 0, 1, 1, 3, 0, 1], 0),
                                   ([0, 3, 0, 1, 1, 3, 0, 1], 1)], res)
-            self.assertEqual('', stdout.getvalue())
-            self.assertEqual('', stderr.getvalue())
 
     """
     Test that horovod.spark.run_elastic works properly in a fault-tolerant situation.

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -423,7 +423,7 @@ class RunTests(unittest.TestCase):
 
     def do_test_prefix_connection(self, string, prefix, index, expected, timestamp=False):
         # create a Pipe Connection and populate it with string
-        (connection, w) = multiprocessing.get_context('spawn').Pipe()
+        (connection, w) = multiprocessing.get_context('spawn').Pipe(duplex=False)
         with os.fdopen(w.fileno(), 'wt', encoding='utf8', newline='', closefd=False) as stream:
             stream.write(string)
         w.close()
@@ -519,12 +519,12 @@ class RunTests(unittest.TestCase):
 
         # one thread writes into the w side of this pipe
         # prefix_connection reads on the other end of this pipe
-        (connection, w) = multiprocessing.get_context('spawn').Pipe()
+        (connection, w) = multiprocessing.get_context('spawn').Pipe(duplex=False)
         writer_thread = in_thread(writer, (w,))
 
         # prefix_connection writes to the write side of this Pipe (opened as a text stream)
         # another thread reads from the r side of this pipe
-        (r, dst_con) = multiprocessing.get_context('spawn').Pipe()
+        (r, dst_con) = multiprocessing.get_context('spawn').Pipe(duplex=False)
         reader_thread = in_thread(reader, (r,))
 
         with os.fdopen(dst_con.fileno(), 'wt', encoding='utf8', newline='', closefd=False) as dst:

--- a/test/single/test_service.py
+++ b/test/single/test_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import io
 import queue
 import threading
 import time
@@ -32,7 +33,7 @@ class SleepRequest(object):
 
 class TestSleepService(network.BasicService):
     def __init__(self, key, duration):
-        super(TestSleepService, self).__init__('test service', key, nics=None)
+        super(TestSleepService, self).__init__('test sleep service', key, nics=None)
         self._duration = duration
 
     def _handle(self, req, client_address):
@@ -46,7 +47,7 @@ class TestSleepService(network.BasicService):
 
 class TestSleepClient(network.BasicClient):
     def __init__(self, service_addresses, key, attempts=1):
-        super(TestSleepClient, self).__init__('test service',
+        super(TestSleepClient, self).__init__('test sleep service',
                                               service_addresses,
                                               key,
                                               verbose=2,
@@ -54,6 +55,39 @@ class TestSleepClient(network.BasicClient):
 
     def sleep(self):
         self._send(SleepRequest())
+
+
+class TestStreamService(network.BasicService):
+    def __init__(self, key, duration):
+        super(TestStreamService, self).__init__('test stream service', key, nics=None)
+        self._duration = duration
+
+    def _handle(self, req, client_address):
+        if isinstance(req, SleepRequest):
+            pipe = Pipe()
+
+            def sleep():
+                time.sleep(self._duration)
+                pipe.write('slept {}'.format(self._duration))
+                pipe.close()
+
+            in_thread(sleep)
+
+            return network.AckStreamResponse(), pipe
+
+        return super(TestStreamService, self)._handle(req, client_address)
+
+
+class TestStreamClient(network.BasicClient):
+    def __init__(self, service_addresses, key, attempts=1):
+        super(TestStreamClient, self).__init__('test stream service',
+                                               service_addresses,
+                                               key,
+                                               verbose=2,
+                                               attempts=attempts)
+
+    def sleep(self, stream):
+        self._send(SleepRequest(), stream)
 
 
 class NetworkTests(unittest.TestCase):
@@ -69,15 +103,17 @@ class NetworkTests(unittest.TestCase):
         sleep = 2.0
         key = secret.make_secret_key()
         service = TestSleepService(key, duration=sleep)
-        client = TestSleepClient(service.addresses(), key, attempts=1)
-
-        start = time.time()
-        threads = list([in_thread(client.sleep, daemon=False) for _ in range(1)])
-        for thread in threads:
-            thread.join(sleep + 1.0)
-            self.assertFalse(thread.is_alive(), 'thread should have terminated by now')
-        duration = time.time() - start
-        print('concurrent requests completed in {} seconds'.format(duration))
+        try:
+            client = TestSleepClient(service.addresses(), key, attempts=1)
+            start = time.time()
+            threads = list([in_thread(client.sleep, daemon=False) for _ in range(1)])
+            for thread in threads:
+                thread.join(sleep + 1.0)
+                self.assertFalse(thread.is_alive(), 'thread should have terminated by now')
+            duration = time.time() - start
+            print('concurrent requests completed in {} seconds'.format(duration))
+        finally:
+            service.shutdown()
 
         self.assertGreaterEqual(duration, sleep, 'sleep requests should have been completed')
         self.assertLess(duration, sleep + 1.0, 'sleep requests should have been concurrent')
@@ -86,12 +122,14 @@ class NetworkTests(unittest.TestCase):
         sleep = 2.0
         key = secret.make_secret_key()
         service = TestSleepService(key, duration=sleep)
-        client = TestSleepClient(service.addresses(), key, attempts=1)
+        try:
+            client = TestSleepClient(service.addresses(), key, attempts=1)
+            start = time.time()
+            threads = list([in_thread(client.sleep, name='request {}'.format(i+1), daemon=False) for i in range(5)])
+            time.sleep(sleep / 2.0)
+        finally:
+            service.shutdown()
 
-        start = time.time()
-        threads = list([in_thread(client.sleep, name='request {}'.format(i+1), daemon=False) for i in range(5)])
-        time.sleep(sleep / 2.0)
-        service.shutdown()
         duration = time.time() - start
         print('shutdown completed in {} seconds'.format(duration))
         self.assertGreaterEqual(duration, sleep, 'sleep requests should have been completed')
@@ -109,15 +147,18 @@ class NetworkTests(unittest.TestCase):
 
         key = secret.make_secret_key()
         service_name = 'test-service'
-        service = BasicTaskService(service_name, key, nics=None, verbose=2)
-        client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
-        thread = threading.Thread(target=wait_for_exit_code, args=(client, result_queue))
+        service = BasicTaskService(service_name, 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+            thread = threading.Thread(target=wait_for_exit_code, args=(client, result_queue))
 
-        start = time.time()
-        thread.start()  # wait for command exit code
-        client.run_command('sleep 2', {})  # execute command
-        time.sleep(0.5)  # give the thread some time to connect before shutdown
-        service.shutdown()  # shutdown should wait on request to finish
+            start = time.time()
+            thread.start()  # wait for command exit code
+            client.run_command('sleep 2', {})  # execute command
+            time.sleep(0.5)  # give the thread some time to connect before shutdown
+        finally:
+            service.shutdown()  # shutdown should wait on request to finish
+
         duration = time.time() - start
         self.assertGreaterEqual(duration, 2)
 
@@ -134,9 +175,28 @@ class NetworkTests(unittest.TestCase):
         """test non-zero exit code"""
         key = secret.make_secret_key()
         service_name = 'test-service'
-        service = BasicTaskService(service_name, key, nics=None, verbose=2)
-        client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+        service = BasicTaskService(service_name, 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient(service_name, service.addresses(), key, verbose=2, attempts=1)
+            client.run_command('false', {})
+            res = client.wait_for_command_exit_code()
+            self.assertEqual(1, res)
+        finally:
+            service.shutdown()
 
-        client.run_command('false', {})
-        res = client.wait_for_command_exit_code()
-        self.assertEqual(1, res)
+    def test_stream(self):
+        sleep = 2.0
+        key = secret.make_secret_key()
+        service = TestStreamService(key, duration=sleep)
+        try:
+            client = TestStreamClient(service.addresses(), key, attempts=1)
+
+            start = time.time()
+            stream = io.StringIO()
+            client.sleep(stream)
+            duration = time.time() - start
+
+            self.assertEqual(f'slept {sleep}', stream.getvalue())
+            self.assertGreaterEqual(duration, 2)
+        finally:
+            service.shutdown()

--- a/test/single/test_service.py
+++ b/test/single/test_service.py
@@ -25,7 +25,7 @@ import pytest
 from horovod.runner.common.service.task_service import BasicTaskClient, BasicTaskService
 from horovod.runner.common.util import network, secret
 from horovod.runner.util.threads import in_thread
-from horovod.runner.util.stream import Pipe
+from horovod.runner.util.streams import Pipe
 
 
 class SleepRequest(object):

--- a/test/single/test_service.py
+++ b/test/single/test_service.py
@@ -25,6 +25,7 @@ import pytest
 from horovod.runner.common.service.task_service import BasicTaskClient, BasicTaskService
 from horovod.runner.common.util import network, secret
 from horovod.runner.util.threads import in_thread
+from horovod.runner.util.stream import Pipe
 
 
 class SleepRequest(object):

--- a/test/single/test_task_service.py
+++ b/test/single/test_task_service.py
@@ -162,7 +162,7 @@ class TaskServiceTest(unittest.TestCase):
         self.do_test_stream_command_output_reconnect(attempts=3, succeeds=True)
 
     def test_stream_command_output_no_reconnect(self):
-        self.do_test_stream_command_output_reconnect(attempts=1, succeeds=False)
+        self.do_test_stream_command_output_reconnect(attempts=1, succeeds=None)
 
     def do_test_stream_command_output_reconnect(self, attempts, succeeds):
         key = secret.make_secret_key()
@@ -182,10 +182,8 @@ class TaskServiceTest(unittest.TestCase):
             terminated, exit = client.command_result()
             self.assertEqual(True, terminated)
 
-            if succeeds:
-                self.assertEqual(0, exit)
-            else:
-                self.assertTrue(exit != 0)
+            if succeeds is not None:
+                self.assertEqual(succeeds, exit == 0)
 
             if stdout_t is not None:
                 stdout_t.join(1.0)

--- a/test/single/test_task_service.py
+++ b/test/single/test_task_service.py
@@ -4,6 +4,7 @@ import unittest
 
 from horovod.runner.common.service.task_service import BasicTaskService, BasicTaskClient
 from horovod.runner.common.util import secret
+import os
 
 
 class FaultyStream:
@@ -24,7 +25,8 @@ class FaultyStream:
 
 class TaskServiceTest(unittest.TestCase):
 
-    cmd_with_stdout = 'find ../.. | sort'
+    path = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+    cmd_with_stdout = f'find {path} | sort'
     cmd_with_stdout_and_stderr = f'bash -c "{cmd_with_stdout} >&2 & {cmd_with_stdout}"'
 
     cmd_single_line = f'{cmd_with_stdout} | wc'

--- a/test/single/test_task_service.py
+++ b/test/single/test_task_service.py
@@ -6,125 +6,186 @@ from horovod.runner.common.service.task_service import BasicTaskService, BasicTa
 from horovod.runner.common.util import secret
 
 
+class FaultyStream:
+    """This stream raises an exception after some text has been written."""
+    def __init__(self, stream):
+        self.stream = stream
+        self.raised = False
+
+    def write(self, b):
+        self.stream.write(b)
+        if not self.raised and len(self.stream.getvalue()) > 1024:
+            self.raised = True
+            raise RuntimeError()
+
+    def close(self):
+        pass
+
+
 class TaskServiceTest(unittest.TestCase):
+
+    cmd_with_stdout = 'find ../.. | sort'
+    cmd_with_stdout_and_stderr = f'bash -c "{cmd_with_stdout} >&2 & {cmd_with_stdout}"'
+
+    cmd_single_line = f'{cmd_with_stdout} | wc'
+    cmd_single_line_both = f'bash -c "{cmd_single_line} >&2 & {cmd_single_line}"'
 
     def test_run_command(self):
         key = secret.make_secret_key()
         service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
         try:
             client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
-            client.run_command('find ../.. | wc', {})
+            client.run_command(self.cmd_single_line_both, {})
             exit = client.wait_for_command_exit_code()
             self.assertEqual(0, exit)
             self.assertEqual((True, 0), client.command_result())
         finally:
             service.shutdown()
 
-    cmd_with_stdout = 'find ../.. | sort'
-    cmd_with_stdout_and_stderr = f'bash -c "{cmd_with_stdout} >&2 & {cmd_with_stdout}"'
+    def do_test_stream_command_output(self,
+                                      command,
+                                      capture_stdout, capture_stderr,
+                                      prefix_output_with_timestamp):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        key = secret.make_secret_key()
+        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
+            stdout_t, stderr_t = client.stream_command_output(stdout, stderr)
+            client.run_command(command, {},
+                               capture_stdout=capture_stdout, capture_stderr=capture_stderr,
+                               prefix_output_with_timestamp=prefix_output_with_timestamp)
+            client.wait_for_command_termination(delay=0.2)
+            self.assertEqual((True, 0), client.command_result())
+
+            if stdout_t is not None:
+                stdout_t.join(1.0)
+                self.assertEqual(False, stdout_t.is_alive())
+            if stderr_t is not None:
+                stderr_t.join(1.0)
+                self.assertEqual(False, stderr_t.is_alive())
+        finally:
+            service.shutdown()
+
+        stdout = stdout.getvalue()
+        stderr = stderr.getvalue()
+
+        # remove timestamps from each line in outputs
+        if prefix_output_with_timestamp:
+            stdout_no_ts = re.sub('^[^[]+', '', stdout, flags=re.MULTILINE)
+            stderr_no_ts = re.sub('^[^[]+', '', stderr, flags=re.MULTILINE)
+            # test we are removing something (hopefully timestamps)
+            if capture_stdout:
+                self.assertNotEqual(stdout_no_ts, stdout)
+            if capture_stderr:
+                self.assertNotEqual(stderr_no_ts, stderr)
+            stdout = stdout_no_ts
+            stderr = stderr_no_ts
+
+        # remove prefix
+        stdout_no_prefix = re.sub('\[0\]<stdout>:', '', stdout, flags=re.MULTILINE)
+        stderr_no_prefix = re.sub('\[0\]<stderr>:', '', stderr, flags=re.MULTILINE)
+        # test we are removing something (hopefully prefixes)
+        if capture_stdout:
+            self.assertNotEqual(stdout_no_prefix, stdout)
+        if capture_stderr:
+            self.assertNotEqual(stderr_no_prefix, stderr)
+        stdout = stdout_no_prefix
+        stderr = stderr_no_prefix
+
+        if capture_stdout and capture_stderr:
+            # both streams should be equal
+            self.assertEqual(stdout, stderr)
+
+        # streams should have meaningful number of lines and characters
+        if capture_stdout:
+            self.assertTrue(len(stdout) > 1024)
+            self.assertTrue(len(stdout.splitlines()) > 10)
+        if capture_stderr:
+            self.assertTrue(len(stderr) > 1024)
+            self.assertTrue(len(stderr.splitlines()) > 10)
 
     def test_stream_command_output(self):
-        key = secret.make_secret_key()
-        output = io.StringIO()
-        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
-        try:
-            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
-            thread = client.stream_command_output(output)
-            client.run_command(self.cmd_with_stdout_and_stderr, {}, capture=True)
-            client.wait_for_command_termination(delay=0.2)
-            thread.join(1.0)
-            self.assertEqual(False, thread.is_alive())
-            self.assertEqual((True, 0), client.command_result())
-        finally:
-            service.shutdown()
+        self.do_test_stream_command_output(self.cmd_with_stdout_and_stderr,
+                                           capture_stdout=True, capture_stderr=True,
+                                           prefix_output_with_timestamp=True)
 
-        # remove timestamps from each line in output
-        output = re.sub('^[^[]+', '', output.getvalue(), flags=re.MULTILINE)
-        # split output into stdout and stderr
-        stdout = '\n'.join([line[12:]
-                            for line in output.splitlines()
-                            if line.startswith('[0]<stdout>')])
-        stderr = '\n'.join([line[12:]
-                            for line in output.splitlines()
-                            if line.startswith('[0]<stderr>')])
+    def test_stream_command_output_stdout(self):
+        self.do_test_stream_command_output(self.cmd_with_stdout_and_stderr,
+                                           capture_stdout=True, capture_stderr=False,
+                                           prefix_output_with_timestamp=True)
 
-        # both streams should be equal
-        self.assertEqual(stdout, stderr)
-        # streams should have meaningful number of lines and characters
-        self.assertTrue(len(stdout) > 1024)
-        self.assertTrue(len(stdout.splitlines()) > 10)
+    def test_stream_command_output_stderr(self):
+        self.do_test_stream_command_output(self.cmd_with_stdout_and_stderr,
+                                           capture_stdout=False, capture_stderr=True,
+                                           prefix_output_with_timestamp=True)
+
+    def test_stream_command_output_neither(self):
+        self.do_test_stream_command_output(self.cmd_single_line_both,
+                                           capture_stdout=False, capture_stderr=False,
+                                           prefix_output_with_timestamp=True)
+
+    def test_stream_command_output_un_prefixed(self):
+        self.do_test_stream_command_output(self.cmd_with_stdout_and_stderr,
+                                           capture_stdout=True, capture_stderr=True,
+                                           prefix_output_with_timestamp=False)
 
     def test_stream_command_output_reconnect(self):
+        self.do_test_stream_command_output_reconnect(attempts=3, succeeds=True)
+
+    def test_stream_command_output_no_reconnect(self):
+        self.do_test_stream_command_output_reconnect(attempts=1, succeeds=False)
+
+    def do_test_stream_command_output_reconnect(self, attempts, succeeds):
         key = secret.make_secret_key()
-        output = io.StringIO()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
 
-        class Stream:
-            """This stream raises an exception after some text has been written."""
-            raised = False
-
-            def write(self, b):
-                output.write(b)
-                if not self.raised and len(output.getvalue()) > 1024:
-                    print('raise exception')
-                    self.raised = True
-                    raise RuntimeError()
-
-        stream = Stream()
+        stdout_s = FaultyStream(stdout)
+        stderr_s = FaultyStream(stderr)
         service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
         try:
-            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=3)
-            thread = client.stream_command_output(stream)
-            client.run_command(self.cmd_with_stdout_and_stderr, {}, capture=True)
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=attempts)
+            stdout_t, stderr_t = client.stream_command_output(stdout_s, stderr_s)
+            client.run_command(self.cmd_with_stdout_and_stderr, {},
+                               capture_stdout=True, capture_stderr=True,
+                               prefix_output_with_timestamp=False)
             client.wait_for_command_termination(delay=0.2)
-            thread.join(1.0)
-            self.assertEqual(False, thread.is_alive())
-            self.assertEqual((True, 0), client.command_result())
-        finally:
-            service.shutdown()
-
-        # we are likely to loose some lines, so output is hard to evaluate
-        output = output.getvalue()
-        self.assertTrue(len(output) > 1024)
-        self.assertTrue(len(output.splitlines()) > 10)
-        self.assertTrue(stream.raised)
-
-    def test_stream_command_output_stdout_no_reconnect(self):
-        self.do_test_stream_command_output_no_reconnect(self.cmd_with_stdout)
-
-    def test_stream_command_output_stdboth_no_reconnect(self):
-        self.do_test_stream_command_output_no_reconnect(self.cmd_with_stdout_and_stderr)
-
-    def do_test_stream_command_output_no_reconnect(self, command):
-        key = secret.make_secret_key()
-        output = io.StringIO()
-
-        class Stream:
-            """This stream raises an exception after some text has been written."""
-            raised = False
-
-            def write(self, b):
-                output.write(b)
-                if not self.raised and len(output.getvalue()) > 1024:
-                    self.raised = True
-                    raise RuntimeError()
-
-        stream = Stream()
-        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
-        try:
-            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
-            thread = client.stream_command_output(stream)
-            client.run_command(command, {}, capture=True)
-            client.wait_for_command_termination(delay=0.2)
-            thread.join(1.0)
-            self.assertEqual(False, thread.is_alive())
             terminated, exit = client.command_result()
             self.assertEqual(True, terminated)
-            self.assertTrue(exit != 0)
+
+            if succeeds:
+                self.assertEqual(0, exit)
+            else:
+                self.assertTrue(exit != 0)
+
+            if stdout_t is not None:
+                stdout_t.join(1.0)
+                self.assertEqual(False, stdout_t.is_alive())
+            if stderr_t is not None:
+                stderr_t.join(1.0)
+                self.assertEqual(False, stderr_t.is_alive())
         finally:
             service.shutdown()
 
+        stdout = stdout.getvalue()
+        stderr = stderr.getvalue()
+
         # we are likely to loose some lines, so output is hard to evaluate
-        output = output.getvalue()
-        self.assertTrue(len(output) > 1024)
-        self.assertTrue(len(output.splitlines()) > 10)
-        self.assertTrue(stream.raised)
+        self.assertGreaterEqual(len(stdout), 1024)
+        self.assertGreater(len(stdout.splitlines()), 10)
+        self.assertTrue(stdout_s.raised)
+
+        self.assertGreaterEqual(len(stderr), 1024)
+        self.assertGreater(len(stderr.splitlines()), 10)
+        self.assertTrue(stderr_s.raised)
+
+        # assert stdout and stderr similarity (how many lines both have in common)
+        stdout = re.sub('\[0\]<stdout>:', '', stdout, flags=re.MULTILINE)
+        stderr = re.sub('\[0\]<stderr>:', '', stderr, flags=re.MULTILINE)
+        stdout_set = set(stdout.splitlines())
+        stderr_set = set(stderr.splitlines())
+        intersect = stdout_set.intersection(stderr_set)
+        self.assertGreater(len(intersect) / min(len(stdout_set), len(stderr_set)), 0.99)

--- a/test/single/test_task_service.py
+++ b/test/single/test_task_service.py
@@ -1,0 +1,130 @@
+import io
+import re
+import unittest
+
+from horovod.runner.common.service.task_service import BasicTaskService, BasicTaskClient
+from horovod.runner.common.util import secret
+
+
+class TaskServiceTest(unittest.TestCase):
+
+    def test_run_command(self):
+        key = secret.make_secret_key()
+        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
+            client.run_command('find ../.. | wc', {})
+            exit = client.wait_for_command_exit_code()
+            self.assertEqual(0, exit)
+            self.assertEqual((True, 0), client.command_result())
+        finally:
+            service.shutdown()
+
+    cmd_with_stdout = 'find ../.. | sort'
+    cmd_with_stdout_and_stderr = f'bash -c "{cmd_with_stdout} >&2 & {cmd_with_stdout}"'
+
+    def test_stream_command_output(self):
+        key = secret.make_secret_key()
+        output = io.StringIO()
+        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
+            thread = client.stream_command_output(output)
+            client.run_command(self.cmd_with_stdout_and_stderr, {}, capture=True)
+            client.wait_for_command_termination(delay=0.2)
+            thread.join(1.0)
+            self.assertEqual(False, thread.is_alive())
+            self.assertEqual((True, 0), client.command_result())
+        finally:
+            service.shutdown()
+
+        # remove timestamps from each line in output
+        output = re.sub('^[^[]+', '', output.getvalue(), flags=re.MULTILINE)
+        # split output into stdout and stderr
+        stdout = '\n'.join([line[12:]
+                            for line in output.splitlines()
+                            if line.startswith('[0]<stdout>')])
+        stderr = '\n'.join([line[12:]
+                            for line in output.splitlines()
+                            if line.startswith('[0]<stderr>')])
+
+        # both streams should be equal
+        self.assertEqual(stdout, stderr)
+        # streams should have meaningful number of lines and characters
+        self.assertTrue(len(stdout) > 1024)
+        self.assertTrue(len(stdout.splitlines()) > 10)
+
+    def test_stream_command_output_reconnect(self):
+        key = secret.make_secret_key()
+        output = io.StringIO()
+
+        class Stream:
+            """This stream raises an exception after some text has been written."""
+            raised = False
+
+            def write(self, b):
+                output.write(b)
+                if not self.raised and len(output.getvalue()) > 1024:
+                    print('raise exception')
+                    self.raised = True
+                    raise RuntimeError()
+
+        stream = Stream()
+        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=3)
+            thread = client.stream_command_output(stream)
+            client.run_command(self.cmd_with_stdout_and_stderr, {}, capture=True)
+            client.wait_for_command_termination(delay=0.2)
+            thread.join(1.0)
+            self.assertEqual(False, thread.is_alive())
+            self.assertEqual((True, 0), client.command_result())
+        finally:
+            service.shutdown()
+
+        # we are likely to loose some lines, so output is hard to evaluate
+        output = output.getvalue()
+        self.assertTrue(len(output) > 1024)
+        self.assertTrue(len(output.splitlines()) > 10)
+        self.assertTrue(stream.raised)
+
+    def test_stream_command_output_stdout_no_reconnect(self):
+        self.do_test_stream_command_output_no_reconnect(self.cmd_with_stdout)
+
+    def test_stream_command_output_stdboth_no_reconnect(self):
+        self.do_test_stream_command_output_no_reconnect(self.cmd_with_stdout_and_stderr)
+
+    def do_test_stream_command_output_no_reconnect(self, command):
+        key = secret.make_secret_key()
+        output = io.StringIO()
+
+        class Stream:
+            """This stream raises an exception after some text has been written."""
+            raised = False
+
+            def write(self, b):
+                output.write(b)
+                if not self.raised and len(output.getvalue()) > 1024:
+                    self.raised = True
+                    raise RuntimeError()
+
+        stream = Stream()
+        service = BasicTaskService('test service', 0, key, nics=None, verbose=2)
+        try:
+            client = BasicTaskClient('test service', service.addresses(), key, verbose=2, attempts=1)
+            thread = client.stream_command_output(stream)
+            client.run_command(command, {}, capture=True)
+            client.wait_for_command_termination(delay=0.2)
+            thread.join(1.0)
+            self.assertEqual(False, thread.is_alive())
+            terminated, exit = client.command_result()
+            self.assertEqual(True, terminated)
+            self.assertTrue(exit != 0)
+        finally:
+            service.shutdown()
+
+        # we are likely to loose some lines, so output is hard to evaluate
+        output = output.getvalue()
+        self.assertTrue(len(output) > 1024)
+        self.assertTrue(len(output.splitlines()) > 10)
+        self.assertTrue(stream.raised)

--- a/test/single/test_util.py
+++ b/test/single/test_util.py
@@ -1,7 +1,22 @@
-from runner.util.streams import Pipe
-from horovod.runner.util.threads import in_thread
+# Copyright 2021 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
 import unittest
+
+from horovod.runner.util.streams import Pipe
+from horovod.runner.util.threads import in_thread
 
 
 class UtilTests(unittest.TestCase):

--- a/test/single/test_util.py
+++ b/test/single/test_util.py
@@ -1,4 +1,4 @@
-from runner.util.stream import Pipe
+from runner.util.streams import Pipe
 from horovod.runner.util.threads import in_thread
 
 import unittest

--- a/test/single/test_util.py
+++ b/test/single/test_util.py
@@ -1,0 +1,126 @@
+from runner.util.stream import Pipe
+from horovod.runner.util.threads import in_thread
+
+import unittest
+
+
+class UtilTests(unittest.TestCase):
+
+    def test_pipe(self):
+        pipe = Pipe()
+        pipe.write('abcdefg')
+        read = pipe.read()
+        self.assertEqual('abcdefg', read)
+
+    def test_pipe_close_before_read(self):
+        pipe = Pipe()
+        pipe.write('abcdefg')
+        pipe.close()
+        self.assertEqual('abcdefg', pipe.read())
+        self.assertIsNone(pipe.read())
+
+    def test_pipe_close_empty_before_read(self):
+        pipe = Pipe()
+
+        buf = []
+        timeout = 1.0
+
+        def read():
+            buf.append(pipe.read())
+
+        thread = in_thread(read)
+        thread.join(timeout)
+        self.assertEqual(True, thread.is_alive())
+
+        pipe.close()
+        thread.join(timeout)
+        self.assertEqual(False, thread.is_alive())
+        self.assertEqual([None], buf)
+
+    def test_pipe_close_empty_before_write(self):
+        pipe = Pipe()
+        pipe.close()
+        with self.assertRaises(RuntimeError):
+            pipe.write('abcdefg')
+
+    def test_pipe_close_before_write(self):
+        pipe = Pipe()
+        pipe.write('abcdefg')
+        pipe.close()
+        with self.assertRaises(RuntimeError):
+            pipe.write('hijklmn')
+
+    def test_pipe_close_blocked_write(self):
+        timeout = 1.0
+        pipe = Pipe()
+        pipe.write('abcdefg')
+
+        thread = in_thread(pipe.write, ('hijklmn',))
+        thread.join(timeout)
+        self.assertEqual(True, thread.is_alive())
+
+        pipe.close()
+        with self.assertRaises(RuntimeError):
+            pipe.write('opqrstu')
+        thread.join(timeout)
+        self.assertEqual(False, thread.is_alive())
+
+    def test_pipe_read_length(self):
+        pipe = Pipe()
+        pipe.write('abcdefg')
+        for c in 'abcdefg':
+            r = pipe.read(length=1)
+            self.assertEqual(c, r)
+
+        pipe.write('∀∁∂∃∄∅')
+        self.assertEqual('∀∁∂', pipe.read(length=3))
+        self.assertEqual('∃∄∅', pipe.read(length=3))
+
+        pipe.write('∍∎∏∐∑⌚⌛⛄✅…')
+        self.assertEqual('∍∎∏∐∑⌚', pipe.read(length=6))
+        self.assertEqual('⌛⛄✅…', pipe.read(length=6))
+
+        pipe.write('∆∇∈∉')
+        self.assertEqual('∆∇∈∉', pipe.read(length=4))
+
+        pipe.write('∊∋∌')
+        self.assertEqual('∊∋∌', pipe.read(length=4))
+
+        pipe.write('∀∁∂∃∄∅')
+        self.assertEqual('∀∁∂', pipe.read(length=3))
+        self.assertEqual('∃∄∅', pipe.read())
+
+    def test_pipe_blocking(self):
+        buf = []
+        timeout = 1.0
+
+        def read():
+            buf.append(pipe.read())
+
+        def write(content):
+            pipe.write(content)
+
+        pipe = Pipe()
+
+        pipe.write('first')
+        thread = in_thread(write, ('second',))
+        thread.join(timeout)
+
+        self.assertEqual(True, thread.is_alive())
+        self.assertEqual('first', pipe.read())
+        self.assertEqual('second', pipe.read())
+        thread.join(timeout)
+        self.assertEqual(False, thread.is_alive())
+
+        thread = in_thread(read)
+        thread.join(timeout)
+        self.assertEqual(True, thread.is_alive())
+
+        pipe.write('third')
+        thread.join(timeout)
+        self.assertEqual(False, thread.is_alive())
+        self.assertEqual(['third'], buf)
+
+    def test_pipe_flush(self):
+        pipe = Pipe()
+        pipe.flush()

--- a/test/single/test_util.py
+++ b/test/single/test_util.py
@@ -139,3 +139,11 @@ class UtilTests(unittest.TestCase):
     def test_pipe_flush(self):
         pipe = Pipe()
         pipe.flush()
+
+    def test_pipe_with_bytes(self):
+        pipe = Pipe()
+        pipe.write('∀∁∂∃∄∅'.encode('utf8'))
+        self.assertEqual(b'\xe2\x88', pipe.read(2))
+        self.assertEqual(b'\x80\xe2\x88\x81', pipe.read(4))
+        self.assertEqual(b'\xe2\x88\x82\xe2\x88\x83\xe2\x88', pipe.read(8))
+        self.assertEqual(b'\x84\xe2\x88\x85', pipe.read())


### PR DESCRIPTION
Currently, running your training function on Spark over Gloo does not forward stdout / stderr to your driver. The output is written to Spark workers' log files, which are sometimes hard to find.

This PR allows to forward stdout or stderr or both to the driver.