### PR TITLE
Add process set support for PyTorch

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -49,6 +49,7 @@ if _MPI_LIB_AVAILABLE:
     from horovod.torch.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
     from horovod.torch.mpi_ops import gloo_enabled, gloo_built
     from horovod.torch.mpi_ops import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
+    from horovod.torch.mpi_ops import ProcessSet, global_process_set, add_process_set, remove_process_set
     from horovod.torch.mpi_ops import Average, Sum, Adasum
     from horovod.torch.optimizer import DistributedOptimizer
     from horovod.torch.sync_batch_norm import SyncBatchNorm

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -51,7 +51,6 @@ cross_size = _basics.cross_size
 rank = _basics.rank
 local_rank = _basics.local_rank
 cross_rank = _basics.cross_rank
-_process_set_rank = _basics._process_set_rank
 mpi_threads_supported = _basics.mpi_threads_supported
 mpi_enabled = _basics.mpi_enabled
 mpi_built = _basics.mpi_built
@@ -626,7 +625,7 @@ class HorovodAllgather(torch.autograd.Function):
         dim_t = torch.IntTensor([ctx.dim])
         dim = allgather(dim_t, process_set=ctx.process_set).view(ctx.process_set.size())
 
-        r = _process_set_rank(ctx.process_set.process_set_id)
+        r = ctx.process_set.rank()
         offset = torch.sum(dim.narrow(0, 0, r)).item() if r != 0 else 0
         return grad_reduced.narrow(0, offset, ctx.dim), None, None
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This is a straightforward extension of #2839, adding the process set feature to the PyTorch API.

Included are the ops `allgather`, `allreduce`, `alltoall`, `broadcast`, `grouped_allreduce` and their gradients, as well as the `DistributedOptimizer` (+ `broadcast_object`, `sparse_allreduce_async`).
