### PR TITLE
Skip TensorFlowTests::test_horovod_allreduce_multi_gpu if there are less than 2 GPUs per worker

### DIFF
--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -471,17 +471,18 @@ class TensorFlowTests(tf.test.TestCase):
         if not tf.test.is_gpu_available(cuda_only=True):
             self.skipTest(("No GPUs available"))
 
+        hvd.init()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+        local_size = hvd.local_size()
+
         # Only do this test if there are enough GPUs available.
-        if len(tf.config.experimental.list_physical_devices('GPU')) < 2:
-            self.skipTest(("Too few GPUs available"))
+        if len(tf.config.experimental.list_physical_devices('GPU')) < 2 * local_size:
+            self.skipTest("Too few GPUs available")
 
         if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
             self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
-
-        hvd.init()
-        local_rank = hvd.local_rank()
-        size = hvd.size()
 
         iter = 0
         gpu_ids = [local_rank * 2, local_rank * 2 + 1]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

The test requires at least four GPUs if it is run with two workers. Sometimes one of the Buildkite CI jobs seem to be run with only three active GPUs although four GPUs were requested. This causes quite confusing failure messages "ncclCommInitRank failed: invalid usage" if this test is not skipped. Example: https://github.com/horovod/horovod/pull/2839/checks?check_run_id=2402052960