### PR TITLE
Use separate CMake build dirs for release and debug builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,15 +85,16 @@ class custom_build_ext(build_ext):
             # -- specifies that these args are going to the native build tool: make
             cmake_build_args += ['--'] + make_args
 
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
+        cmake_build_dir = os.path.join(self.build_temp, config)
+        if not os.path.exists(cmake_build_dir):
+            os.makedirs(cmake_build_dir)
 
         # Config and build the extension
         try:
             subprocess.check_call([cmake_bin, self.extensions[0].cmake_lists_dir] + cmake_args,
-                                  cwd=self.build_temp)
+                                  cwd=cmake_build_dir)
             subprocess.check_call([cmake_bin, '--build', '.'] + cmake_build_args,
-                                  cwd=self.build_temp)
+                                  cwd=cmake_build_dir)
         except OSError as e:
             raise RuntimeError('CMake failed: {}'.format(str(e)))
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This makes it easier and faster to switch between debug and release builds during development because one doesn't need to clean the entire build dir.