### PR TITLE
Add executable arg to horovod.spark.run

### DIFF
--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -33,10 +33,11 @@ def _exec_command_fn(driver, key, settings, env, stdout, stderr, prefix_output_w
     return _exec_command
 
 
-def gloo_run(settings, nics, driver, env, stdout=None, stderr=None):
+def gloo_run(executable, settings, nics, driver, env, stdout=None, stderr=None):
     """
     Run distributed gloo jobs.
 
+    :param executable: Executable to run when launching the workers.
     :param settings: Settings for running the distributed jobs.
                      Note: settings.num_proc and settings.hosts must not be None.
     :param nics: Interfaces to use by gloo.
@@ -57,7 +58,7 @@ def gloo_run(settings, nics, driver, env, stdout=None, stderr=None):
     # threads will keep running and ssh session.
     iface = list(nics)[0]
     server_ip = driver.addresses()[iface][0][0]
-    command = (sys.executable,
+    command = (executable,
                '-m', 'horovod.spark.task.gloo_exec_fn',
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))

--- a/horovod/spark/mpi_run.py
+++ b/horovod/spark/mpi_run.py
@@ -20,10 +20,11 @@ from horovod.runner.mpi_run import mpi_run as hr_mpi_run
 from horovod.runner.common.util import codec, secret
 
 
-def mpi_run(settings, nics, driver, env, stdout=None, stderr=None):
+def mpi_run(executable, settings, nics, driver, env, stdout=None, stderr=None):
     """
     Runs mpirun.
 
+    :param executable: Executable to run when launching the workers.
     :param settings: Settings for running MPI.
                      Note: settings.num_proc and settings.hosts must not be None.
     :param nics: Interfaces to include by MPI.
@@ -41,14 +42,14 @@ def mpi_run(settings, nics, driver, env, stdout=None, stderr=None):
     # we don't want the key to be serialized along with settings from here on
     settings.key = None
 
-    rsh_agent = (sys.executable,
+    rsh_agent = (executable,
                  '-m', 'horovod.spark.driver.mpirun_rsh',
                  codec.dumps_base64(driver.addresses()),
                  codec.dumps_base64(settings))
     settings.extra_mpi_args = ('{extra_mpi_args} -x NCCL_DEBUG=INFO -mca plm_rsh_agent "{rsh_agent}"'
                                .format(extra_mpi_args=settings.extra_mpi_args if settings.extra_mpi_args else '',
                                        rsh_agent=' '.join(rsh_agent)))
-    command = (sys.executable,
+    command = (executable,
                '-m', 'horovod.spark.task.mpirun_exec_fn',
                codec.dumps_base64(driver.addresses()),
                codec.dumps_base64(settings))


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Add parameter to specify an executable path for workers spawn by horovod on spark.
Useful in situations where the python env is shipped with `conda-pack` or https://github.com/criteo/cluster-pack
PR similar to #2708 

Tested with horovod on spark in a CPU cluster.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
