### PR TITLE
Enforce a single concurrent run of docker workflow per branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [ master ]
 
+# we want an ongoing run of this workflow to be canceled by a later commit
+# so that there is only one concurrent run of this workflow for each branch
+concurrency:
+  group: docker-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner


### PR DESCRIPTION
Pushing a few commits to a branch kicks of the docker workflow for each of them, causing concurrent runs. Firstly, the earlier runs are redundant, secondly, a slow earlier run may overwrite (on master only) images published by a later run.

This enforces a single concurrent run of the docker workflow for each branch, which kills earlier runs.