### PR TITLE
Add debugging to new CI Workflow

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -130,7 +130,12 @@ def main():
                 f'\n')
 
     def jobs(*jobs: str) -> str:
-        return 'jobs:\n' + '\n'.join(jobs)
+        return 'jobs:\n' \
+               '  debug:\n' \
+               '    runs-on: ubuntu-latest\n' \
+               '    steps:\n' \
+               '    - name: Debug Action\n' \
+               '      uses: hmarr/debug-action@v1.0.0\n' + '\n'.join(jobs)
 
     def validate_workflow_job() -> str:
         return (f'  init-workflow:\n'

--- a/.github/workflows/ci-fork.yaml
+++ b/.github/workflows/ci-fork.yaml
@@ -7,6 +7,12 @@ on:
       - completed
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Action
+        uses: hmarr/debug-action@v1.0.0
+
   buildkite:
     name: "Build and Test (GPUs on Builtkite)"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Debug Action
+      uses: hmarr/debug-action@v1.0.0
   init-workflow:
     name: "Init Workflow"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The new CI Workflow does not yet work well with fork PRs. This adds some debugging to CI and CI-Fork.