### PR TITLE
TorchEstimator: use validation_steps instead of validation_steps_per_…

### DIFF
--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -347,7 +347,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                             val_loader = InMemBatchedDataLoader(val_reader,
                                                                 batch_size=val_batch_size,
                                                                 num_epochs=epochs,
-                                                                rows_capacity=validation_steps_per_epoch*val_batch_size,
+                                                                rows_capacity=validation_steps*val_batch_size,
                                                                 shuffle=False)
                         else:
                             val_loader = BatchedDataLoader(val_reader,


### PR DESCRIPTION
…epoch

validation_steps_per_epoch could be None if user doesn't specify.
Also modify unit test to cover val dataloader cases.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
