### PR TITLE
Fix docker build for fork PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,10 @@ concurrency:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner (${{ matrix.docker-image }})
-    if: github.repository == 'horovod/horovod'
+    if: >
+      github.event_name == 'schedule' && github.repository == 'horovod/horovod' ||
+      github.event_name == 'push' && github.repository == 'horovod/horovod' ||
+      github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'horovod/horovod' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
We are still seeing issues with PRs from forks that try to build docker on EC2. Depending on the event (`schedule`, `push` or `pul_request`), the content of `github` changes.