### PR TITLE
Build release Docker images on github-hosted runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Cleanup Docker
+        run: docker image prune -a --force
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,49 +10,9 @@ on:
     branches: [ master ]
 
 jobs:
-  start-runner:
-    name: Start self-hosted EC2 runner
-    if: >
-      github.event_name == 'schedule' && github.repository == 'horovod/horovod' ||
-      github.event_name == 'push' && github.repository == 'horovod/horovod' ||
-      github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name == 'horovod/horovod' && !github.event.pull_request.head.repo.fork
-    runs-on: ubuntu-latest
-
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Start EC2 runner
-        id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: start
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-0759580dedc953d1f
-          ec2-instance-type: r5.large
-          subnet-id: subnet-0983be43
-          security-group-id: sg-4cba0d08
-          aws-resource-tags: >
-            [
-              {"Key": "Name", "Value": "horovod-github-${{ github.head_ref || github.sha }}"},
-              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
-              {"Key": "GitHubHeadRef", "Value": "${{ github.head_ref }}"},
-              {"Key": "GitHubSHA", "Value": "${{ github.sha }}"}
-            ]
-
   docker:
     name: Build docker image ${{ matrix.docker-image }} (push=${{ github.event_name != 'pull_request' }})
-    if: needs.start-runner.result != 'skipped'
-    needs: start-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runners
+    runs-on: ubuntu-latest
 
     # we want an ongoing run of this workflow to be canceled by a later commit
     # so that there is only one concurrent run of this workflow for each branch
@@ -73,13 +33,12 @@ jobs:
           - horovod-ray
 
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      -
-        name: Docker meta
+
+      - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
@@ -95,21 +54,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -117,29 +75,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-  stop-runner:
-    name: Stop self-hosted EC2 runner
-
-    # required to stop the runner even if the error happened in the previous job
-    if: always() && needs.start-runner.result != 'skipped'
-    needs:
-      - start-runner # required to get output from the start-runner job
-      - docker # required to wait when the main job is done
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.2.0
-        with:
-          mode: stop
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,3 +78,22 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Free Space
+        if: always()
+        run: |
+          echo ::group::Disk Space
+          df -h
+          echo ::endgroup::
+
+          echo ::group::Docker Space
+          docker system df
+          echo ::endgroup::
+
+          echo ::group::Docker Images
+          docker images -a
+          echo ::endgroup::
+
+          echo ::group::Docker Container
+          docker container list -a
+          echo ::endgroup::

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         ibverbs-providers \
         openjdk-8-jdk-headless \
         openssh-client \
-        openssh-server
+        openssh-server \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Open MPI
 RUN wget --progress=dot:mega -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/horovod/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz && \
@@ -57,14 +58,15 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 # Install TensorFlow, Keras, PyTorch and MXNet
-RUN pip install future typing packaging
-RUN pip install tensorflow-cpu==${TENSORFLOW_VERSION} \
-                keras \
-                h5py
+RUN pip install --no-cache-dir future typing packaging
+RUN pip install --no-cache-dir \
+    tensorflow-cpu==${TENSORFLOW_VERSION} \
+    keras \
+    h5py
 
 RUN pip install --no-cache-dir torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION}
-RUN pip install pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
-RUN pip install mxnet==${MXNET_VERSION}
+RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+RUN pip install --no-cache-dir mxnet==${MXNET_VERSION}
 
 # Install Spark stand-alone cluster.
 RUN wget --progress=dot:giga "https://www.apache.org/dyn/closer.lua/spark/${SPARK_PACKAGE}?action=download" -O - | tar -xzC /tmp; \

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -57,15 +57,16 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 
-# Install TensorFlow, Keras, PyTorch and MXNet
+# Install PyTorch, TensorFlow, Keras and MXNet
+RUN pip install --no-cache-dir torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION}
+RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+
 RUN pip install --no-cache-dir future typing packaging
 RUN pip install --no-cache-dir \
     tensorflow-cpu==${TENSORFLOW_VERSION} \
     keras \
     h5py
 
