### PR TITLE
TorchEstimator: add phase into stdout

### DIFF
--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -304,8 +304,9 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                     def print_metrics(batch_idx, loss, metric_value_groups, phase):
                         if user_verbose > 0 and hvd.rank() == 0 and \
                                 batch_idx % METRIC_PRINT_FREQUENCY == 0:
-                            print("epoch:\t{epoch}\tstep\t{batch_idx}:\t{metrics}".
-                                  format(epoch=epoch,
+                            print("{phase}\tepoch:\t{epoch}\tstep\t{batch_idx}:\t{metrics}".
+                                  format(phase=phase,
+                                         epoch=epoch,
                                          batch_idx=batch_idx,
                                          metrics=aggregate_metrics(phase, epoch, loss,
                                                                    metric_value_groups)))


### PR DESCRIPTION
Sometime we got the below kind of stdout and it is confusing:
Wed Apr 21 08:06:33 2021[1,0]<stdout>:epoch:	39	step	6500:	{'loss': 31255.2109375, 'all_metrics': []}
Wed Apr 21 08:06:37 2021[1,0]<stdout>:epoch:	39	step	0:	{'loss': 27432.6484375, 'all_metrics': []}

The first line is training and the second line is validation.

Adding phase str into stdout to make it more clear.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
