### PR TITLE
Merge CPU and GPU CI jobs into one again

### DIFF
--- a/.github/workflows/ci-fork.yaml
+++ b/.github/workflows/ci-fork.yaml
@@ -27,7 +27,7 @@ jobs:
         id: workflow-conclusion
         run: |
           curl -s "${{ github.event.workflow_run.jobs_url }}" > workflow_run_jobs.json
-          conclusion=$(jq -r '.jobs[] | select(.name | startswith("Build and Test CPU") or startswith("Build GPU")) | .conclusion' workflow_run_jobs.json | sort | uniq | paste -sd "," -)
+          conclusion=$(jq -r '.jobs[] | select(.name | startswith("Build and Test (") | .conclusion' workflow_run_jobs.json | sort | uniq | paste -sd "," -)
           echo "::set-output name=build-and-test::${conclusion}"
         shell: bash
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,8 @@ jobs:
           fi
           echo "::set-output name=needed::true"
 
-  build-and-test-cpu:
-    name: "Build and Test CPU (${{ matrix.image }})"
+  build-and-test:
+    name: "Build and Test (${{ matrix.image }})"
     needs: [init-workflow]
     if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
     runs-on: ubuntu-latest
@@ -219,6 +219,24 @@ jobs:
             Spark_PyTests: true
             Spark_Torch_MNIST: true
             build_timeout: 30
+
+          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_3_1-mxnet1_5_1_p0-pyspark3_1_2
+            build_timeout: 40
+
+          - image: test-gpu-gloo-py3_8-tf2_3_2-keras2_3_1-torch1_7_1-mxnet1_6_0_p0-pyspark3_1_2
+            build_timeout: 40
+
+          - image: test-gpu-gloo-py3_8-tf2_3_2-keras2_3_1-torch1_7_1-mxnet1_7_0_p1-pyspark3_1_2
+            build_timeout: 40
+
+          - image: test-gpu-gloo-py3_8-tf2_4_1-keras2_4_3-torch1_8_1-mxnet1_8_0_p0-pyspark3_1_2
+            build_timeout: 40
+
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_5_0-keras_none-torch1_9_0-mxnet1_8_0_p0-pyspark3_1_2
+            build_timeout: 40
+
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_5_0-keras_none-torch1_9_0-mxnet1_8_0_p0-pyspark3_1_2
+            build_timeout: 40
 
     steps:
       - name: Clean up disk space
@@ -1706,148 +1724,9 @@ jobs:
           docker tag ${{ matrix.image }} ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
           docker push ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
 
-  build-gpu:
-    name: "Build GPU (${{ matrix.image }})"
-    needs: [init-workflow]
-    if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
-    runs-on: ubuntu-latest
-
-    strategy:
-      max-parallel: 6
-      fail-fast: false
-      matrix:
-        include:
-          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_3_1-mxnet1_5_1_p0-pyspark3_1_2
-            build_timeout: 40
-
-          - image: test-gpu-gloo-py3_8-tf2_3_2-keras2_3_1-torch1_7_1-mxnet1_6_0_p0-pyspark3_1_2
-            build_timeout: 40
-
-          - image: test-gpu-gloo-py3_8-tf2_3_2-keras2_3_1-torch1_7_1-mxnet1_7_0_p1-pyspark3_1_2
-            build_timeout: 40
-
-          - image: test-gpu-gloo-py3_8-tf2_4_1-keras2_4_3-torch1_8_1-mxnet1_8_0_p0-pyspark3_1_2
-            build_timeout: 40
-
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_5_0-keras_none-torch1_9_0-mxnet1_8_0_p0-pyspark3_1_2
-            build_timeout: 40
-
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_5_0-keras_none-torch1_9_0-mxnet1_8_0_p0-pyspark3_1_2
-            build_timeout: 40
-
-    steps:
-      - name: Clean up disk space
-        # deleting these paths frees 38 GB disk space:
-        #   sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-        # but this sometimes takes 3-4 minutes
-        # so we delete only some sub-paths which are known to be quick (10s) and 20 GB
-        run: |
-          echo ::group::Disk space before clean up
-          df -h
-          echo ::endgroup::
-
-          for dir in /usr/share/dotnet/sdk/\*/nuGetPackagesArchive.lzma \
-                     /usr/share/dotnet/shared \
-                     /usr/local/lib/android/sdk/ndk \
-                     /usr/local/lib/android/sdk/build-tools \
-                     /opt/ghc
-          do
-            echo ::group::Deleting "$dir"
-            sudo du -hsc $dir | tail -n1 || true
-            sudo rm -rf $dir
-            echo ::endgroup::
-          done
-
-          echo ::group::Disk space after clean up
-          df -h
-          echo ::endgroup::
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Setup docker-compose
-        run: pip install docker-compose
-
-      - name: Configure AWS credentials
-        id: aws
-        uses: aws-actions/configure-aws-credentials@v1
-        # AWS credentials are used to authenticate against AWS ECR to pull and push test images
-        # We can only authenticate when running on Horovod repo (not a fork)
-        if: github.repository == 'horovod/horovod'
-        continue-on-error: true
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR
-        id: ecr
-        if: steps.aws.outcome == 'success'
-        continue-on-error: true
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Add cache_from to docker-compose YAML
-        if: steps.ecr.outcome == 'success'
-        run: |
-          cat > docker-compose.test.override.yml <<EOF
-          version: '2.3'
-          services:
-            ${{ matrix.image }}:
-              build:
-                cache_from:
-                  - ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
-          EOF
-          cat docker-compose.test.override.yml
-        shell: bash
-
-      - name: Pull latest test image
-        if: steps.ecr.outcome == 'success'
-        continue-on-error: true
-        run: |
-          docker pull ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Build
-        id: build
-        run: |
-          override_yaml=""
-          if [ -e docker-compose.test.override.yml ]; then override_yaml="-f docker-compose.test.override.yml"; fi
-          .github/timeout-and-retry.sh ${{ matrix.build_timeout }}m 3 10 docker-compose -f docker-compose.test.yml $override_yaml build --pull ${{ matrix.image }}
-        env:
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
-
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v2
-        if: always() && contains(matrix.image, '-cpu-')
-        with:
-          name: Unit Test Results - ${{ matrix.image }}
-          path: artifacts/${{ matrix.image }}/**/*.xml
-
-      - name: Push test image
-        # We push test image to AWS ECR on push to Horovod master (not a fork)
-        if: >
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/master' &&
-          github.repository == 'horovod/horovod' &&
-          steps.ecr.outcome == 'success'
-        continue-on-error: true
-        run: |
-          docker tag ${{ matrix.image }} ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
-          docker push ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
-
   build-and-test-heads:
     name: "Build and Test heads (${{ matrix.image }})"
