### PR TITLE
Move cancellation hook into job from workflow to ensure instance cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,12 +9,6 @@ on:
   pull_request:
     branches: [ master ]
 
-# we want an ongoing run of this workflow to be canceled by a later commit
-# so that there is only one concurrent run of this workflow for each branch
-concurrency:
-  group: docker-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner (${{ matrix.docker-image }})
@@ -67,6 +61,13 @@ jobs:
     if: needs.start-runner.result != 'skipped'
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ matrix.label }} # run the job on the newly created runners
+
+    # we want an ongoing run of this workflow to be canceled by a later commit
+    # so that there is only one concurrent run of this workflow for each branch
+    concurrency:
+      group: docker-${{ github.head_ref }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Some instances in EC2 have been dangling for a few days. I suspect it's due to workflow cancellation signals being sent when a new commit is pushed. Canceling the workflow (I suspect) is preventing the cleanup job from running at the end. This change moves the cancellation handler into the job, so that the following cleanup job can still run.