-RUN pip install --no-cache-dir torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION}
-RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
 RUN pip install --no-cache-dir mxnet==${MXNET_VERSION}
 
 # Install Spark stand-alone cluster.

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -14,26 +14,28 @@ ARG TORCHVISION_VERSION=0.9.1+cu111
 SHELL ["/bin/bash", "-cu"]
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
-    build-essential \
-    wget \
-    git \
-    curl \
-    cmake \
-    rsync \
-    vim
+        build-essential \
+        wget \
+        git \
+        curl \
+        cmake \
+        rsync \
+        vim \
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # Install TensorFlow and Keras
-RUN pip install future typing packaging
-RUN pip install tensorflow==${TENSORFLOW_VERSION} \
-                keras \
-                h5py
+RUN pip install --no-cache-dir future typing packaging
+RUN pip install --no-cache-dir \
+    tensorflow==${TENSORFLOW_VERSION} \
+    keras \
+    h5py
 
 # Install PyTorch
-RUN pip install \
+RUN pip install --no-cache-dir \
     torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
-RUN pip install pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
 
 USER ray
 RUN sudo mkdir -p /horovod && sudo chown ray:users /horovod

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -23,19 +23,19 @@ RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install
         vim \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
-# Install TensorFlow and Keras
-RUN pip install --no-cache-dir future typing packaging
-RUN pip install --no-cache-dir \
-    tensorflow==${TENSORFLOW_VERSION} \
-    keras \
-    h5py
-
 # Install PyTorch
 RUN pip install --no-cache-dir \
     torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
 RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+
+# Install TensorFlow and Keras
+RUN pip install --no-cache-dir future typing packaging
+RUN pip install --no-cache-dir \
+    tensorflow==${TENSORFLOW_VERSION} \
+    keras \
+    h5py
 
 USER ray
 RUN sudo mkdir -p /horovod && sudo chown ray:users /horovod

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -66,18 +66,19 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 
-# Install TensorFlow, Keras, PyTorch and MXNet
+# Install PyTorch, TensorFlow, Keras and MXNet
+RUN pip install --no-cache-dir \
+    torch==${PYTORCH_VERSION} \
+    torchvision==${TORCHVISION_VERSION} \
+    -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
+RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+
 RUN pip install --no-cache-dir future typing packaging
 RUN pip install --no-cache-dir \
     tensorflow==${TENSORFLOW_VERSION} \
     keras \
     h5py
 
-RUN pip install --no-cache-dir \
-    torch==${PYTORCH_VERSION} \
-    torchvision==${TORCHVISION_VERSION} \
-    -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
-RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
 RUN pip install --no-cache-dir mxnet-cu112==${MXNET_VERSION}
 
 # Install Spark stand-alone cluster.

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -66,17 +66,18 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     rm get-pip.py
 
 # Install TensorFlow, Keras, PyTorch and MXNet
-RUN pip install future typing packaging
-RUN pip install tensorflow==${TENSORFLOW_VERSION} \
-                keras \
-                h5py
+RUN pip install --no-cache-dir future typing packaging
+RUN pip install --no-cache-dir \
+    tensorflow==${TENSORFLOW_VERSION} \
+    keras \
+    h5py
 
-RUN pip install \
+RUN pip install --no-cache-dir \
     torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
-RUN pip install pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
-RUN pip install mxnet-cu112==${MXNET_VERSION}
+RUN pip install --no-cache-dir pytorch_lightning==${PYTORCH_LIGHTNING_VERSION}
+RUN pip install --no-cache-dir mxnet-cu112==${MXNET_VERSION}
 
 # Install Spark stand-alone cluster.
 RUN wget --progress=dot:giga "https://www.apache.org/dyn/closer.lua/spark/${SPARK_PACKAGE}?action=download" -O - | tar -xzC /tmp; \

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         ibverbs-providers \
         openjdk-8-jdk-headless \
         openssh-client \
-        openssh-server
+        openssh-server \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Open MPI
 RUN wget --progress=dot:mega -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/horovod/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz && \


### PR DESCRIPTION
We can build release Docker images with GitHub actions and avoid EC2 instances. The `horovod-ray` image is the largest, as the input image is 4.27 GB, where `horovod`'s input Nvidia image is only 2.17 GB.

Several improvements make this work now:
- running `pip install` with `--no-cache-dir` so that downloaded pip packages are not stored in the Docker image
- running `apt-get` together with `apt-get clean && rm -rf /var/lib/apt/lists/*` removes distribution files
- installing PyTorch first, as this requires 2 GB temporary space (GPU)
- pruning docker images before running docker build frees enough disk space to even build `horovod-ray` frees another 4 GB of pre-allocated disk space

It looks like we have 1.7 GB disk space head room: https://github.com/horovod/horovod/runs/2800641461?check_suite_focus=true#step:9:20