### PR TITLE
Estimator: set num_epochs of petastorm reader as 1

### DIFF
--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -212,7 +212,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
             # and enables ranks to perform training and validation with
             # unequal number of samples
             with reader_factory(remote_store.train_data_path,
-                                num_epochs=None,
+                                num_epochs=1,
                                 cur_shard=hvd.rank(),
                                 reader_pool_type='process',
                                 workers_count=train_reader_worker_count,
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                                 transform_spec=transform_spec,
                                 **reader_factory_kwargs) as train_reader:
                 with reader_factory(remote_store.val_data_path,
-                                    num_epochs=None,
+                                    num_epochs=1,
                                     cur_shard=hvd.rank(),
                                     reader_pool_type='process',
                                     workers_count=val_reader_worker_count,

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -221,7 +221,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
             # and enables ranks to perform training and validation with
             # unequal number of samples
             with reader_factory(remote_store.train_data_path,
-                                num_epochs=1 if inmemory_cache_all else None,
+                                num_epochs=1,
                                 cur_shard=hvd.rank(),
                                 reader_pool_type='process',
                                 workers_count=train_reader_worker_count,
@@ -231,7 +231,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                 transform_spec=transform_spec,
                                 **reader_factory_kwargs) as train_reader:
                 with reader_factory(remote_store.val_data_path,
-                                    num_epochs=1 if inmemory_cache_all else None,
+                                    num_epochs=1,
                                     cur_shard=hvd.rank(),
                                     reader_pool_type='process',
                                     workers_count=val_reader_worker_count,


### PR DESCRIPTION
Setting num_epoch > 1 in petastorm reader, will introduce replicas
when reaching to the tail of data. Training and validation stages
prefer non-duplicated data to avoid overfitting.

Set num_epochs = 1 in petastorm reader to resolve above issues.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
