### PR TITLE
Revert "Add support for custom LearningRateSchedule for TF2 (#2706)"

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -157,14 +157,8 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
     cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
                dict(_DistributedOptimizer.__dict__))
 
-    config = optimizer.get_config()
-    if not _PRE_TF_2_4_0 and issubclass(optimizer.lr.__class__,
-                                        keras.optimizers.schedules.LearningRateSchedule):
-        lr_cls = type(optimizer.lr.__class__.__name__, (optimizer.lr.__class__,),
-                      dict(optimizer.lr.__dict__))
-        config['learning_rate'] = lr_cls.from_config(config['learning_rate']['config'])
+    return cls.from_config(optimizer.get_config())
 
-    return cls.from_config(config)
 
 def _eval(backend, op_or_result):
     if hvd._executing_eagerly():


### PR DESCRIPTION
This reverts commit b1ae83a611d6005c705d73faf73aa0628d8c2a61.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).
This is to revert one of my previous PR. I realized the correct way to use the custom LR + HVD should be using this keras decorator: https://www.tensorflow.org/api_docs/python/tf/keras/utils/register_keras_serializable.

So, users should apply the above decorator to their LR subclass before applying HVD. Also, the original PR might expose the issue when the custom LR is a nested LR class.

cc. @nluehr @DEKHTIARJonathan @romerojosh 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
