### PR TITLE
Estimator: make metadata path unique

### DIFF
--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -30,7 +30,7 @@ import pyarrow.parquet as pq
 import fsspec
 from fsspec.core import split_protocol
 
-from horovod.spark.common.util import is_databricks
+from horovod.spark.common.util import is_databricks, host_hash
 
 
 class Store(object):
@@ -225,7 +225,8 @@ class AbstractFilesystemStore(Store):
         localized_path = self.get_localized_path(path)
         if localized_path.endswith('/'):
             localized_path = localized_path[:-1] # Remove the slash at the end if there is one
-        metadata_cache = localized_path+"_cached_metadata.pkl"
+        file_hash = host_hash()
+        metadata_cache = localized_path+"_"+file_hash+"_cached_metadata.pkl"
         return metadata_cache
 
     def saving_runs(self):


### PR DESCRIPTION
To avoid possible file writing conflicts when multiple workflows using
same training path.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
On Uber side, we have found that for some parallel autotune training workflows using same training file path, it is possible to run into `HDFS file not found` exception as below:

```
But see this error:
org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): File does not exist: /user/csashi/canvas/workspaces/poka_yoke_model_exploration_v2/variables/fa2048ad-6b93-44a6-8e97-453a58f72d60/value/value.parquet_cached_metadata.pkl (inode 24400193212) Holder DFSClient_NONMAPREDUCE_1435370252_1 does not have any open files.
at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.checkLease(FSNamesystem.java:2724)
at org.apache.hadoop.hdfs.server.namenode.FSDirWriteFileOp.completeFileInternal(FSDirWriteFileOp.java:621)

File "/usr/lib/python3.6/site-packages/horovod/spark/common/util.py", line 426, in _save_meta_to_fs
train_meta_file.write(serialized_content.encode('utf-8'))
File "pyarrow/io.pxi", line 75, in pyarrow.lib.NativeFile._exit_
File "pyarrow/io.pxi", line 133, in pyarrow.lib.NativeFile.close
File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
OSError: HDFS CloseFile failed, errno: 255 (Unknown error 255) Please check that you are connecting to the correct HDFS RPC port
```

The root cause on our observation is that multiple workflows are writing meta data to the same path on HDFS concurrently, since meta data file name is generated by on training file path only.

This PR is to make meta data file name unique to each workflow.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
