### PR TITLE
Configure docker builds for forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,14 +4,31 @@ on:
   schedule:
     - cron: '0 10 * * *' # everyday at 10am
   push:
+    # only consider push to master and tags
+    # otherwise modify job.config.outputs.push
     branches: [ master ]
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ master ]
 
 jobs:
+  config:
+    name: Configure workflow
+    runs-on: ubuntu-latest
+    outputs:
+      # run workflow for all events on Horovod repo and non-schedule events on forks
+      run: ${{ github.repository == 'horovod/horovod' || github.event_name != 'schedule' }}
+      # push images only from Horovod repo and for schedule and push events
+      push: ${{ github.repository == 'horovod/horovod' && contains('schedule,push', github.event_name) }}
+
+    steps:
+      - name: Nothing to do
+        run: true
+
   docker:
-    name: Build docker image ${{ matrix.docker-image }} (push=${{ github.event_name != 'pull_request' }})
+    name: Build docker image ${{ matrix.docker-image }} (push=${{ needs.config.outputs.push }})
+    if: needs.config.outputs.run == 'true'
+    needs: config
     runs-on: ubuntu-latest
 
     # we want an ongoing run of this workflow to be canceled by a later commit
@@ -61,7 +78,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: needs.config.outputs.push == 'true'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -98,7 +115,7 @@ jobs:
         with:
           context: .
           file: ./docker/${{ matrix.docker-image }}/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ needs.config.outputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,9 @@ jobs:
     # we want an ongoing run of this workflow to be canceled by a later commit
     # so that there is only one concurrent run of this workflow for each branch
     concurrency:
-      # head_ref will mean only one workflow can run for the given pull request.
+      # github.ref means something like refs/heads/master or refs/tags/v0.22.1 or the branch.
+      # This helps to not cancel concurrent runs on master and a tag that share the same commit
+      # head_ref refers to the pull request branch so we run only one workflow for the given pull request.
       # On master, head_ref is empty, so we use the SHA of the commit, this means
       # commits to master will not be cancelled, which is important to ensure
       # that every commit to master is full tested and deployed.


### PR DESCRIPTION
With the rework of our `docker.yml` we have lost the specific behaviour for fork repositories (#2970).

This change disables the `schedule` event for fork repositories, as well as the login step for Dockerhub.

And this adds some more context to the concurrency logic added in #2971.