-    needs: [init-workflow, build-and-test-cpu, build-gpu]
+    needs: [init-workflow, build-and-test]
     if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
     runs-on: ubuntu-latest
 
@@ -3363,7 +3242,7 @@ jobs:
 
   build-and-test-macos:
     name: "Build and Test macOS (${{ matrix.image }}-macos)"
-    needs: [init-workflow, build-and-test-cpu, build-gpu]
+    needs: [init-workflow, build-and-test]
     if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
     runs-on: macos-latest
 
@@ -3454,7 +3333,7 @@ jobs:
 
   buildkite:
     name: "Build and Test GPU (on Builtkite)"
-    needs: [init-workflow, build-and-test-cpu, build-gpu]
+    needs: [init-workflow, build-and-test]
     runs-on: ubuntu-latest
     if: >
       needs.init-workflow.outputs.run_builds_and_tests != 'false' &&
@@ -3498,7 +3377,7 @@ jobs:
 
   publish-test-results:
     name: "Publish Unit Tests Results"
-    needs: [build-and-test-cpu, build-gpu, build-and-test-heads, build-and-test-macos, buildkite]
+    needs: [build-and-test, build-and-test-heads, build-and-test-macos, buildkite]
     runs-on: ubuntu-latest
     # only run this job when the workflow is in success or failure state,
     # not when it is in cancelled or skipped state
@@ -3522,7 +3401,7 @@ jobs:
 
   docker-config:
     name: Configure docker build
-    needs: [init-workflow, build-and-test-cpu, build-gpu, buildkite]
+    needs: [init-workflow, build-and-test, buildkite]
     # build-and-test-cpu, build-gpu and buildkite might have been skipped (needs.init-workflow.outputs.run_builds_and_tests == 'false')
     # buildkite might have been skipped (workflow runs for a fork PR)
     # we still want to build docker images in these cases
@@ -3530,8 +3409,7 @@ jobs:
       always() &&
       needs.init-workflow.result == 'success' && (
         needs.init-workflow.outputs.run_builds_and_tests == 'false' ||
-        needs.build-and-test-cpu.result == 'success' &&
-        needs.build-gpu.result == 'success' &&
+        needs.build-and-test.result == 'success' &&
         ( needs.buildkite.result == 'success' || needs.buildkite.result == 'skipped' )
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
The "Build and Test" job has been split in #3025 because it looked like a good idea (separation of concerns). But the job dependency graph is more complex now. And each job has the full `max-parallel`, where before that split the cpu images determined the `max-parallel` value as CPU build and test takes much longer than GPU build.

Merging both jobs together will de-prioritize the GPU jobs again and leave more concurrent jobs for other workflow runs.