### PR TITLE
Keras estimator: set reader's epoch = 1 to avoid sample duplication and drop-out in a single epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Supports Ray Client without code changes. ([#2882](https://github.com/horovod/horovod/pull/2882))
 
+- Supports inmemory cache option for Keras Estimator. ([#2896](https://github.com/horovod/horovod/pull/2896))
+
 ### Changed
 
 - Changed `alltoall` to return the received splits as a second return value if non-uniform splits are sent. ([#2631](https://github.com/horovod/horovod/pull/2631))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Changed `alltoall` to return the received splits as a second return value if non-uniform splits are sent. ([#2631](https://github.com/horovod/horovod/pull/2631))
 - Changed ``RayExecutor`` to use [Ray Placement Groups](https://docs.ray.io/en/master/placement-group.html) for worker colocation. ([#2824](https://github.com/horovod/horovod/pull/2824))
+- Changed ``Inmemory dataloader`` usage for Torch Estimator with petastorm v0.11.0 release. ([#2896](https://github.com/horovod/horovod/pull/2896))
 
 
 ### Deprecated

--- a/examples/spark/keras/keras_spark_mnist.py
+++ b/examples/spark/keras/keras_spark_mnist.py
@@ -114,6 +114,7 @@ if __name__ == '__main__':
                                          label_cols=['label_vec'],
                                          batch_size=args.batch_size,
                                          epochs=args.epochs,
+                                         inmemory_cache_all=True,
                                          verbose=1)
 
     keras_model = keras_estimator.fit(train_df).setOutputCols(['label_prob'])

--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -61,15 +61,27 @@ class TFKerasUtil(object):
             has_sparse_col, sample_weight_col, feature_columns,
             label_columns, input_shapes, label_shapes, output_names)
 
-        def fn(reader, batch_size, shuffle_buffer_size, is_batch_reader, shuffle=False):
+        def fn(reader, batch_size, shuffle_buffer_size, is_batch_reader, shuffle=False, cache=False):
             from petastorm.tf_utils import make_petastorm_dataset
 
             dataset = make_petastorm_dataset(reader)
             if is_batch_reader:
                 dataset = dataset.apply(tf.data.experimental.unbatch())
 
+            # Apply cache() before shuffle, so we can reshuffle in each iteration.
+            if cache:
+                dataset = dataset.cache()
+
             if shuffle:
                 dataset = dataset.shuffle(shuffle_buffer_size)
+
+            # Use tf.data.Dataset.repeat() to set up an infinite iterator
+            # and to enable ranks to perform training and validation with
+            # unequal number of samples.
+            # FIXME(chongxiaoc): Use a very large number (10^9) for enough loops.
+            # None and -1 are not working with petastorm dataset for repeating.
+            # Verify this parameter again in future with new TF and Petastorm versions.
+            dataset = dataset.repeat(1000000000)
 
             # Decompress sparse data if necessary
             if has_sparse_col:
@@ -220,13 +232,14 @@ class BareKerasUtil(object):
 
     @staticmethod
     def make_dataset_fn(feature_columns, label_columns, sample_weight_col, metadata,
-                        input_shapes, label_shapes, output_names, batch_size):
+                        input_shapes, label_shapes, output_names):
         batch_generator = BareKerasUtil._batch_generator_fn(
             feature_columns, label_columns, sample_weight_col,
-            input_shapes, label_shapes, batch_size, metadata)
+            input_shapes, label_shapes, metadata)
 
-        def fn(reader, shuffle_buffer_size, shuffle=False):
-            return batch_generator(reader, shuffle_buffer_size, shuffle)
+        def fn(reader, batch_size, shuffle_buffer_size, is_batch_reader, shuffle=False, cache=inmemory_cache_all):
+            # is_batch_reader and cache are not used for BareKerasUtil.
+            return batch_generator(reader, batch_size, shuffle_buffer_size, shuffle)
 
         return fn
 
@@ -282,21 +295,25 @@ class BareKerasUtil(object):
 
     @staticmethod
     def _batch_generator_fn(feature_columns, label_columns, sample_weight_col,
-                            input_shapes, label_shapes, batch_size, metadata):
+                            input_shapes, label_shapes, metadata):
         prepare_data_bare_keras = BareKerasUtil._prepare_data_fn(metadata)
 
         cols = feature_columns + label_columns
         if sample_weight_col:
             cols.append(sample_weight_col)
 
-        def batch_generator(reader, shuffle_buffer_size, shuffle=False):
+        def batch_generator(reader, batch_size, shuffle_buffer_size, shuffle=False):
             while True:
                 num_rows_read_sofar = 0
                 data = None
+                # Create iterator from reader to start a new iteration from beginning.
+                reader_iter = iter(reader)
                 while num_rows_read_sofar < shuffle_buffer_size:
-                    # Each call to next reads one row group at a time. reader is an infinite
-                    # generator and never ends
-                    row_group_data = next(reader)
+                    # Each call to next reads one row group at a time.
+                    row_group_data = next(reader_iter, None)
+                    if row_group_data is None:
+                        # No data left in reader, stop filling.
+                        break
                     if not data:
                         data = {col: getattr(row_group_data, col) for col in cols}
                     else:

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -244,7 +244,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                     if should_validate else empty_batch_reader() as val_reader:
 
                     if inmemory_cache_all:
-                        # Petastorm introduced InMemBatchedDataLoader class in v0.11.0rc6
+                        # Petastorm introduced InMemBatchedDataLoader class in v0.11.0
                         train_loader = InMemBatchedDataLoader(train_reader,
                                                               batch_size=batch_size,
                                                               num_epochs=epochs,
@@ -343,7 +343,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                             validation_steps = validation_steps_per_epoch
 
                         if inmemory_cache_all:
-                            # Petastorm introduced InMemBatchedDataLoader class in v0.11.0rc6
+                            # Petastorm introduced InMemBatchedDataLoader class in v0.11.0
                             val_loader = InMemBatchedDataLoader(val_reader,
                                                                 batch_size=val_batch_sze,
                                                                 num_epochs=epochs,

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -99,7 +99,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
     def train(serialized_model, optimizer_cls, model_opt_state_serialized,
               train_rows, val_rows, avg_row_size):
         from petastorm import TransformSpec, make_reader, make_batch_reader
-        from petastorm.pytorch import BatchedDataLoader
+        from petastorm.pytorch import BatchedDataLoader, InMemBatchedDataLoader
         import torch
         import horovod.torch as hvd
 
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
             # and enables ranks to perform training and validation with
             # unequal number of samples
             with reader_factory(remote_store.train_data_path,
-                                num_epochs=1 if inmemory_cache_all else None,
+                                num_epochs=None,
                                 cur_shard=hvd.rank(),
                                 reader_pool_type=reader_pool_type,
                                 workers_count=train_reader_worker_count,
@@ -232,7 +232,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                 transform_spec=transform_spec,
                                 **reader_factory_kwargs) as train_reader:
                 with reader_factory(remote_store.val_data_path,
-                                    num_epochs=1 if inmemory_cache_all else None,
+                                    num_epochs=None,
                                     cur_shard=hvd.rank(),
                                     reader_pool_type=reader_pool_type,
                                     workers_count=val_reader_worker_count,
@@ -243,12 +243,17 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                     **reader_factory_kwargs) \
                     if should_validate else empty_batch_reader() as val_reader:
 
-                    # requires petastorm<0.11.0
-                    train_loader = BatchedDataLoader(train_reader,
-                                                     num_epochs=epochs if inmemory_cache_all else None,
-                                                     batch_size=batch_size,
-                                                     shuffling_queue_capacity=shuffle_buffer_size,
-                                                     inmemory_cache_all=inmemory_cache_all)
+                    if inmemory_cache_all:
+                        # Petastorm introduced InMemBatchedDataLoader class in v0.11.0rc6
+                        train_loader = InMemBatchedDataLoader(train_reader,
+                                                              batch_size=batch_size,
+                                                              num_epochs=epochs,
+                                                              rows_capacity=steps_per_epoch*batch_size,
+                                                              shuffle=True)
+                    else:
+                        train_loader = BatchedDataLoader(train_reader,
+                                                         batch_size=batch_size,
+                                                         shuffling_queue_capacity=shuffle_buffer_size)
                     train_loader_iter = iter(train_loader)
 
                     def prepare_batch(row):
@@ -332,17 +337,23 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                         return aggregate_metrics('train', epoch, train_loss, metric_value_groups)
 
                     if should_validate:
-                        # requires petastorm<0.11.0
-                        val_loader = BatchedDataLoader(val_reader,
-                                                       num_epochs=epochs if inmemory_cache_all else None,
-                                                       batch_size=batch_size,
-                                                       inmemory_cache_all=inmemory_cache_all)
-                        val_loader_iter = iter(val_loader)
-
                         if validation_steps_per_epoch is None:
                             validation_steps = int(math.ceil(float(val_rows) / val_batch_size / hvd.size()))
                         else:
                             validation_steps = validation_steps_per_epoch
+
+                        if inmemory_cache_all:
+                            # Petastorm introduced InMemBatchedDataLoader class in v0.11.0rc6
+                            val_loader = InMemBatchedDataLoader(val_reader,
+                                                                batch_size=val_batch_sze,
+                                                                num_epochs=epochs,
+                                                                rows_capacity=validation_steps_per_epoch*val_batch_size,
+                                                                shuffle=False)
+                        else:
+                            val_loader = BatchedDataLoader(val_reader,
+                                                           batch_size=val_batch_size,
+                                                           shuffling_queue_capacity=0)
+                        val_loader_iter = iter(val_loader)
 
                         def _validate(epoch):
                             model.eval()

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm==0.11.0rc6', 'pyarrow>=0.15.0']
+spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.11.0', 'pyarrow>=0.15.0']
 ray_require_list = ['ray']
 pytorch_spark_require_list = pytorch_require_list + \
                              spark_require_list + \

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
 # Pin h5py: https://github.com/h5py/h5py/issues/1732
-spark_require_list = ['h5py<3', 'numpy', 'petastorm>=0.9.8,<0.11.0', 'pyarrow>=0.15.0']
+spark_require_list = ['h5py<3', 'numpy', 'petastorm==0.11.0rc6', 'pyarrow>=0.15.0']
 ray_require_list = ['ray']
 pytorch_spark_require_list = pytorch_require_list + \
                              spark_require_list + \


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
We set infinite epochs for petastorm reader in horovod, due to the known issue that data partition is not guarantee to be equivalent size. TF's dataset shuffle function will automatically refill the shuffle buffer after retrieving a single element.
Code in horovod:
```
            if shuffle:
                dataset = dataset.shuffle(shuffle_buffer_size)
```
Mixing infinite iterations from reader and TF's shuffle function, will introduce sample duplication and drop-out in a single epoch. For example, training dataset is [`0,1,2,3,4,5,6,7]`, and shuffle size is 8.
Shuffling buffer is initialized as `[0,1,2,3,4,5,6,7]`
It randomly pick 7, and refill with 0 again: `[0,1,2,3,4,5,6,0]`
Now it is highly possible 0 will be selected twice in next few iterations, even before other values are selected once.

This PR fixes above issue by setting reader's epoch to be 1, while looping infinitely inside dataloader.
Also we introduced cache() support from `tf.data.Dataset` since it speeds up throughput.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
