### PR TITLE
Add fused buffer scaling and unpack/pack kernels on GPU.

### DIFF
--- a/horovod/common/ops/cuda/cuda_kernels.h
+++ b/horovod/common/ops/cuda/cuda_kernels.h
@@ -39,6 +39,9 @@ void BatchedD2DMemcpyCudaImpl(BatchedD2DParams& params, int num_copies, cudaStre
 void ScaleBufferCudaImpl(const void* fused_input_data, void* buffer_data, const int64_t num_elements,
                          double scale_factor, DataType dtype, cudaStream_t stream);
 
+void BatchedScaledD2DMemcpyCudaImpl(BatchedD2DParams& params, int num_copies, double scale_factor,
+                                    DataType dtype, cudaStream_t stream);
+
 } // namespace common
 } // namespace horovod
 

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -149,6 +149,64 @@ void GPUAllreduce::MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& ent
 }
 #endif
 
+#if HAVE_CUDA
+void GPUAllreduce::ScaleMemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries, const void*& fused_input_data,
+                                             void*& buffer_data, size_t& buffer_len, double scale_factor) {
+  auto& first_entry = entries[0];
+  // Access the fusion buffer.
+  auto buffer = global_state_->fusion_buffer.GetBuffer(
+      first_entry.device, first_entry.context->framework(), global_state_->current_nccl_stream);
+  buffer_data = const_cast<void*>(buffer->AccessData(first_entry.context));
+
+  if (global_state_->batch_d2d_memcopies) {
+    int64_t offset = 0;
+    int idx = 0;
+    int count = 0;
+
+    BatchedD2DParams d2d_params;
+    for (auto& e : entries) {
+      void* buffer_data_at_offset = (uint8_t*)buffer_data + offset;
+
+      // Set input/output pointers and sizes
+      d2d_params.out[idx % BATCHED_D2D_CAPACITY] = buffer_data_at_offset;
+      d2d_params.in[idx % BATCHED_D2D_CAPACITY] = (void*) e.tensor->data();
+      d2d_params.sizes[idx % BATCHED_D2D_CAPACITY] = e.tensor->size();
+
+      offset += BATCHED_D2D_PADDING * ((e.tensor->size() + BATCHED_D2D_PADDING - 1) / BATCHED_D2D_PADDING);
+      idx++;
+      count++;
+
+      if (idx % BATCHED_D2D_CAPACITY == 0 || idx == (int) entries.size()) {
+        // Perform batched d2d memcpy
+        BatchedScaledD2DMemcpyCudaImpl(d2d_params, count, scale_factor, first_entry.tensor->dtype(),
+                                       gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+        // TODO: https://github.com/horovod/horovod/issues/2230
+        //gpu_context_->ErrorCheck("BatchedScaledD2DMemcpyCudaImpl", cudaGetLastError());
+        count = 0;
+      }
+    }
+    buffer_len = (size_t)offset;
+
+  } else {
+    int64_t offset = 0;
+    for (auto& e : entries) {
+      void* buffer_data_at_offset = (uint8_t*) buffer_data + offset;
+      MemcpyEntryInFusionBuffer(entries, e, buffer_data_at_offset);
+      offset += e.tensor->size();
+    }
+
+    buffer_len = (size_t) offset;
+    int64_t num_elements = buffer_len / DataType_Size(first_entry.tensor->dtype());
+    if (scale_factor != 1.0) {
+      ScaleBuffer(scale_factor, entries, buffer_data, buffer_data, num_elements);
+    }
+  }
+
+  // Set the input data to originate from the buffer.
+  fused_input_data = buffer_data;
+}
+#endif
+
 
 void GPUAllreduce::MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                                              const TensorTableEntry& e, void* buffer_data_at_offset) {
@@ -188,6 +246,55 @@ void GPUAllreduce::MemcpyOutFusionBuffer(const void* buffer_data, std::vector<Te
     }
 
   } else {
+    int64_t offset = 0;
+    for (auto& e : entries) {
+      void* buffer_data_at_offset = (uint8_t*) buffer_data + offset;
+      MemcpyEntryOutFusionBuffer(entries, buffer_data_at_offset, e);
+      offset += e.tensor->size();
+    }
+  }
+}
+#endif
+
+#if HAVE_CUDA
+void GPUAllreduce::ScaleMemcpyOutFusionBuffer(void* buffer_data, size_t buffer_len, double scale_factor,
+                                              std::vector<TensorTableEntry>& entries) {
+  auto& first_entry = entries[0];
+
+  if (global_state_->batch_d2d_memcopies) {
+    int64_t offset = 0;
+    int idx = 0;
+    int count = 0;
+
+    BatchedD2DParams d2d_params;
+    for (auto& e : entries) {
+      void* buffer_data_at_offset = (uint8_t*)buffer_data + offset;
+
+      // Set input/output pointers and sizes
+      d2d_params.out[idx % BATCHED_D2D_CAPACITY] = (void*)(e.output->data());
+      d2d_params.in[idx % BATCHED_D2D_CAPACITY] = buffer_data_at_offset;
+      d2d_params.sizes[idx % BATCHED_D2D_CAPACITY] = e.tensor->size();
+
+      offset += BATCHED_D2D_PADDING * ((e.tensor->size() + BATCHED_D2D_PADDING - 1) / BATCHED_D2D_PADDING);
+      idx++;
+      count++;
+
+      if (idx % BATCHED_D2D_CAPACITY == 0 || idx == (int) entries.size()) {
+        // Perform batched d2d memcpy
+        BatchedScaledD2DMemcpyCudaImpl(d2d_params, count, scale_factor, first_entry.tensor->dtype(),
+                                       gpu_context_->streams[global_state_->current_nccl_stream][first_entry.device]);
+        // TODO: https://github.com/horovod/horovod/issues/2230
+        //gpu_context_->ErrorCheck("BatchedD2DMemcpyCudaImpl", cudaGetLastError());
+        count = 0;
+      }
+    }
+
+  } else {
+    int64_t num_elements = buffer_len / DataType_Size(first_entry.tensor->dtype());
+    if (scale_factor != 1.0) {
+      ScaleBuffer(scale_factor, entries, buffer_data, buffer_data, num_elements);
+    }
+
     int64_t offset = 0;
     for (auto& e : entries) {
       void* buffer_data_at_offset = (uint8_t*) buffer_data + offset;

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -138,9 +138,14 @@ public:
 protected:
 #if HAVE_CUDA
   void MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries, const void*& fused_input_data,
-                                    void*& buffer_data, size_t& buffer_len) override;
+                            void*& buffer_data, size_t& buffer_len) override;
 
   void MemcpyOutFusionBuffer(const void* buffer_data, std::vector<TensorTableEntry>& entries) override;
+
+  void ScaleMemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries, const void*& fused_input_data,
+                                 void*& buffer_data, size_t& buffer_len, double scale_factor);
+  void ScaleMemcpyOutFusionBuffer(void* buffer_data, size_t buffer_len, double scale_factor,
+                                  std::vector<TensorTableEntry>& entries);
 #endif
 
   void MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -135,10 +135,9 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
   void* buffer_data;
   size_t buffer_len;
 
