### PR TITLE
Un-pin torch-nightly

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -195,7 +195,7 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly" ]]; then \
 # Install PyTorch (nightly).
 # Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
-        pip install --no-cache-dir --pre torch==1.9.0.dev20210303+cpu ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
+        pip install --no-cache-dir --pre torch ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; \
         if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
             pip install --no-cache-dir "Pillow<7.0" --no-deps; \
         fi; \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -167,7 +167,7 @@ RUN if [[ ${TENSORFLOW_PACKAGE} == "tf-nightly-gpu" ]]; then \
 # Install PyTorch (nightly).
 # Pin Pillow<7.0 for torchvision < 0.5.0: https://github.com/pytorch/vision/issues/1718
 RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly-cu"* ]]; then \
-        pip install --no-cache-dir --pre torch==1.9.0.dev20210303+${PYTORCH_PACKAGE/#torch-nightly-/} ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/${PYTORCH_PACKAGE/#torch-nightly-/}/torch_nightly.html; \
+        pip install --no-cache-dir --pre torch ${TORCHVISION_PACKAGE} -f https://download.pytorch.org/whl/nightly/${PYTORCH_PACKAGE/#torch-nightly-/}/torch_nightly.html; \
         if [[ "${TORCHVISION_PACKAGE/%+*/}" == torchvision==0.[1234].* ]]; then \
             pip install --no-cache-dir "Pillow<7.0" --no-deps; \
         fi; \

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -26,7 +26,8 @@ from horovod.tensorflow import local_rank
 from horovod.tensorflow import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.tensorflow import gloo_enabled, gloo_built
 from horovod.tensorflow import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
-from horovod.tensorflow import Average, Compression, Sum
+from horovod.tensorflow import Average, Sum
+from horovod.tensorflow import compression
 
 
 from horovod.keras import callbacks, elastic
@@ -35,7 +36,7 @@ import horovod._keras as _impl
 
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
-                         compression=Compression.none,
+                         compression=compression.Compression.none,
                          sparse_as_dense=False,
                          gradient_predivide_factor=1.0,
                          op=Average,
@@ -164,7 +165,7 @@ def broadcast(value, root_rank, name=None):
     return _impl.broadcast(K, value, root_rank, name)
 
 
-def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none):
+def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=compression.Compression.none):
     """
     Loads a saved Keras model with a Horovod DistributedOptimizer.
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -243,6 +243,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                     **reader_factory_kwargs) \
                     if should_validate else empty_batch_reader() as val_reader:
 
+                    # requires petastorm<0.11.0
                     train_loader = BatchedDataLoader(train_reader,
                                                      num_epochs=epochs if inmemory_cache_all else None,
                                                      batch_size=batch_size,
@@ -331,6 +332,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                         return aggregate_metrics('train', epoch, train_loss, metric_value_groups)
 
                     if should_validate:
+                        # requires petastorm<0.11.0
                         val_loader = BatchedDataLoader(val_reader,
                                                        num_epochs=epochs if inmemory_cache_all else None,
                                                        batch_size=batch_size,

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -30,7 +30,9 @@ from horovod.tensorflow import local_rank
 from horovod.tensorflow import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.tensorflow import gloo_enabled, gloo_built
 from horovod.tensorflow import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
-from horovod.tensorflow import Average, Compression, Sum
+from horovod.tensorflow import Average, Sum
+from horovod.tensorflow import compression
+
 
 import horovod._keras as _impl
 from horovod.tensorflow.keras import callbacks, elastic
@@ -47,7 +49,7 @@ except:
 
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
-                         compression=Compression.none,
+                         compression=compression.Compression.none,
                          sparse_as_dense=False,
                          gradient_predivide_factor=1.0,
                          op=Average,
@@ -147,7 +149,7 @@ def allreduce(value, name=None, average=None,
               prescale_factor=1.0,
               postscale_factor=1.0,
               op=None,
-              compression=Compression.none):
+              compression=compression.Compression.none):
     """
     Perform an allreduce on a tensor-compatible value.
 
@@ -208,7 +210,7 @@ def broadcast(value, root_rank, name=None):
     return _impl.broadcast(K, value, root_rank, name)
 
 
