### PR TITLE
Push docker test images from Github

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -83,24 +83,6 @@ build_test() {
   echo "    queue: cpu"
 }
 
-cache_test() {
-  local test=$1
-
-  echo "- label: ':docker: Update ${BUILDKITE_PIPELINE_SLUG}-${test}-latest'"
-  echo "  plugins:"
-  echo "  - docker-compose#v3.5.0:"
-  echo "      push: ${test}:${repository}:${BUILDKITE_PIPELINE_SLUG}-${test}-latest"
-  echo "      config: docker-compose.test.yml"
-  echo "      push-retries: 3"
-  echo "  - ecr#v1.2.0:"
-  echo "      login: true"
-  echo "  timeout_in_minutes: 5"
-  echo "  retry:"
-  echo "    automatic: true"
-  echo "  agents:"
-  echo "    queue: cpu"
-}
-
 run_test() {
   local test=$1
   local queue=$2
@@ -415,13 +397,6 @@ done
 
 # wait for all builds to finish
 echo "- wait"
-
-# cache test containers if built from master
-if [[ "${BUILDKITE_BRANCH}" == "master" ]]; then
-  for test in ${tests[@]-}; do
-    cache_test "${test}"
-  done
-fi
 
 oneccl_env="\\\$(cat:/oneccl_env):&&"
 oneccl_cmd_ofi="${oneccl_env}:echo:'/mpirun_command_ofi':>:/mpirun_command:&&"

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -327,8 +327,11 @@ def main():
                 f'          steps.ecr.outcome == \'success\'\n'
                 f'        continue-on-error: true\n'
                 f'        run: |\n'
-                f'          docker tag ${{{{ matrix.image }}}} ${{{{ steps.ecr.outputs.registry }}}}:horovod-${{{{ matrix.image }}}}-latest\n'
-                f'          docker push ${{{{ steps.ecr.outputs.registry }}}}:horovod-${{{{ matrix.image }}}}-latest\n')
+                f'          docker image ls | head\n'
+                f'          docker tag horovod_${{{{ matrix.image }}}} ${{{{ steps.ecr.outputs.registry }}}}/buildkite:horovod-${{{{ matrix.image }}}}-latest\n'
+                f'          docker push ${{{{ steps.ecr.outputs.registry }}}}/buildkite:horovod-${{{{ matrix.image }}}}-latest\n'
+                f'          docker image ls | head\n'
+                f'        shell: bash\n')
 
     def build_and_test_macos(id: str, name: str, needs: List[str]) -> str:
         if 'init-workflow' not in needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1721,8 +1721,11 @@ jobs:
           steps.ecr.outcome == 'success'
         continue-on-error: true
         run: |
-          docker tag ${{ matrix.image }} ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
-          docker push ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
+          docker image ls | head
+          docker tag horovod_${{ matrix.image }} ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
+          docker push ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
+          docker image ls | head
+        shell: bash
 
   build-and-test-heads:
     name: "Build and Test heads (${{ matrix.image }})"
@@ -3237,8 +3240,11 @@ jobs:
           steps.ecr.outcome == 'success'
         continue-on-error: true
         run: |
-          docker tag ${{ matrix.image }} ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
-          docker push ${{ steps.ecr.outputs.registry }}:horovod-${{ matrix.image }}-latest
+          docker image ls | head
+          docker tag horovod_${{ matrix.image }} ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
+          docker push ${{ steps.ecr.outputs.registry }}/buildkite:horovod-${{ matrix.image }}-latest
+          docker image ls | head
+        shell: bash
 
   build-and-test-macos:
     name: "Build and Test macOS (${{ matrix.image }}-macos)"


### PR DESCRIPTION
Pushing test images from master allows to use them as caches for later test builds. This mimics the behaviour that we have seen on Buildkite.