### PR TITLE
Fixed CPU docker images and added additional sanity checks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: c5.large
+          ec2-instance-type: r5.large
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: c5.9xlarge
+          ec2-instance-type: c5.large
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: c5.9xlarge
+          ec2-instance-type: r5.large
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
       - name: Start EC2 runner (horovod-cpu)
@@ -50,7 +50,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: c5.9xlarge
+          ec2-instance-type: r5.large
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
       - name: Start EC2 runner (horovod-ray)

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -77,7 +77,10 @@ RUN pip install --no-cache-dir ${PYSPARK_PACKAGE}
 WORKDIR /horovod
 COPY . .
 RUN python setup.py sdist && \
-    bash -c "HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[all-frameworks]" && \
-    horovodrun --check-build
+    bash -c "HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray]" && \
+    horovodrun --check-build && \
+    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()" && \
+    python -c "import horovod.mxnet as hvd; hvd.init()"
 
 WORKDIR "/horovod/examples"

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -78,9 +78,10 @@ WORKDIR /horovod
 COPY . .
 RUN python setup.py sdist && \
     bash -c "HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray]" && \
-    horovodrun --check-build && \
-    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    horovodrun --check-build
+
+# Check all frameworks are working correctly
+WORKDIR "/horovod/examples"
+RUN python -c "import horovod.tensorflow as hvd; hvd.init()" && \
     python -c "import horovod.torch as hvd; hvd.init()" && \
     python -c "import horovod.mxnet as hvd; hvd.init()"
-
-WORKDIR "/horovod/examples"

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -47,7 +47,10 @@ RUN python setup.py sdist && \
     horovodrun --check-build && \
     sudo ldconfig
 
-# Check all frameworks are working correctly
+# Check all frameworks are working correctly. Use CUDA stubs to ensure CUDA libs can be found correctly
+# when running on CPU machine
 WORKDIR "/horovod/examples"
-RUN python -c "import horovod.tensorflow as hvd; hvd.init()" && \
-    python -c "import horovod.torch as hvd; hvd.init()"
+RUN sudo ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
+    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()" && \
+    sudo ldconfig

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -45,6 +45,8 @@ RUN python setup.py sdist && \
     sudo ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[ray] && \
     horovodrun --check-build && \
+    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()" && \
     sudo ldconfig
 
 WORKDIR "/horovod/examples"

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -45,8 +45,9 @@ RUN python setup.py sdist && \
     sudo ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[ray] && \
     horovodrun --check-build && \
-    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
-    python -c "import horovod.torch as hvd; hvd.init()" && \
     sudo ldconfig
 
+# Check all frameworks are working correctly
 WORKDIR "/horovod/examples"
+RUN python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()"

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -90,7 +90,7 @@ WORKDIR /horovod
 COPY . .
 RUN python setup.py sdist && \
     ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
-    bash -c "HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[all-frameworks]" && \
+    bash -c "HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray]" && \
     horovodrun --check-build && \
     ldconfig
 

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -94,8 +94,11 @@ RUN python setup.py sdist && \
     horovodrun --check-build && \
     ldconfig
 
-# Check all frameworks are working correctly
+# Check all frameworks are working correctly. Use CUDA stubs to ensure CUDA libs can be found correctly
+# when running on CPU machine
 WORKDIR "/horovod/examples"
-RUN python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
+    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
     python -c "import horovod.torch as hvd; hvd.init()" && \
-    python -c "import horovod.mxnet as hvd; hvd.init()"
+    python -c "import horovod.mxnet as hvd; hvd.init()" && \
+    ldconfig

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -92,6 +92,9 @@ RUN python setup.py sdist && \
     ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     bash -c "HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[all-frameworks]" && \
     horovodrun --check-build && \
+    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()" && \
+    python -c "import horovod.mxnet as hvd; hvd.init()" && \
     ldconfig
 
 WORKDIR "/horovod/examples"

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -92,9 +92,10 @@ RUN python setup.py sdist && \
     ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
     bash -c "HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[all-frameworks]" && \
     horovodrun --check-build && \
-    python -c "import horovod.tensorflow as hvd; hvd.init()" && \
-    python -c "import horovod.torch as hvd; hvd.init()" && \
-    python -c "import horovod.mxnet as hvd; hvd.init()" && \
     ldconfig
 
+# Check all frameworks are working correctly
 WORKDIR "/horovod/examples"
+RUN python -c "import horovod.tensorflow as hvd; hvd.init()" && \
+    python -c "import horovod.torch as hvd; hvd.init()" && \
+    python -c "import horovod.mxnet as hvd; hvd.init()"

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ pytorch_spark_require_list = pytorch_require_list + \
 
 # all frameworks' dependencies
 all_frameworks_require_list = tensorflow_require_list + \
-                              tensorflow_gpu_require_list + \
                               keras_require_list + \
                               pytorch_require_list + \
                               mxnet_require_list + \


### PR DESCRIPTION
Previously, using `all-framemworks` extras for CPU builds was resulting in both `tensorflow-cpu` and `tensorflow` being installed, which broke `horovod.tensorflow` imports.

Also changes EC2 instance used to build the image to a smaller, cheaper instance, as most of the build is single-threaded and does not need high amounts of CPU, memory, or network bandwidth.