### PR TITLE
torch: add missing root_rank in broadcast_optimizer_state

### DIFF
--- a/horovod/torch/functions.py
+++ b/horovod/torch/functions.py
@@ -179,7 +179,7 @@ def broadcast_optimizer_state(optimizer, root_rank):
     broadcast_parameters(params, root_rank)
 
     # Broadcast and cleanup for non-tensor parameters
-    scalars = broadcast_object(scalars)
+    scalars = broadcast_object(scalars, root_rank)
     for key, p in scalars.items():
         callbacks[key](p)
 


### PR DESCRIPTION
For non-tensor parameters, we should also follow the passed in
root_rank, as broadcast of all tensor parameters.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
