### PR TITLE
Un-pin tf-nightly

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -99,7 +99,7 @@ services:
     extends: test-cpu-base
     build:
       args:
-        TENSORFLOW_PACKAGE: tf-nightly==2.6.0.dev20210331
+        TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: None
         PYTORCH_PACKAGE: torch-nightly
         TORCHVISION_PACKAGE: torchvision
@@ -196,7 +196,7 @@ services:
         CUDA_DOCKER_VERSION: 11.2.2-devel-ubuntu18.04
         CUDNN_VERSION: 8.1.1.33-1+cuda11.2
         NCCL_VERSION_OVERRIDE: 2.8.4-1+cuda11.2
-        TENSORFLOW_PACKAGE: tf-nightly-gpu==2.6.0.dev20210331
+        TENSORFLOW_PACKAGE: tf-nightly-gpu
         KERAS_PACKAGE: None
         PYTORCH_PACKAGE: torch-nightly-cu111
         TORCHVISION_PACKAGE: torchvision


### PR DESCRIPTION
We had to pin tensorflow nightlies in #2814. This tests if nightlies work again and to un-pin it in master.