### PR TITLE
Docker should not cache nightly packages

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -125,12 +125,15 @@ RUN if [[ ${MPI_KIND} != "None" ]]; then \
     fi
 
 # Install TensorFlow and Keras (releases).
-# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Pin h5py only for tensorflow<2.5: https://github.com/h5py/h5py/issues/1732
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
 RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly" ]]; then \
         pip install ${TENSORFLOW_PACKAGE}; \
         if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+            if [[ ${TENSORFLOW_PACKAGE} == tensorflow*==1.* ]] || [[ ${TENSORFLOW_PACKAGE} == tensorflow*==2.[01234].* ]]; then \
+                h5py="h5py<3"; \
+            fi; \
+            pip install ${KERAS_PACKAGE} ${h5py:-} "scipy!=1.4.0" "pandas<1.1.0"; \
         fi; \
         mkdir -p ~/.keras; \
         python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \
@@ -165,12 +168,12 @@ COPY . /horovod
 # Install nightly packages here so they do not get cached
 
 # Install TensorFlow and Keras (nightly).
-# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Do not pin h5py since tf>=2.5 requires h5py~=3.1
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
 RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly" ]]; then \
         pip install ${TENSORFLOW_PACKAGE}; \
         if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+            pip install ${KERAS_PACKAGE} "scipy!=1.4.0" "pandas<1.1.0"; \
         fi; \
         mkdir -p ~/.keras; \
         python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -184,7 +184,7 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly" ]]; then \
 # Install PyTorch (nightly).
 # Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
         if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
             pip install "Pillow<7.0" --no-deps; \
         fi; \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -124,33 +124,27 @@ RUN if [[ ${MPI_KIND} != "None" ]]; then \
         pip install mpi4py; \
     fi
 
-# Install TensorFlow.
-RUN pip install ${TENSORFLOW_PACKAGE}
-
-# Install Keras.
+# Install TensorFlow and Keras (releases).
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-        pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly" ]]; then \
+        pip install ${TENSORFLOW_PACKAGE}; \
+        if [[ ${KERAS_PACKAGE} != "None" ]]; then \
+            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+        fi; \
+        mkdir -p ~/.keras; \
+        python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \
     fi
-RUN mkdir -p ~/.keras
-RUN python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"
 
-# Install PyTorch.
-RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
-    else \
+# Install PyTorch (releases).
+RUN if [[ ${PYTORCH_PACKAGE} != "torch-nightly" ]]; then \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
 # Pin Pillow<7.0: https://github.com/pytorch/vision/issues/1718
 RUN pip install "Pillow<7.0" --no-deps
 
-# Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet==2.0.0b20210319 -f https://dist.mxnet.io/python/all; \
-    elif [[ ${MXNET_PACKAGE} == "mxnet=="*b* ]]; then \
-        pip install --pre ${MXNET_PACKAGE} -f https://dist.mxnet.io/python; \
-    else \
+# Install MXNet (releases).
+RUN if [[ ${MXNET_PACKAGE} != "mxnet-nightly" ]]; then \
         pip install ${MXNET_PACKAGE} ; \
     fi
 
@@ -167,6 +161,30 @@ RUN wget --progress=dot:mega https://horovod-datasets.s3.amazonaws.com/pytorch_d
 
 ### END OF CACHE ###
 COPY . /horovod
+
+# Install nightly packages here so they do not get cached
+
+# Install TensorFlow and Keras (nightly).
+# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
+RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly" ]]; then \
+        pip install ${TENSORFLOW_PACKAGE}; \
+        if [[ ${KERAS_PACKAGE} != "None" ]]; then \
+            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+        fi; \
+        mkdir -p ~/.keras; \
+        python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \
+    fi
+
+# Install PyTorch (nightly).
+RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+    fi
+
+# Install MXNet (nightly).
+RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
+        pip install --pre mxnet==2.0.0b20210319 -f https://dist.mxnet.io/python/all; \
+    fi
 
 # Install Horovod.
 RUN if [[ ${MPI_KIND} == "ONECCL" ]]; then \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -140,11 +140,13 @@ RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly" ]]; then \
     fi
 
 # Install PyTorch (releases).
+# Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN if [[ ${PYTORCH_PACKAGE} != "torch-nightly" ]]; then \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/torch_stable.html; \
+        if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
+            pip install "Pillow<7.0" --no-deps; \
+        fi; \
     fi
