### PR TITLE
Pin tf-nightly to 2.6.0.dev20210331

### DIFF
--- a/Jenkinsfile.ppc64le
+++ b/Jenkinsfile.ppc64le
@@ -1,7 +1,7 @@
 pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '30'))
-        timeout(time: 10, unit: 'MINUTES')
+        timeout(time: 15, unit: 'MINUTES')
     }
     agent {
         docker {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -101,7 +101,7 @@ services:
     extends: test-cpu-base
     build:
       args:
-        TENSORFLOW_PACKAGE: tf-nightly
+        TENSORFLOW_PACKAGE: tf-nightly==2.6.0.dev20210331
         KERAS_PACKAGE: None
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -209,7 +209,7 @@ services:
         CUDA_DOCKER_VERSION: 11.0-devel-ubuntu18.04
         CUDNN_VERSION: 8.0.5.39-1+cuda11.0
         NCCL_VERSION_OVERRIDE: 2.7.8-1+cuda11.0
-        TENSORFLOW_PACKAGE: tf-nightly-gpu
+        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.6.0.dev20210331
         KERAS_PACKAGE: None
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision


### PR DESCRIPTION
TF-Head seems to break our tests in `test-cpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark_3_0_1`:

```
test_keras.py:23: in <module>
    import keras
/usr/local/lib/python3.8/dist-packages/keras/__init__.py:25: in <module>
    from keras import models
/usr/local/lib/python3.8/dist-packages/keras/models.py:20: in <module>
    from keras import metrics as metrics_module
/usr/local/lib/python3.8/dist-packages/keras/metrics.py:27: in <module>
    from keras import activations
/usr/local/lib/python3.8/dist-packages/keras/activations.py:20: in <module>
    from keras.layers import advanced_activations
/usr/local/lib/python3.8/dist-packages/keras/layers/__init__.py:24: in <module>
    from keras.engine.input_layer import Input
/usr/local/lib/python3.8/dist-packages/keras/engine/input_layer.py:21: in <module>
    from keras.engine import base_layer
/usr/local/lib/python3.8/dist-packages/keras/engine/base_layer.py:41: in <module>
    from keras.mixed_precision import loss_scale_optimizer
/usr/local/lib/python3.8/dist-packages/keras/mixed_precision/loss_scale_optimizer.py:1180: in <module>
    mixed_precision._register_wrapper_optimizer_cls(optimizer_v2.OptimizerV2,
E   AttributeError: module 'tensorflow.python.training.experimental.mixed_precision' has no attribute '_register_wrapper_optimizer_cls'
```