### PR TITLE
Removed store from closure variables sent to remote workers

### DIFF
--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -88,6 +88,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     store = estimator.getStore()
     is_dbfs = isinstance(store, DBFSLocalStore)
     remote_store = store.to_remote(run_id, dataset_idx)
+    storage_options = store.storage_options
 
     def SyncCallback(root_path, sync_to_store_fn, keras):
         class _SyncCallback(keras.callbacks.Callback):
@@ -218,7 +219,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                                 hdfs_driver=PETASTORM_HDFS_DRIVER,
                                 schema_fields=schema_fields,
                                 transform_spec=transform_spec,
-                                storage_options=store.storage_options,
+                                storage_options=storage_options,
                                 **reader_factory_kwargs) as train_reader:
                 with reader_factory(remote_store.val_data_path,
                                     num_epochs=1,
@@ -229,7 +230,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                                     hdfs_driver=PETASTORM_HDFS_DRIVER,
                                     schema_fields=schema_fields,
                                     transform_spec=transform_spec,
-                                    storage_options=store.storage_options,
+                                    storage_options=storage_options,
                                     **reader_factory_kwargs) \
                     if should_validate else empty_batch_reader() as val_reader:
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -219,6 +219,7 @@ def _make_reset_callbacks():
 
 
 def _set_data_loader_fn(transformation, schema_fields, batch_size, data_loader_cls, num_epochs, store, verbose=False):
+    storage_options = store.storage_options
 
     @contextlib.contextmanager
     def set_data_loader(model, data_path, dataloader_attr, reader_worker_count, reader_pool_type, shuffling_queue_capacity,
@@ -264,7 +265,7 @@ def _set_data_loader_fn(transformation, schema_fields, batch_size, data_loader_c
                             hdfs_driver=PETASTORM_HDFS_DRIVER,
                             schema_fields=schema_fields,
                             transform_spec=transform_spec,
-                            storage_options=store.storage_options,
+                            storage_options=storage_options,
                             **reader_factory_kwargs) as reader:
             def dataloader_fn():
                 return data_loader_cls(reader=reader, batch_size=batch_size,

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -91,6 +91,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
     store = estimator.getStore()
     remote_store = store.to_remote(run_id, dataset_idx)
     is_dbfs = isinstance(store, DBFSLocalStore)
+    storage_options = store.storage_options
 
     @contextlib.contextmanager
     def empty_batch_reader():
@@ -236,7 +237,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                 hdfs_driver=PETASTORM_HDFS_DRIVER,
                                 schema_fields=schema_fields,
                                 transform_spec=transform_spec,
-                                storage_options=store.storage_options,
+                                storage_options=storage_options,
                                 **reader_factory_kwargs) as train_reader:
                 with reader_factory(remote_store.val_data_path,
                                     num_epochs=None,
@@ -247,7 +248,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                                     hdfs_driver=PETASTORM_HDFS_DRIVER,
                                     schema_fields=schema_fields,
                                     transform_spec=transform_spec,
-                                    storage_options=store.storage_options,
+                                    storage_options=storage_options,
                                     **reader_factory_kwargs) \
                     if should_validate else empty_batch_reader() as val_reader:
 


### PR DESCRIPTION
In #2927 we added `storage_options` to the store object, but in doing so, also made the `store` part of the closure sent to remote workers, resulting in an attempt to serialize / deserialize the store. Unfortunately, the HDFS store in particular cannot be serialized correctly, so this change fixes this by putting the `storage_options` only into the closure.