-# Pin Pillow<7.0: https://github.com/pytorch/vision/issues/1718
-RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet (releases).
 RUN if [[ ${MXNET_PACKAGE} != "mxnet-nightly" ]]; then \
@@ -180,8 +182,12 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly" ]]; then \
     fi
 
 # Install PyTorch (nightly).
+# Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
+            pip install "Pillow<7.0" --no-deps; \
+        fi; \
     fi
 
 # Install MXNet (nightly).

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -93,38 +93,30 @@ RUN if [[ ${MPI_KIND} != "None" ]]; then \
         pip install mpi4py; \
     fi
 
-# Install TensorFlow.
-RUN pip install ${TENSORFLOW_PACKAGE}
-
-# Install Keras.
+# Install TensorFlow and Keras (releases).
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
-RUN if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-        pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly-gpu" ]]; then \
+        pip install ${TENSORFLOW_PACKAGE}; \
+        if [[ ${KERAS_PACKAGE} != "None" ]]; then \
+            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+        fi; \
+        mkdir -p ~/.keras; \
+        ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs; \
+        python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \
+        ldconfig; \
     fi
-RUN mkdir -p ~/.keras
-RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
-    python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()" && \
-    ldconfig
 
-# Install PyTorch.
+# Install PyTorch (releases).
 RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
-    if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-	    pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
-    else \
+    if [[ ${PYTORCH_PACKAGE} != "torch-nightly" ]]; then \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/cu${PYTORCH_CUDA}/torch_stable.html; \
     fi
 # Pin Pillow<7.0: https://github.com/pytorch/vision/issues/1718
 RUN pip install "Pillow<7.0" --no-deps
 
-# Install MXNet.
-RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --pre mxnet-cu101==2.0.0b20210319 -f https://dist.mxnet.io/python/cu101; \
-    elif [[ ${MXNET_PACKAGE} == "mxnet-cu101=="*b* ]]; then \
-        pip install --pre ${MXNET_PACKAGE} -f https://dist.mxnet.io/python/cu101; \
-    elif [[ ${MXNET_PACKAGE} == "mxnet-nightly-cu110" ]]; then \
-        pip install --pre mxnet-cu110==2.0.0b20210319 -f https://dist.mxnet.io/python/cu110; \
-    else \
+# Install MXNet (releases).
+RUN if [[ ${MXNET_PACKAGE} != "mxnet-nightly-cu"* ]]; then \
         pip install ${MXNET_PACKAGE} ; \
     fi
 
@@ -141,6 +133,34 @@ RUN wget --progress=dot:mega https://horovod-datasets.s3.amazonaws.com/pytorch_d
 
 ### END OF CACHE ###
 COPY . /horovod
+
+# Install nightly packages here so they do not get cached
+
+# Install TensorFlow and Keras (nightly).
+# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
+RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly-gpu" ]]; then \
+        pip install ${TENSORFLOW_PACKAGE}; \
+        if [[ ${KERAS_PACKAGE} != "None" ]]; then \
+            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+        fi; \
+        mkdir -p ~/.keras; \
+        ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs; \
+        python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"; \
+        ldconfig; \
+    fi
+
+# Install PyTorch (nightly).
+RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
+    if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+    fi
+
+# Install MXNet (nightly).
+RUN MXNET_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
+    if [[ ${MXNET_PACKAGE} == "mxnet-nightly-cu"* ]] || [[ ${MXNET_PACKAGE} == "mxnet-cu"*"=="*b* ]]; then \
+        pip install --pre ${MXNET_PACKAGE/-nightly/}==2.0.0b20210319 -f https://dist.mxnet.io/python/cu${MXNET_CUDA}; \
+    fi
 
 # Install Horovod.
 RUN cd /horovod && \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -94,12 +94,15 @@ RUN if [[ ${MPI_KIND} != "None" ]]; then \
     fi
 
 # Install TensorFlow and Keras (releases).
-# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Pin h5py only for tensorflow<2.5: https://github.com/h5py/h5py/issues/1732
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
 RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly-gpu" ]]; then \
         pip install ${TENSORFLOW_PACKAGE}; \
         if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+            if [[ ${TENSORFLOW_PACKAGE} == tensorflow*==1.* ]] || [[ ${TENSORFLOW_PACKAGE} == tensorflow*==2.[01234].* ]]; then \
+                h5py="h5py<3"; \
+            fi; \
+            pip install ${KERAS_PACKAGE} ${h5py:-} "scipy!=1.4.0" "pandas<1.1.0"; \
         fi; \
         mkdir -p ~/.keras; \
         ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs; \
@@ -137,12 +140,12 @@ COPY . /horovod
 # Install nightly packages here so they do not get cached
 
 # Install TensorFlow and Keras (nightly).
