### PR TITLE
Use matrix to start and stop EC2 instances

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,13 +19,20 @@ jobs:
   start-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-image: [horovod, horovod-cpu, horovod-ray]
+
     outputs:
-      label-horovod: ${{ steps.start-ec2-runner-horovod.outputs.label }}
-      label-horovod-cpu: ${{ steps.start-ec2-runner-horovod-cpu.outputs.label }}
-      label-horovod-ray: ${{ steps.start-ec2-runner-horovod-ray.outputs.label }}
-      ec2-instance-id-horovod: ${{ steps.start-ec2-runner-horovod.outputs.ec2-instance-id }}
-      ec2-instance-id-horovod-cpu: ${{ steps.start-ec2-runner-horovod-cpu.outputs.ec2-instance-id }}
-      ec2-instance-id-horovod-ray: ${{ steps.start-ec2-runner-horovod-ray.outputs.ec2-instance-id }}
+      label-horovod: ${{ steps.ec2-meta.outputs.label-horovod }}
+      label-horovod-cpu: ${{ steps.ec2-meta.outputs.label-horovod-cpu }}
+      label-horovod-ray: ${{ steps.ec2-meta.outputs.label-horovod-ray }}
+      ec2-instance-id-horovod: ${{ steps.ec2-meta.outputs.ec2-instance-id-horovod }}
+      ec2-instance-id-horovod-cpu: ${{ steps.ec2-meta.outputs.ec2-instance-id-horovod-cpu }}
+      ec2-instance-id-horovod-ray: ${{ steps.ec2-meta.outputs.ec2-instance-id-horovod-ray }}
+
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -33,8 +40,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Start EC2 runner (horovod)
-        id: start-ec2-runner-horovod
+
+      - name: Start EC2 runner (${{ matrix.docker-image }})
+        id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2.2.0
         with:
           mode: start
@@ -43,26 +51,12 @@ jobs:
           ec2-instance-type: r5.large
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
-      - name: Start EC2 runner (horovod-cpu)
-        id: start-ec2-runner-horovod-cpu
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: r5.large
-          subnet-id: subnet-0983be43
-          security-group-id: sg-4cba0d08
-      - name: Start EC2 runner (horovod-ray)
-        id: start-ec2-runner-horovod-ray
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: r5.large
-          subnet-id: subnet-0983be43
-          security-group-id: sg-4cba0d08
+
+      - name: EC2 instance meta
+        id: ec2-meta
+        run: |
+          echo "::set-output name=label-${{ matrix.docker-image }}::${{ steps.start-ec2-runner.outputs.label}}"
+          echo "::set-output name=ec2-instance-id-${{ matrix.docker-image }}::${{ steps.start-ec2-runner.outputs.ec2-instance-id}}"
 
   docker:
     if: github.repository_owner == 'horovod'
@@ -132,6 +126,21 @@ jobs:
       - docker # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: always() # required to stop the runner even if the error happened in the previous jobs
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker-image: horovod
+            lablel: ${{ needs.start-runner.outputs.label-horovod }}
+            ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod }}
+          - docker-image: horovod-cpu
+            lablel: ${{ needs.start-runner.outputs.label-horovod-cpu }}
+            ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-cpu }}
+          - docker-image: horovod-ray
+            lablel: ${{ needs.start-runner.outputs.label-horovod-ray }}
+            ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-ray }}
+
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -139,24 +148,11 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Stop EC2 runner (horovod)
+
+      - name: Stop EC2 runner (${{ matrix.docker-image }})
         uses: machulav/ec2-github-runner@v2.2.0
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label-horovod }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod }}
-      - name: Stop EC2 runner (horovod-cpu)
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label-horovod-cpu }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-cpu }}
-      - name: Stop EC2 runner (horovod-ray)
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label-horovod-ray }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-ray }}
+          label: ${{ matrix.label }}
+          ec2-instance-id: ${{ matrix.ec2-instance-id }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   start-runner:
-    name: Start self-hosted EC2 runner
+    name: Start self-hosted EC2 runner (${{ matrix.docker-image }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -52,13 +52,14 @@ jobs:
           subnet-id: subnet-0983be43
           security-group-id: sg-4cba0d08
 
-      - name: EC2 instance meta
+      - name: Get EC2 instance meta
         id: ec2-meta
         run: |
           echo "::set-output name=label-${{ matrix.docker-image }}::${{ steps.start-ec2-runner.outputs.label}}"
           echo "::set-output name=ec2-instance-id-${{ matrix.docker-image }}::${{ steps.start-ec2-runner.outputs.ec2-instance-id}}"
 
   docker:
+    name: Build docker image ${{ matrix.docker-image }} (push=${{ github.event_name != 'pull_request' }})
     if: github.repository_owner == 'horovod'
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ matrix.label }} # run the job on the newly created runners
@@ -72,7 +73,6 @@ jobs:
             label: ${{ needs.start-runner.outputs.label-horovod-cpu }}
           - docker-image: horovod-ray
             label: ${{ needs.start-runner.outputs.label-horovod-ray }}
-    name: docker ${{ matrix.docker-image }}
     steps:
       -
         name: Checkout
@@ -120,7 +120,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   stop-runner:
-    name: Stop self-hosted EC2 runner
+    name: Stop self-hosted EC2 runner (${{ matrix.docker-image }})
     needs:
       - start-runner # required to get output from the start-runner job
       - docker # required to wait when the main job is done
@@ -132,13 +132,13 @@ jobs:
       matrix:
         include:
           - docker-image: horovod
-            lablel: ${{ needs.start-runner.outputs.label-horovod }}
+            label: ${{ needs.start-runner.outputs.label-horovod }}
             ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod }}
           - docker-image: horovod-cpu
-            lablel: ${{ needs.start-runner.outputs.label-horovod-cpu }}
+            label: ${{ needs.start-runner.outputs.label-horovod-cpu }}
             ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-cpu }}
           - docker-image: horovod-ray
-            lablel: ${{ needs.start-runner.outputs.label-horovod-ray }}
+            label: ${{ needs.start-runner.outputs.label-horovod-ray }}
             ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id-horovod-ray }}
 
     steps:


### PR DESCRIPTION
Using matrix strategy when starting and stopping EC2 instances. Reduces some code duplication and starts and stops instances in parallel:

[![grafik](https://user-images.githubusercontent.com/44700269/119275430-4e5d3b00-bc15-11eb-9d0d-91bd95e44b3e.png)](https://github.com/horovod/horovod/actions/runs/869344199)
