### PR TITLE
Fix bug #2674. Save metadata using store because spark has 2G limit on file size 

### DIFF
--- a/horovod/spark/common/serialization.py
+++ b/horovod/spark/common/serialization.py
@@ -31,7 +31,8 @@ class HorovodParamsWriter(DefaultParamsWriter):
                                   extraMetadata,
                                   paramMap,
                                   param_serializer_fn)
-        sc.parallelize([metadata_json], 1).saveAsTextFile(metadata_path)
+
+        instance.store.write_text(metadata_path, metadata_json)
 
     @staticmethod
     def _get_metadata_to_save(instance, sc, extra_metadata=None, param_map=None,

--- a/horovod/spark/common/serialization.py
+++ b/horovod/spark/common/serialization.py
@@ -32,7 +32,8 @@ class HorovodParamsWriter(DefaultParamsWriter):
                                   paramMap,
                                   param_serializer_fn)
 
-        if hasattr(instance, 'getStore'):
+        # save mode by store as spark has 2G limitation on file size.
+        if hasattr(instance, 'getStore') and instance.getStore() is not None:
             instance.getStore().write_text(metadata_path, metadata_json)
         else:
             sc.parallelize([metadata_json], 1).saveAsTextFile(metadata_path)

--- a/horovod/spark/common/serialization.py
+++ b/horovod/spark/common/serialization.py
@@ -32,7 +32,10 @@ class HorovodParamsWriter(DefaultParamsWriter):
                                   paramMap,
                                   param_serializer_fn)
 
-        instance.store.write_text(metadata_path, metadata_json)
+        if hasattr(instance, 'getStore'):
+            instance.getStore().write_text(metadata_path, metadata_json)
+        else:
+            sc.parallelize([metadata_json], 1).saveAsTextFile(metadata_path)
 
     @staticmethod
     def _get_metadata_to_save(instance, sc, extra_metadata=None, param_map=None,

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -106,6 +106,10 @@ class Store(object):
         """Returns the contents of the path as bytes."""
         raise NotImplementedError()
 
+    def write_text(self, path, text):
+        """Write text file to path."""
+        raise NotImplementedError()
+
     def get_local_output_dir_fn(self, run_id):
         raise NotImplementedError()
 
@@ -183,6 +187,10 @@ class FilesystemStore(Store):
 
         model_bytes = self.read(ckpt_path)
         return codec.dumps_base64(model_bytes)
+
+    def write_text(self, path, text):
+        with self.get_filesystem().open(self.get_localized_path(path), 'w') as f:
+            f.write(text)
 
     def is_parquet_dataset(self, path):
         try:


### PR DESCRIPTION
## Description
Fixes #2674 
Save metadata using store because spark has 2G limit on file size