### PR TITLE
Adding Horovod License to the metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(name='horovod',
       packages=find_packages(),
       description='Distributed training framework for TensorFlow, Keras, PyTorch, and Apache MXNet.',
       author='The Horovod Authors',
+      license='Apache 2.0',
       long_description=textwrap.dedent('''\
           Horovod is a distributed training framework for TensorFlow, Keras, PyTorch, and Apache MXNet.
           The goal of Horovod is to make distributed Deep Learning fast and easy to use.'''),


### PR DESCRIPTION
Not a big change, though I noticed that Horovod wasn't reporting the license in the metadata:

```
License: UNKNOWN
```

Now this will be fixed ;)