### PR TITLE
[TF2.4 - HVD Keras Fix] - Horovod worker desynchronization - Potentially deadlock training TF 2.4

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -68,6 +68,32 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
 
             super(self.__class__, self).__init__(**kwargs)
 
+        def _compute_gradients(self, loss, var_list, grad_loss=None, tape=None):
+            """
+            Compute gradients of all trainable variables.
+
+            See Optimizer.get_gradients() for more info.
+
+            In DistributedOptimizer, get_gradients() is overriden to also
+            allreduce the gradients before returning them.
+            """
+            if _PRE_TF_2_4_0:
+                return super(self.__class__, self)._compute_gradients(
+                    loss, var_list, grad_loss, tape)
+
+            tape = backprop.GradientTape() if tape is None else tape
+            grads_and_vars = super(self.__class__, self)._compute_gradients(
+                # pylint: disable=protected-access
+                loss,
+                var_list,
+                grad_loss,
+                tape=tape)
+            grads = [g for g, _ in grads_and_vars]
+            weights = [v for _, v in grads_and_vars]
+
+            allreduced_grads = self._allreduce(grads)
+            return list(zip(allreduced_grads, weights))
+
         def get_gradients(self, loss, params):
             """
             Compute gradients of all trainable variables.
@@ -81,13 +107,13 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
             return self._allreduce(gradients)
 
         def _aggregate_gradients(self, grads_and_vars):
-            grads, vars = list(zip(*grads_and_vars))
-            aggregated_grads = self._allreduce(grads)
             if _PRE_TF_2_4_0:
-                # Prior to TF 2.4.0, this function was expected to return only a list of
-                # grads, not a list of (grad, var) tuples.
+                grads, vars = list(zip(*grads_and_vars))
+                aggregated_grads = self._allreduce(grads)
                 return aggregated_grads
-            return list(zip(aggregated_grads, vars))
+            else:
+                return super(self.__class__, self)._aggregate_gradients(
+                    grads_and_vars)
 
         def _allreduce(self, grads):
             self._aggregated_gradients = True
@@ -117,7 +143,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
             else:
                 results = super(self.__class__, self).apply_gradients(*args, **kwargs)
 
-            if not self._aggregated_gradients:
+            if _PRE_TF_2_4_0 and not self._aggregated_gradients:
                 raise Exception('`apply_gradients()` was called without a call to '
                                 '`get_gradients()` or `_aggregate_gradients`. If you\'re '
                                 'using TensorFlow 2.0, please specify '

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -88,8 +88,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                 var_list,
                 grad_loss,
                 tape=tape)
-            grads = [g for g, _ in grads_and_vars]
-            weights = [v for _, v in grads_and_vars]
+            grads, weights = list(zip(*grads_and_vars))
 
             allreduced_grads = self._allreduce(grads)
             return list(zip(allreduced_grads, weights))

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -163,6 +163,8 @@ class Tf2KerasTests(tf.test.TestCase):
         assert state.batch == 21
         assert state.epoch == 11
 
+    @pytest.mark.skipif(LooseVersion(tf.__version__) >= LooseVersion('2.4.0'),
+                        reason='TensorFlow 2.4.0+ does not support this path')
     def test_gradient_aggregation(self):
         class TestingOptimizer(optimizer_v2.OptimizerV2):
             """
@@ -228,7 +230,7 @@ class Tf2KerasTests(tf.test.TestCase):
                     experimental_aggregate_gradients=False
                 )
             else:
-                apply_gradients_in_tf_function(gradients, variables)
+                raise RuntimeError("This test should be skipped ...")
 
             updated_variable_value = variables[0][0].numpy()
             assert updated_variable_value == compute_expected_value(idx)


### PR DESCRIPTION
CC: @romerojosh @tgaddair @nluehr 

This PR aims to fix a bug with TF2.4 already reported here: https://github.com/tensorflow/tensorflow/issues/46863

Basically this PR does the following:
- Rollback the `allreduce` in `_aggregate_gradients` and make sure to execute the allreduce during gradient computation
- Yes it means that in the eventuality the Grad Step is skipped (by mixed precision) we have allreduced for no reason, but this event is supposed to be very rare. And it's still better than having worker to desynchronize or deadlock.
- `self._aggregated_gradients = True` has been moved to gradient computation instead of `allreduce` itself. This is done to work around that gradient tape is used to compute gradient with a CTL

@tgaddair : would be nice to push a new release" to address this bug, that way we can unblock TF2.4 users ;) 

Thanks everyone