-def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none):
+def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=compression.Compression.none):
     """
     Loads a saved Keras model with a Horovod DistributedOptimizer.
 

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -168,9 +168,8 @@ class _SyncBatchNorm(Function):
 
             if _SYNC_BN_V4:
                 # from 1.9.0 on we need a count tensor on all devices
-                count_all_handle = allreduce_async(count_all, op=Sum, name='sync_batch_norm.count_all')
-                count_all = synchronize(count_all_handle)
-                count_all = count_all.view(-1).int().to(grad_output.device)
+                # count_all is calculated as total count across all ranks in forward function
+                count_all = count_all.to(dtype=torch.int, device=grad_output.device)
             elif _SYNC_BN_V2 or _SYNC_BN_V3:
                 # before 1.9.0 we need the count as an integer to compute means values
                 count = count_all.sum()

--- a/horovod/torch/sync_batch_norm.py
+++ b/horovod/torch/sync_batch_norm.py
@@ -34,6 +34,7 @@ _SYNC_BN_V2 = (
     LooseVersion(torch.__version__) <= LooseVersion('1.6.0')
 )
 _SYNC_BN_V3 = LooseVersion(torch.__version__) >= LooseVersion('1.6.0')
+_SYNC_BN_V4 = LooseVersion(torch.__version__) >= LooseVersion('1.9.0')
 
 
 class SyncBatchNorm(_BatchNorm):
@@ -165,26 +166,45 @@ class _SyncBatchNorm(Function):
             sum_dy = synchronize(sum_dy_handle)
             sum_dy_xmu = synchronize(sum_dy_xmu_handle)
 
-            if _SYNC_BN_V2 or _SYNC_BN_V3:
-                count_all_sum = count_all.sum()
-                mean_dy = sum_dy / count_all_sum
-                mean_dy_xmu = sum_dy_xmu / count_all_sum
+            if _SYNC_BN_V4:
+                # from 1.9.0 on we need a count tensor on all devices
+                count_all_handle = allreduce_async(count_all, op=Sum, name='sync_batch_norm.count_all')
+                count_all = synchronize(count_all_handle)
+                count_all = count_all.view(-1).int().to(grad_output.device)
+            elif _SYNC_BN_V2 or _SYNC_BN_V3:
+                # before 1.9.0 we need the count as an integer to compute means values
+                count = count_all.sum()
             else:
                 # before 1.5.0, sum_dy was sum of means from every worker, so we just 
                 # need to divide it by number of workers
-                mean_dy = sum_dy / size()
-                mean_dy_xmu = sum_dy_xmu / size()
+                count = size()
 
             # backward pass for gradient calculation
-            grad_input = torch.batch_norm_backward_elemt(
-                grad_output,
-                saved_input,
-                mean,
-                invstd,
-                weight,
-                mean_dy,
-                mean_dy_xmu
-            )
+            # we are calling into a non-public undocumented function which broke moving to 1.9.0
+            # https://github.com/pytorch/pytorch/issues/57900
+            if _SYNC_BN_V4:
+                # from 1.9.0 on, sums and count parameters expected
+                grad_input = torch.batch_norm_backward_elemt(
+                    grad_output,
+                    saved_input,
+                    mean,
+                    invstd,
+                    weight,
+                    sum_dy,
+                    sum_dy_xmu,
+                    count_all
+                )
+            else:
+                # before 1.9.0, mean parameters expected, not sums and count
+                grad_input = torch.batch_norm_backward_elemt(
+                    grad_output,
+                    saved_input,
+                    mean,
+                    invstd,
+                    weight,
+                    sum_dy / count,
+                    sum_dy_xmu / count
+                )
         else:
             grad_input = None
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8', 'pyarrow>=0.15.0']
+spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8,<0.11.0', 'pyarrow>=0.15.0']
 ray_require_list = ['ray']
 pytorch_spark_require_list = pytorch_require_list + \
                              spark_require_list + \

--- a/test/integration/test_elastic_torch.py
+++ b/test/integration/test_elastic_torch.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 
-import mock
 import os
 import unittest
 import warnings
+
+import mock
 
 from elastic_common import BaseElasticTests
 
@@ -37,3 +38,13 @@ class ElasticTorchTests(BaseElasticTests, unittest.TestCase):
     @mock.patch('horovod.runner.gloo_run._get_min_start_hosts', return_value=1)
     def test_min_hosts_timeout(self, mock_get_min_start_hosts):
         self.skipTest('This test fails due to https://github.com/horovod/horovod/issues/2030')
+
+    @mock.patch('horovod.runner.elastic.driver.DISCOVER_HOSTS_FREQUENCY_SECS', 0.01)
+    @mock.patch('horovod.runner.gloo_run._get_min_start_hosts', return_value=1)
+    def test_fault_tolerance_without_scaling(self, mock_get_min_start_hosts):
+        self.skipTest('This test fails due to https://github.com/horovod/horovod/issues/2908')
+
+    @mock.patch('horovod.runner.elastic.driver.DISCOVER_HOSTS_FREQUENCY_SECS', 0.01)
+    @mock.patch('horovod.runner.gloo_run._get_min_start_hosts', return_value=1)
+    def test_single_rank_failure(self, mock_get_min_start_hosts):
+        self.skipTest('This test fails due to https://github.com/horovod/horovod/issues/2908')


### PR DESCRIPTION
In #2730 we have pinned torch nightly, this un-pins it by adjusting for upstream changed.

* The API of `torch.batch_norm_backward_elemt` changes in 1.9.0.

Unrelated changes but fixed in this PR:
* Some package imports broke readthedocs build in master.
* Latest petastorm version (0.11.0) breaks `BatchedDataLoader` constructor break master, so limiting to `petastorm<0.11.0` (#2909).

Not handled in this PR:
* Elastic torch tests started to fail on all torch versions across CPU and GPU on an uncaught GLOO IO Exception (#2908)