### PR TITLE
torch: sync values_handle firstly in sparse_allreduce_async

### DIFF
--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -518,8 +518,11 @@ def sparse_allreduce_async(tensor, name, op):
     values_handle = allgather_async(t._values(), name=f'{name}.values')
 
     def handle():
-        indices = synchronize(indices_handle)
+        # We need to sync values handle firstly for torch nightly >= 10.0
+        # Issue: https://github.com/horovod/horovod/issues/2961
         values = synchronize(values_handle)
+        indices = synchronize(indices_handle)
+
         values = (values / size()) if op == Average else values
 
         if indices.dim() == 0 or values.dim() == 0:

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -2421,8 +2421,6 @@ class TorchTests(unittest.TestCase):
             loss.backward()
             opt.step()
 
-    @pytest.mark.skipif(LooseVersion(torch.__version__) > LooseVersion('1.10.0'),
-                        reason='https://github.com/horovod/horovod/issues/2961')
     def test_async_sparse_allreduce(self):
         """Test that allgather over indices and values is equivalent to allreduce."""
         hvd.init()


### PR DESCRIPTION
Root cause hasn't been found out. But if values_handle is not synced
firstly, sparse_allreduce_async will be hanging in unit test.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #2961

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
