### PR TITLE
Support sparse gradients and respect `global_step` parameter in gradient aggregation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Changed RayExecutor to use Ray node ID to enable multi-container:single-host setups. ([#2883](https://github.com/horovod/horovod/pull/2882))
+- Support sparse gradients aggregation in TF1 Keras. ([#2879](https://github.com/horovod/horovod/pull/2879))
+- Respect `global_step` parameter for LegacyOptimizers when aggregating gradients.  ([#2879](https://github.com/horovod/horovod/pull/2879))
 
 ## [v0.21.3] - 2021-02-15
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -475,17 +475,19 @@ if _LegacyOptimizer is not None:
                 avg_grads = self._allreduce_grads(grads, vars)
             return list(zip(avg_grads, vars))
 
-        def apply_gradients(self, *args, **kwargs):
+        def apply_gradients(self, grads_and_vars, global_step=None, name=None):
             """Calls this same method on the underlying optimizer."""
             if self._agg_helper:
                 return self._agg_helper.apply_gradients(
-                    lambda: self._optimizer.apply_gradients(*args, **kwargs),
+                    lambda: self._optimizer.apply_gradients(
+                        grads_and_vars, global_step=global_step, name=name),
                     self._optimizer,
-                    *args,
-                    **kwargs,
+                    grads_and_vars,
+                    global_step=global_step,
+                    name=name,
                 )
-
-            return self._optimizer.apply_gradients(*args, **kwargs)
+            return self._optimizer.apply_gradients(
+                grads_and_vars, global_step=global_step, name=name)
 
         def get_slot(self, *args, **kwargs):
             """Calls this same method on the underlying optimizer."""

--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -146,7 +146,7 @@ class LocalGradientAggregationHelper:
 
         return aggregation_ops_list
 
-    def _allreduce_grads_helper(self, grads, vars):
+    def _allreduce_grads_helper(self, vars):
         # Read in latest variables values.
         aggregated_grads = []
         aggregation_read_ops_list = []
@@ -210,7 +210,7 @@ class LocalGradientAggregationHelper:
             # the counter back to 0.
             allreduced_grads = tf.cond(
                 tf.equal(self.counter, self.backward_passes_per_step),
-                lambda: self._allreduce_grads_helper(grads, vars),
+                lambda: self._allreduce_grads_helper(vars),
                 lambda: [self._maybe_convert_grad(g) for g in grads]
             )
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? _no docs changes_
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

- Fixes #2806
- Support sparse gradients aggregation in TF1 Keras.
- Respect `global_step` parameter for LegacyOptimizers when aggregating gradients. Previously, we'd always increment default tf `global_step`, but tensorflow allows users to pass custom `global_step` variables, and we should respect and support this behavior.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
