### PR TITLE
Added github.ref to concurrency group

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
       # On master, head_ref is empty, so we use the SHA of the commit, this means
       # commits to master will not be cancelled, which is important to ensure
       # that every commit to master is full tested and deployed.
-      group: docker-${{ matrix.docker-image }}-${{ github.head_ref || github.sha }}
+      group: docker-${{ matrix.docker-image }}-${{ github.ref }}-${{ github.head_ref || github.sha }}
       cancel-in-progress: true
 
     strategy:


### PR DESCRIPTION
Without this change, a commit to `master` followed by pushing a new `tag` will result in a concurrency conflict, because they share the same `github.sha`. The idea here is that `github.ref` will be something like `refs/heads/master` for the commit and `refs/tags/v0.22.1` for the tag.

See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context for more details.