-# Pin h5py: https://github.com/h5py/h5py/issues/1732
+# Do not pin h5py since tf>=2.5 requires h5py~=3.1
 # Pin scipy!=1.4.0: https://github.com/scipy/scipy/issues/11237
 RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly-gpu" ]]; then \
         pip install ${TENSORFLOW_PACKAGE}; \
         if [[ ${KERAS_PACKAGE} != "None" ]]; then \
-            pip install ${KERAS_PACKAGE} "h5py<3" "scipy!=1.4.0" "pandas<1.1.0"; \
+            pip install ${KERAS_PACKAGE} "scipy!=1.4.0" "pandas<1.1.0"; \
         fi; \
         mkdir -p ~/.keras; \
         ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs; \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -111,12 +111,14 @@ RUN if [[ ${TENSORFLOW_PACKAGE} != "tf-nightly-gpu" ]]; then \
     fi
 
 # Install PyTorch (releases).
+# Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
     if [[ ${PYTORCH_PACKAGE} != "torch-nightly" ]]; then \
         pip install ${PYTORCH_PACKAGE} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/cu${PYTORCH_CUDA}/torch_stable.html; \
+        if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
+            pip install "Pillow<7.0" --no-deps; \
+        fi; \
     fi
-# Pin Pillow<7.0: https://github.com/pytorch/vision/issues/1718
-RUN pip install "Pillow<7.0" --no-deps
 
 # Install MXNet (releases).
 RUN if [[ ${MXNET_PACKAGE} != "mxnet-nightly-cu"* ]]; then \
@@ -154,9 +156,13 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly-gpu" ]]; then \
     fi
 
 # Install PyTorch (nightly).
+# Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
     if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
         pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
+            pip install "Pillow<7.0" --no-deps; \
+        fi; \
     fi
 
 # Install MXNet (nightly).

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -159,7 +159,7 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly-gpu" ]]; then \
 # Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN PYTORCH_CUDA=$(echo ${CUDA_DOCKER_VERSION} | awk -F- '{print $1}' | sed 's/\.//'); \
     if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --pre torch ${TORCHVISION_PACKAGE} -v -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
+        pip install --pre torch ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/cu${PYTORCH_CUDA}/torch_nightly.html; \
         if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
             pip install "Pillow<7.0" --no-deps; \
         fi; \


### PR DESCRIPTION
The tensorflow, torch, torchvision and mxnet dependencies are installed in `Dockerfile.test.cpu` and `Dockerfile.test.gpu` before Horovod sources are copied, thus they are cached by Docker as long as the RUN command does not change. This should not happen for nightly packages.

This PR moves the installation of nightly packages after copying Horovod sources. This forces their download and installation on every run. Release versions, however, are still installed before the copy and thus subject for caching.

See all the RUN commands before `Step 50/63 : COPY . /horovod` in https://buildkite.com/organizations/horovod/pipelines/horovod/builds/5125/jobs/b3a90cef-21b8-41b9-8595-b5a25c16bd51/raw_log. **They are all cached, which is a great cache hit rate if it wouldn't be *test-gpu-gloo-py3_8-tfhead-keras2_4_3-torchhead-mxnethead-pyspark_3_0_1*, which is bad for testing nightly versions.**

This is probably the reason why we haven't seen `mxnet-nightly-cu110` fail earlier when they have moved from MKLDNN headers to oneDNN headers.

Also fixes this warning that does not make the build fail, so it is burried in the logs:
```
pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tf-nightly-gpu 2.6.0.dev20210331 requires h5py~=3.1.0, but you have h5py 2.10.0 which is incompatible.
```

Further, `Pillow` had been fixed to `<7.0` though the respective bug has been fixed in `torchvision>=0.5.0`. To avoid issues with future torch vision version, this constraint has been relaxed.

Installation of nightly torch packages is done with `-v`, which pollutes the logs with thousands of lines. Enable when really needed to debug something.

Depends on #2814 being merged into master first.