### PR TITLE
Require setting HOROVOD_TIMELINE=DYNAMIC to enable dynamic timeline API usage

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -96,7 +96,7 @@ class HorovodBasics(object):
         Raises a `ValueError` if Horovod is not initialized.
         """
         result = self.MPI_LIB_CTYPES.horovod_stop_timeline()
-        if not result:
+        if result == -1:
             raise ValueError('Horovod has not been initialized; use hvd.init().')
 
     def size(self):

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -85,8 +85,10 @@ class HorovodBasics(object):
         result = self.MPI_LIB_CTYPES.horovod_start_timeline(
             ctypes.c_char_p(file_path.encode('utf-8')),
             ctypes.c_bool(mark_cycles))
-        if not result:
+        if result == -1:
             raise ValueError('Horovod has not been initialized; use hvd.init().')
+        elif result == -2:
+            raise ValueError('Set HOROVOD_TIMELINE=DYNAMIC to enable dynamic timeline usage.');
 
     def stop_timeline(self):
         """Stops the active timeline recording and closes the file.

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -985,7 +985,7 @@ void Controller::SynchronizeTimelineEnabled() {
   timeline_enabled_ = timeline_enabled_pending_;
 }
 
-bool Controller::TimeLineEnabled() {
+bool Controller::TimelineEnabled() {
   std::lock_guard<std::recursive_mutex> guard(timeline_mutex_);
   return timeline_enabled_;
 }

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -127,7 +127,7 @@ public:
   bool IsCoordinator() const { return is_coordinator_; };
   bool IsHomogeneous() const { return is_homogeneous_; };
   void SetTimelineEnabled(bool value);
-  bool TimeLineEnabled();
+  bool TimelineEnabled();
   void SetTimelineEnabledPending(bool value);
   bool TimelineEnabledPending();
   void SetMarkCyclesInTimelinePending(bool value);

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -47,6 +47,8 @@ ccl_supported_types = set([torch.ByteTensor, torch.CharTensor, torch.ShortTensor
                            torch.IntTensor, torch.LongTensor, torch.FloatTensor,
                            torch.DoubleTensor])
 
+# Set environment variable for dynamic timeline API test
+os.environ["HOROVOD_TIMELINE"] = "DYNAMIC"
 
 class TorchTests(unittest.TestCase):
     """
@@ -2296,7 +2298,7 @@ class TorchTests(unittest.TestCase):
             assert torch.allclose(hvd.allreduce(sync_bn.bias.grad, name='sync_bn.bias.grad'), bn.bias.grad, 1e-6)
             assert torch.allclose(hvd.allreduce(ts1.grad, name='ts1.grad'), ts2.grad, 1e-6)
 
-    @pytest.mark.skip(reason='https://github.com/horovod/horovod/issues/2496')
+    @pytest.mark.skipif(platform.system() == 'Darwin', reason='https://github.com/horovod/horovod/issues/2496')
     def test_timeline_api(self):
         hvd.init()
 


### PR DESCRIPTION
## Description
Fixes #2804. 

PR #2215 changed the Horovod initialization code to initialize the timeline unconditionally, rather than only in cases where the user sets `HOROVOD_TIMELINE`. This is a problem because the timeline spawns an additional writer thread that can consume CPU resources. Additionally, there are still places in the code that check whether the timeline is initialized in order to skip unnecessary operations, for example this code block here:
https://github.com/horovod/horovod/blob/2436af9d1c0681090919e314e0cfbd9bc13d7a53/horovod/common/ops/nccl_operations.cc#L165-L167
Since that PR, these branches/operations are executed every time, whether or not a user is using the timeline functionality. 

Another place this occurs is in the response cache coordination logic, where additional bits to communicate information only relevant to the timeline are communicated all the time now, due to `timeline_enabled` being set to true (unless `HOROVOD_TIMELINE=DISABLE`): https://github.com/horovod/horovod/blob/2436af9d1c0681090919e314e0cfbd9bc13d7a53/horovod/common/response_cache.cc#L356-L360
  
This PR fixes this by reverting to the original behavior where the timeline is initialized during Horovod initialization only if `HOROVOD_TIMELINE` is set. For the dynamic timeline API, users can set `HOROVOD_TIMELINE=DYNAMIC` to initialize the timeline for that API to work. 

While the existing implementation has an option to set `HOROVOD_TIMELINE=DISABLE`, this option does not keep the timeline from initializing. Also, given the performance implications and that more users are more often not using the timeline or dynamic timeline API, I think it is better for this feature to be an opt-in, rather than opt-out as it currently is.

I also went ahead and reenabled the `test_timeline_api` test to make sure this change doesn't break the dynamic timeline functionality. It was fully disabled in #2495 due to #2496, but I've limited the skip only to systems running macOS. 