### PR TITLE
add SyncBatchNorm support for training examples

### DIFF
--- a/examples/pytorch/pytorch_imagenet_resnet50.py
+++ b/examples/pytorch/pytorch_imagenet_resnet50.py
@@ -247,7 +247,7 @@ if __name__ == '__main__':
 
 
     # Set up standard ResNet-50 model.
-    model = models.resnet50()
+    model = models.resnet50(norm_layer=hvd.SyncBatchNorm)
 
     # By default, Adasum doesn't need scaling up learning rate.
     # For sum/average with gradient Accumulation: scale learning rate by batches_per_allreduce

--- a/examples/pytorch/pytorch_synthetic_benchmark.py
+++ b/examples/pytorch/pytorch_synthetic_benchmark.py
@@ -44,7 +44,7 @@ if args.cuda:
 cudnn.benchmark = True
 
 # Set up standard model.
-model = getattr(models, args.model)()
+model = getattr(models, args.model)(norm_layer=hvd.SyncBatchNorm)
 
 # By default, Adasum doesn't need scaling up learning rate.
 lr_scaler = hvd.size() if not args.use_adasum else 1


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.

Replace BatchNorm in pytorch examples with  SyncBatchNorm.

Mutil-GPU training with BatchNorm with lead to different BN mean and var between different GPU, and the final accuracy will be lower.