### PR TITLE
Fix name of TorchTests.test_horovod_grouped_allreduce_grad_average()

### DIFF
--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -749,8 +749,8 @@ class TorchTests(unittest.TestCase):
                                 "gradient %s differs from expected %s, "
                                 "error: %s" % (grad_out, expected, str(err)))
 
-    def test_horovod_allreduce_grad_average(self):
-        """Test the correctness of the allreduce averaged gradient."""
+    def test_horovod_grouped_allreduce_grad_average(self):
+        """Test the correctness of the grouped allreduce averaged gradient."""
         hvd.init()
         # Only Tensors of floating point dtype can require gradients
         dtypes = [torch.FloatTensor, torch.DoubleTensor]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This test for `grouped_allreduce` accidentally shadowed `test_horovod_allreduce_grad_average`.

