### PR TITLE
test: fixing flaky estimator test using val dataloader

### DIFF
--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -39,7 +39,7 @@ from horovod.spark.keras.util import _custom_sparse_to_dense_fn, _serialize_para
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import temppath
-from spark_common import CallbackBackend, create_mnist_data, create_xor_data, local_store, spark_session
+from spark_common import CallbackBackend, create_mnist_data, create_xor_data, create_xor_data_with_val, local_store, spark_session
 
 
 def create_xor_model():
@@ -197,7 +197,7 @@ class SparkKerasTests(tf.test.TestCase):
         mock_pin_gpu_fn.return_value = mock.Mock()
 
         with spark_session('test_keras_direct_parquet_train') as spark:
-            df = create_xor_data(spark)
+            df = create_xor_data_with_val(spark)
 
             backend = CallbackBackend()
             with local_store() as store:
@@ -205,7 +205,7 @@ class SparkKerasTests(tf.test.TestCase):
                 store.get_val_data_path = lambda v=None: store._val_path
 
                 # Make sure we cover val dataloader cases
-                for validation in [0.0, 0.5]:
+                for validation in [None, 'val']:
                     with util.prepare_data(backend.num_processes(),
                                            store,
                                            df,

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -52,7 +52,7 @@ from horovod.spark.common import constants, util
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import tempdir, spawn, is_built
-from spark_common import CallbackBackend, create_noisy_xor_data, create_xor_data, local_store, spark_session
+from spark_common import CallbackBackend, create_noisy_xor_data, create_noisy_xor_data_with_val, create_xor_data, local_store, spark_session
 
 
 class XOR(pl.LightningModule):
@@ -355,7 +355,7 @@ class SparkLightningTests(unittest.TestCase):
 
     def test_direct_parquet_train(self):
         with spark_session('test_direct_parquet_train') as spark:
-            df = create_noisy_xor_data(spark)
+            df = create_noisy_xor_data_with_val(spark)
 
             backend = CallbackBackend()
             with local_store() as store:
@@ -363,7 +363,7 @@ class SparkLightningTests(unittest.TestCase):
                 store.get_val_data_path = lambda v=None: store._val_path
 
                 # Make sure to cover val dataloader cases
-                for validation in [0.0, 0.5]:
+                for validation in [None, 'val']:
                     with util.prepare_data(backend.num_processes(),
                                            store,
                                            df,

--- a/test/integration/test_spark_torch.py
+++ b/test/integration/test_spark_torch.py
@@ -42,7 +42,7 @@ from horovod.torch.elastic import run
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 from common import tempdir, spawn, is_built
-from spark_common import CallbackBackend, create_xor_data, local_store, spark_session
+from spark_common import CallbackBackend, create_xor_data, create_xor_data_with_val, local_store, spark_session
 
 
 class XOR(nn.Module):
@@ -336,7 +336,7 @@ class SparkTorchTests(unittest.TestCase):
 
     def test_torch_direct_parquet_train(self):
         with spark_session('test_torch_direct_parquet_train') as spark:
-            df = create_xor_data(spark)
+            df = create_xor_data_with_val(spark)
 
             backend = CallbackBackend()
             with local_store() as store:
@@ -344,7 +344,7 @@ class SparkTorchTests(unittest.TestCase):
                 store.get_val_data_path = lambda v=None: store._val_path
 
                 # Make sure we cover validation dataloader as well
-                for validation in [0.0, 0.5]:
+                for validation in [None, 'val']:
                     # Need validation ratio to split data
                     with util.prepare_data(backend.num_processes(),
                                            store,

--- a/test/utils/spark_common.py
+++ b/test/utils/spark_common.py
@@ -162,6 +162,19 @@ def create_xor_data(spark):
     return df
 
 
+def create_xor_data_with_val(spark):
+    data = [[0, 0, 0.0, 0.1, 1], [0, 1, 1.0, 0.2, 0], [1, 0, 1.0, 0.3, 1], [1, 1, 0.0, 0.4, 0],
+            [0, 0, 0.0, 0.1, 1], [0, 1, 1.0, 0.2, 0], [1, 0, 1.0, 0.3, 1], [1, 1, 0.0, 0.4, 0]]
+    schema = StructType([StructField('x1', IntegerType()),
+                         StructField('x2', IntegerType()),
+                         StructField('y', FloatType()),
+                         StructField('weight', FloatType()),
+                         StructField('val', IntegerType())])
+    raw_df = create_test_data_from_schema(spark, data, schema)
+    df = with_features(raw_df, ['x1', 'x2'])
+    return df
+
+
 def create_noisy_xor_data(spark):
     schema = StructType([StructField('x1', FloatType()),
                          StructField('x2', FloatType()),
@@ -177,6 +190,28 @@ def create_noisy_xor_data(spark):
         original = data[i % len(data)]
         sample = original[0:2] + eps
         samples.append(sample.tolist() + [original[2]] + [float(weights[i])])
+
+    raw_df = create_test_data_from_schema(spark, samples, schema)
+    df = with_features(raw_df, ['x1', 'x2'])
+    return df
+
+
+def create_noisy_xor_data_with_val(spark):
+    schema = StructType([StructField('x1', FloatType()),
+                         StructField('x2', FloatType()),
+                         StructField('y', FloatType()),
+                         StructField('weight', FloatType()),
+                         StructField('val', IntegerType())])
+    data = [[0.0, 0.0, 0.0, 0], [0.0, 1.0, 1.0, 1], [1.0, 0.0, 1.0, 0], [1.0, 1.0, 0.0, 1]]
+    n = 1024
+    weights = np.random.uniform(0, 1, n)
+
+    samples = []
+    noise = np.random.normal(0, 0.1, [n, 2])
+    for i, eps in enumerate(noise):
+        original = data[i % len(data)]
+        sample = original[0:2] + eps
+        samples.append(sample.tolist() + [original[2]] + [float(weights[i])] + [original[3]])
 
     raw_df = create_test_data_from_schema(spark, samples, schema)
     df = with_features(raw_df, ['x1', 'x2'])


### PR DESCRIPTION
Use deterministic val dataframe, instead of split ratio.
Spark may split out unbalanced/empty dataframe since unittest data is
small.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
