### PR TITLE
Build docker images for fork PRs

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -497,6 +497,8 @@ def main():
     def publish_docker_images(needs: List[str], images: List[str]) -> str:
         if 'init-workflow' not in needs:
             needs.insert(0, 'init-workflow')
+        if needs != ['init-workflow', 'build-and-test-cpu', 'build-gpu', 'buildkite']:
+            raise RuntimeError('This job has hard-coded needs, which you may want to adjust')
         return (f'  docker-config:\n'
                 f'    name: Configure docker build\n'
                 f'    needs: [{", ".join(needs)}]\n'

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -500,6 +500,17 @@ def main():
         return (f'  docker-config:\n'
                 f'    name: Configure docker build\n'
                 f'    needs: [{", ".join(needs)}]\n'
+                f"    # build-and-test-cpu, build-gpu and buildkite might have been skipped (needs.init-workflow.outputs.run_builds_and_tests == 'false')\n"
+                f'    # buildkite might have been skipped (workflow runs for a fork PR)\n'
+                f'    # we still want to build docker images in these cases\n'
+                f'    if: >\n'
+                f'      always() &&\n'
+                f"      needs.init-workflow.result == 'success' && (\n"
+                f"        needs.init-workflow.outputs.run_builds_and_tests == 'false' ||\n"
+                f"        needs.build-and-test-cpu.result == 'success' &&\n"
+                f"        needs.build-gpu.result == 'success' &&\n"
+                f"        ( needs.buildkite.result == 'success' || needs.buildkite.result == 'skipped' )\n"
+                f'      )\n'
                 f'    runs-on: ubuntu-latest\n'
                 f'    outputs:\n'
                 f'      run: ${{{{ steps.config.outputs.run }}}}\n'

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -537,7 +537,7 @@ def main():
                 f'  docker-build:\n'
                 f'    name: Build docker image ${{{{ matrix.docker-image }}}} (push=${{{{ needs.docker-config.outputs.push }}}})\n'
                 f'    needs: docker-config\n'
-                f'    if: needs.docker-config.outputs.run == \'true\'\n'
+                f'    if: always() && needs.docker-config.outputs.run == \'true\'\n'
                 f'    runs-on: ubuntu-latest\n'
                 f'\n'
                 f'    # we want an ongoing run of this workflow to be canceled by a later commit\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1483,6 +1483,17 @@ jobs:
   docker-config:
     name: Configure docker build
     needs: [init-workflow, build-and-test-cpu, build-gpu, buildkite]
+    # build-and-test-cpu, build-gpu and buildkite might have been skipped (needs.init-workflow.outputs.run_builds_and_tests == 'false')
+    # buildkite might have been skipped (workflow runs for a fork PR)
+    # we still want to build docker images in these cases
+    if: >
+      always() &&
+      needs.init-workflow.result == 'success' && (
+        needs.init-workflow.outputs.run_builds_and_tests == 'false' ||
+        needs.build-and-test-cpu.result == 'success' &&
+        needs.build-gpu.result == 'success' &&
+        ( needs.buildkite.result == 'success' || needs.buildkite.result == 'skipped' )
+      )
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.config.outputs.run }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1518,7 +1518,7 @@ jobs:
   docker-build:
     name: Build docker image ${{ matrix.docker-image }} (push=${{ needs.docker-config.outputs.push }})
     needs: docker-config
-    if: needs.docker-config.outputs.run == 'true'
+    if: always() && needs.docker-config.outputs.run == 'true'
     runs-on: ubuntu-latest
 
     # we want an ongoing run of this workflow to be canceled by a later commit


### PR DESCRIPTION
The Buildkite step is skipped for fork PRs, as there are no Buildkite credentials in that context. I suspect this to case the dependent docker-config step to also get skipped, so that we do not build Docker images for fork PRs.

This change hopefully enforces docker builds for fork PRs.