### PR TITLE
setup.py: allow horovod to be installed without native libraries

### DIFF
--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -141,7 +141,7 @@ def mpi_built(verbose=False):
             ext_base_name, built_fn, 'built with MPI', verbose)
         if result is not None:
             return result
-    return False
+    return None
 
 
 @_cache
@@ -152,9 +152,7 @@ def gloo_built(verbose=False):
             ext_base_name, built_fn, 'built with Gloo', verbose)
         if result is not None:
             return result
-    raise RuntimeError('Failed to determine if Gloo support has been built. '
-                       'Run again with --verbose for more details.')
-
+    return None
 
 @_cache
 def nccl_built(verbose=False):
@@ -164,9 +162,7 @@ def nccl_built(verbose=False):
             ext_base_name, built_fn, 'built with NCCL', verbose)
         if result is not None:
             return result
-    raise RuntimeError('Failed to determine if NCCL support has been built. '
-                       'Run again with --verbose for more details.')
-
+    return None
 
 @_cache
 def ddl_built(verbose=False):
@@ -176,9 +172,7 @@ def ddl_built(verbose=False):
             ext_base_name, built_fn, 'built with DDL', verbose)
         if result is not None:
             return result
-    raise RuntimeError('Failed to determine if DDL support has been built. '
-                       'Run again with --verbose for more details.')
-
+    return None
 
 @_cache
 def ccl_built(verbose=False):
@@ -188,9 +182,7 @@ def ccl_built(verbose=False):
             ext_base_name, built_fn, 'built with CCL', verbose)
         if result is not None:
             return result
-    raise RuntimeError('Failed to determine if CCL support has been built. '
-                       'Run again with --verbose for more details.')
-
+    return None
 
 @contextmanager
 def env(**kwargs):

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ def get_cmake_bin():
 
 class custom_build_ext(build_ext):
     def build_extensions(self):
+        if os.getenv('HOROVOD_SKIP_COMPILE') == '1':
+            # Skip building extensions using CMake
+            print("Horovod is being installed without native libraries")
+            return
+
         cmake_bin = get_cmake_bin()
 
         config = 'Debug' if self.debug else 'RelWithDebInfo'


### PR DESCRIPTION
If `HOROVOD_SKIP_COMPILE` is set to `1`, native libaries using CMake
will be skipped in building.

Also, check_build function (gloo, nccl, ...) should allow None as return value.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #2688.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
