### PR TITLE
Add support for custom LearningRateSchedule for TF2

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -158,8 +158,8 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                dict(_DistributedOptimizer.__dict__))
 
     config = optimizer.get_config()
-    if issubclass(optimizer.lr.__class__,
-                  keras.optimizers.schedules.LearningRateSchedule):
+    if not _PRE_TF_2_4_0 and issubclass(optimizer.lr.__class__,
+                                        keras.optimizers.schedules.LearningRateSchedule):
         lr_cls = type(optimizer.lr.__class__.__name__, (optimizer.lr.__class__,),
                       dict(optimizer.lr.__dict__))
         config['learning_rate'] = lr_cls.from_config(config['learning_rate']['config'])

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -157,8 +157,14 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
     cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                dict(_DistributedOptimizer.__dict__))
 
-    return cls.from_config(optimizer.get_config())
+    config = optimizer.get_config()
+    if issubclass(optimizer.lr.__class__,
+                  keras.optimizers.schedules.LearningRateSchedule):
+        lr_cls = type(optimizer.lr.__class__.__name__, (optimizer.lr.__class__,),
+                      dict(optimizer.lr.__dict__))
+        config['learning_rate'] = lr_cls.from_config(config['learning_rate']['config'])
 
+    return cls.from_config(config)
 
 def _eval(backend, op_or_result):
     if hvd._executing_eagerly():


### PR DESCRIPTION
## Checklist before submitting

- [Yes] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [No] Did you update the docs?
- [No] Did you write any tests to validate this change?  
- [No] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR fixes an issue the current horovod optimizer wrapper cannot correctly deal with the custom learning rate schedule.

fyi. @nluehr @DEKHTIARJonathan 
Fixes # (issue).
Without this PR, the following script would fail:
```python
import tensorflow as tf
import numpy as np
from tensorflow.keras import layers

import horovod.tensorflow as hvd
hvd.init()
gpus = tf.config.experimental.list_physical_devices('GPU')
for gpu in gpus:
  tf.config.experimental.set_memory_growth(gpu, True)
if gpus:
  tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')

model = tf.keras.Sequential()
model.add(tf.keras.layers.Dense(8))
model.add(tf.keras.layers.Dense(1))

class CustomLearningRateSchedule(
    tf.keras.optimizers.schedules.LearningRateSchedule):
  def __init__(self, lr_values, name):
    super(CustomLearningRateSchedule, self).__init__()
    self.lr_values = lr_values
    self.name = name
    self.learning_rate_ops_cache = {}

  def __call__(self, step):
    if tf.executing_eagerly():
      return self.lr_values * step

    graph = tf.compat.v1.get_default_graph()
    if graph not in self.learning_rate_ops_cache:
      self.learning_rate_ops_cache[graph] = self.lr_values * step
    return self.learning_rate_ops_cache[graph]

  def get_config(self):
    return {
        'lr_values': self.lr_values,
        'name': self.name
    }


learning_rate = CustomLearningRateSchedule(0.001, "toy")
opt = tf.keras.optimizers.SGD(learning_rate)

#opt = tf.optimizers.SGD(0.001)
opt = hvd.DistributedOptimizer(opt)

model.compile(optimizer=opt, loss='mse')
# This builds the model for the first time:

x = np.random.random((100, 3))
y = np.random.random((100,))
model.fit(x, y, batch_size=32, epochs=10)

```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
