### PR TITLE
Clean up disk space before building Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,8 +67,31 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cleanup Docker
-        run: docker image prune -a --force
+      - name: Clean up disk space
+        # deleting these paths frees 38 GB disk space:
+        #   sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        # but this sometimes takes 3-4 minutes
+        # so we delete only some sub-paths which are known to be quick (10s) and 20 GB
+        run: |
+          echo ::group::Disk space before clean up
+          df -h
+          echo ::endgroup::
+
+          for dir in /usr/share/dotnet/sdk/\*/nuGetPackagesArchive.lzma \
+                     /usr/share/dotnet/shared \
+                     /usr/local/lib/android/sdk/ndk \
+                     /usr/local/lib/android/sdk/build-tools \
+                     /opt/ghc
+          do
+            echo ::group::Deleting "$dir"
+            sudo du -hsc $dir | tail -n1 || true
+            sudo rm -rf $dir
+            echo ::endgroup::
+          done
+
+          echo ::group::Disk space after clean up
+          df -h
+          echo ::endgroup::
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -79,7 +102,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Free Space
+      - name: Show free space
         if: always()
         run: |
           echo ::group::Disk Space


### PR DESCRIPTION
Building and pushing Horovod release Docker images via GitHub Action (#2970 failed on master when actually pushing to the registry: https://github.com/horovod/horovod/runs/2807151712.

This cleans up 20 GB disk space before building the image. There are 18 GB more available for clean up, but those sometimes take 2-3 minutes to delete.