### PR TITLE
Disable docker workflow on forks for schedule events

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner (${{ matrix.docker-image }})
-    if: ( ! github.event.repository.fork )
+    if: github.repository == 'horovod/horovod'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Disabling docker workflow in forks (#2937) only worked partially, schedule event does not have the expected data in `github.event`.