-  // Copy memory into the fusion buffer.
+  // Copy (and possibly scale) tensors into the fusion buffer.
   if (entries.size() > 1) {
-    MemcpyInFusionBuffer(entries, fused_input_data, buffer_data, buffer_len);
-
+    ScaleMemcpyInFusionBuffer(entries, fused_input_data, buffer_data, buffer_len, response.prescale_factor());
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue, MEMCPY_IN_FUSION_BUFFER, *gpu_op_context_.stream);
     }
@@ -146,17 +145,16 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     fused_input_data = first_entry.tensor->data();
     buffer_data = (void*) first_entry.output->data();
     buffer_len = (size_t) first_entry.output->size();
-  }
-
-  int64_t num_elements = buffer_len / DataType_Size(first_entry.tensor->dtype());
-
-  if (response.prescale_factor() != 1.0) {
-    // Execute prescaling op
-    ScaleBuffer(response.prescale_factor(), entries, fused_input_data, buffer_data, num_elements);
-    fused_input_data = buffer_data; // for unfused, scale is done out of place
+    int64_t num_elements = buffer_len / DataType_Size(first_entry.tensor->dtype());
+    if (response.prescale_factor() != 1.0) {
+      // Execute prescaling op
+      ScaleBuffer(response.prescale_factor(), entries, fused_input_data, buffer_data, num_elements);
+      fused_input_data = buffer_data; // for unfused, scale is done out of place
+    }
   }
 
   // Do allreduce.
+  int64_t num_elements = buffer_len / DataType_Size(first_entry.tensor->dtype());
   auto nccl_result = ncclAllReduce(fused_input_data, buffer_data,
                                    (size_t) num_elements,
                                    GetNCCLDataType(first_entry.tensor), ncclSum,
@@ -166,17 +164,17 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_ALLREDUCE, *gpu_op_context_.stream);
   }
 
-  if (response.postscale_factor() != 1.0) {
-    // Execute postscaling op
-    ScaleBuffer(response.postscale_factor(), entries, buffer_data, buffer_data, num_elements);
-  }
-
-  // Copy memory out of the fusion buffer.
+  // Copy (and possible scale) tensors out of the fusion buffer.
   if (entries.size() > 1) {
-    MemcpyOutFusionBuffer(buffer_data, entries);
+    ScaleMemcpyOutFusionBuffer(buffer_data, buffer_len, response.postscale_factor(), entries);
 
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue, MEMCPY_OUT_FUSION_BUFFER, *gpu_op_context_.stream);
+    }
+  } else {
+    if (response.postscale_factor() != 1.0) {
+      // Execute postscaling op
+      ScaleBuffer(response.postscale_factor(), entries, buffer_data, buffer_data, num_elements);
     }
   }
 


### PR DESCRIPTION

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
For a Horovod allreduce operation using NCCL, the batched fusion buffer pack, prescaling, postscaling, and batched fusion buffer unpack are all individual CUDA kernel launches. This PR introduces a fused batched memcpy and scaling CUDA kernel to perform a (un)pack and scaling in a single kernel launch. This fusion reduces the number of kernels Horovod launches and improves performance by removing extra read/writes of GPU buffer memory between the existing individual pack and scaling kernels. 