### PR TITLE
Add process set support for MXNet

### DIFF
--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -40,7 +40,7 @@ import warnings
 
 # This is where Horovod's DistributedOptimizer wrapper for MXNet goes
 class DistributedOptimizer(mx.optimizer.Optimizer):
-    def __init__(self, optimizer, gradient_predivide_factor=1.0, num_groups=0):
+    def __init__(self, optimizer, gradient_predivide_factor=1.0, num_groups=0, process_set=global_process_set):
         if gradient_predivide_factor != 1.0 and rocm_built():
             raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 
@@ -50,6 +50,7 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
         self._optimizer.rescale_grad *= (gradient_predivide_factor / size())
         self._gradient_predivide_factor = gradient_predivide_factor
         self._num_groups = num_groups
+        self._process_set = process_set
 
     def __getattr__(self, item):
         return getattr(self._optimizer, item)
@@ -67,22 +68,27 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
 
                 for i, (grads, indices) in enumerate(zip(grad_split, index_split)):
                     grouped_allreduce_(tensors=grads, average=False, name="{}:{}".format(indices[0], indices[-1]), priority=-i,
-                                       prescale_factor=1.0 / self._gradient_predivide_factor)
+                                       prescale_factor=1.0 / self._gradient_predivide_factor,
+                                       process_set=self._process_set)
             else:
               for i in range(len(index)):
                   allreduce_(grad[i], average=False,
                              name=str(index[i]), priority=-i,
-                             prescale_factor=1.0 / self._gradient_predivide_factor)
+                             prescale_factor=1.0 / self._gradient_predivide_factor,
+                             process_set=self._process_set)
         else:
             allreduce_(grad, average=False, name=str(index),
-                       prescale_factor=1.0 / self._gradient_predivide_factor)
+                       prescale_factor=1.0 / self._gradient_predivide_factor,
+                       process_set=self._process_set)
 
     def update(self, index, weight, grad, state):
-        self._do_allreduce(index, grad)
+        if self._process_set.included():
+            self._do_allreduce(index, grad)
         self._optimizer.update(index, weight, grad, state)
 
     def update_multi_precision(self, index, weight, grad, state):
-        self._do_allreduce(index, grad)
+        if self._process_set.included():
+            self._do_allreduce(index, grad)
         self._optimizer.update_multi_precision(index, weight, grad, state)
 
     def set_learning_rate(self, lr):

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -30,6 +30,7 @@ from horovod.mxnet.mpi_ops import size, local_size, cross_size, rank, local_rank
 from horovod.mxnet.mpi_ops import mpi_threads_supported, mpi_enabled, mpi_built
 from horovod.mxnet.mpi_ops import gloo_enabled, gloo_built
 from horovod.mxnet.mpi_ops import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
+from horovod.mxnet.mpi_ops import ProcessSet, global_process_set, add_process_set, remove_process_set
 
 import mxnet as mx
 from collections import OrderedDict, defaultdict

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -55,6 +55,9 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
     def __getattr__(self, item):
         return getattr(self._optimizer, item)
 
+    def create_state(self, index, weight):
+        return self._optimizer.create_state(index, weight)
+
     def create_state_multi_precision(self, index, weight):
         return self._optimizer.create_state_multi_precision(index, weight)
 

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -495,8 +495,7 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
   if (IsTensorOnCPU(inputs[0]) && IsTensorOnCPU(outputs[0])) {
     PushHorovodOperation(OperationType::ALLREDUCE, inputs, outputs, name,
                          priority, num_tensors, process_set_id, -1, average,
-                         nullptr, nullptr, prescale_factor, postscale_factor,
-                         process_set_id);
+                         nullptr, nullptr, prescale_factor, postscale_factor);
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLREDUCE, inputs, outputs,
                                   name, priority, num_tensors, process_set_id,

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -83,6 +83,7 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
   auto prescale_factor = ops_param->prescale_factor;
   auto postscale_factor = ops_param->postscale_factor;
   auto num_tensors = ops_param->input_tensors.size();
+  auto process_set_id = ops_param->process_set_id;
 
   std::vector<std::shared_ptr<Tensor>> hvd_tensors;
   std::vector<std::shared_ptr<OpContext>> hvd_contexts;
@@ -138,13 +139,15 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
       }
 
       enqueue_result = EnqueueTensorAllreduces(
-          hvd_contexts, hvd_tensors, hvd_outputs, ready_event_lists, ops_param->op_names, device,
-          callbacks, (average) ? ReduceOp::AVERAGE : ReduceOp::SUM, prescale_factor, postscale_factor);
+          hvd_contexts, hvd_tensors, hvd_outputs, ready_event_lists,
+          ops_param->op_names, device, callbacks,
+          (average) ? ReduceOp::AVERAGE : ReduceOp::SUM, prescale_factor,
+          postscale_factor, process_set_id);
       break;
     case OperationType::ALLGATHER:
       enqueue_result = EnqueueTensorAllgather(
-          hvd_contexts[0], hvd_tensors[0], ready_event_lists[0], ops_param->op_names[0], device,
-          callbacks[0]);
+          hvd_contexts[0], hvd_tensors[0], ready_event_lists[0],
+          ops_param->op_names[0], device, callbacks[0], process_set_id);
       break;
     case OperationType::BROADCAST:
       if (horovod_rank() != ops_param->root_rank) {
@@ -155,15 +158,15 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 
       enqueue_result = EnqueueTensorBroadcast(
           hvd_contexts[0], hvd_tensors[0], hvd_outputs[0], ops_param->root_rank,
-          ready_event_lists[0], ops_param->op_names[0], device,
-          callbacks[0]);
+          ready_event_lists[0], ops_param->op_names[0], device, callbacks[0],
+          process_set_id);
       break;
     case OperationType::ALLTOALL:
     {
       auto hvd_splits = std::make_shared<MXTensor>(ops_param->splits_tensor.get());
       enqueue_result = EnqueueTensorAlltoall(
-          hvd_contexts[0], hvd_tensors[0], hvd_splits, ready_event_lists[0], ops_param->op_names[0],
-          device, callbacks[0]);
+          hvd_contexts[0], hvd_tensors[0], hvd_splits, ready_event_lists[0],
+          ops_param->op_names[0], device, callbacks[0], process_set_id);
       break;
     }
     default:
@@ -175,7 +178,9 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
 
 inline void PushHorovodOperation(OperationType op_type, NDArray* const * inputs,
                                  NDArray* const * outputs, const char* name,
-                                 int priority, int num_tensors, int root_rank = -1,
+                                 int priority, int num_tensors,
+                                 int process_set_id = 0,
+                                 int root_rank = -1,
                                  bool average = true,
                                  NDArray* splits = nullptr,
                                  NDArray* output_received_splits = nullptr,
@@ -248,9 +253,11 @@ inline void PushHorovodOperation(OperationType op_type, NDArray* const * inputs,
     received_splits_tensor = std::make_shared<NDArray>(*output_received_splits);
   }
 
-  auto ops_param = CreateMpiOpsParam(std::move(input_copies), std::move(output_copies),
-    std::move(outputs_vec), cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names), root_rank,
-    average, splits_tensor, received_splits_tensor, prescale_factor, postscale_factor);
+  auto ops_param = CreateMpiOpsParam(
+      std::move(input_copies), std::move(output_copies), std::move(outputs_vec),
+      cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names),
+      root_rank, average, splits_tensor, received_splits_tensor,
+      prescale_factor, postscale_factor, process_set_id);
 
   // Not in-place
   if (!inplace) {
@@ -284,6 +291,7 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   auto prescale_factor = ops_param->prescale_factor;
   auto postscale_factor = ops_param->postscale_factor;
   auto num_tensors = ops_param->cpu_input_tensors.size();
+  auto process_set_id = ops_param->process_set_id;
 
   std::vector<std::shared_ptr<Tensor>> hvd_cpu_buffers;
   std::vector<std::shared_ptr<OpContext>> hvd_contexts;
@@ -324,32 +332,34 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
 
   Status enqueue_result;
   switch (ops_param->op_type) {
-    case OperationType::ALLREDUCE:
-      enqueue_result = EnqueueTensorAllreduces(
-          hvd_contexts, hvd_cpu_buffers, hvd_cpu_buffers, ready_event_lists, ops_param->op_names, device,
-          callbacks, (average) ? ReduceOp::AVERAGE : ReduceOp::SUM, prescale_factor, postscale_factor);
-      break;
-    case OperationType::ALLGATHER:
-      enqueue_result = EnqueueTensorAllgather(
-          hvd_contexts[0], hvd_cpu_buffers[0], ready_event_lists[0], ops_param->op_names[0], device,
-          callbacks[0]);
-      break;
-    case OperationType::BROADCAST:
-      enqueue_result = EnqueueTensorBroadcast(
-          hvd_contexts[0], hvd_cpu_buffers[0], hvd_cpu_buffers[0], ops_param->root_rank,
-          ready_event_lists[0], ops_param->op_names[0], device,
-          callbacks[0]);
-      break;
-    case OperationType::ALLTOALL:
-    {
-      auto hvd_splits = std::make_shared<MXTensor>(ops_param->splits_tensor.get());
-      enqueue_result = EnqueueTensorAlltoall(
-          hvd_contexts[0], hvd_cpu_buffers[0], hvd_splits, ready_event_lists[0], ops_param->op_names[0],
-          device, callbacks[0]);
-      break;
-    }
-    default:
-      throw std::logic_error("Unsupported Horovod operation type.");
+  case OperationType::ALLREDUCE:
+    enqueue_result = EnqueueTensorAllreduces(
+        hvd_contexts, hvd_cpu_buffers, hvd_cpu_buffers, ready_event_lists,
+        ops_param->op_names, device, callbacks,
+        (average) ? ReduceOp::AVERAGE : ReduceOp::SUM, prescale_factor,
+        postscale_factor, process_set_id);
+    break;
+  case OperationType::ALLGATHER:
+    enqueue_result = EnqueueTensorAllgather(
+        hvd_contexts[0], hvd_cpu_buffers[0], ready_event_lists[0],
+        ops_param->op_names[0], device, callbacks[0], process_set_id);
+    break;
+  case OperationType::BROADCAST:
+    enqueue_result = EnqueueTensorBroadcast(
+        hvd_contexts[0], hvd_cpu_buffers[0], hvd_cpu_buffers[0],
+        ops_param->root_rank, ready_event_lists[0], ops_param->op_names[0],
+        device, callbacks[0], process_set_id);
+    break;
+  case OperationType::ALLTOALL: {
+    auto hvd_splits =
+        std::make_shared<MXTensor>(ops_param->splits_tensor.get());
+    enqueue_result = EnqueueTensorAlltoall(
+        hvd_contexts[0], hvd_cpu_buffers[0], hvd_splits, ready_event_lists[0],
+        ops_param->op_names[0], device, callbacks[0], process_set_id);
+    break;
+  }
+  default:
+    throw std::logic_error("Unsupported Horovod operation type.");
   }
 
   ThrowIfError(enqueue_result);
@@ -357,13 +367,14 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
 
 inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* const * inputs,
                                           NDArray* const * outputs, const char* name,
-                                          int priority, int num_tensors, int root_rank = -1,
+                                          int priority, int num_tensors,
+                                          int process_set_id = 0,
+                                          int root_rank = -1,
                                           bool average = true,
                                           NDArray* splits = nullptr,
                                           NDArray* output_received_splits = nullptr,
                                           double prescale_factor = 1.0,
                                           double postscale_factor = 1.0) {
-
   auto op_type_name = GetOpTypeName(op_type);
 
   std::vector<std::shared_ptr<NDArray>> input_copies; //empty
@@ -413,9 +424,11 @@ inline void PushHorovodOperationCudaOnCPU(OperationType op_type, NDArray* const 
     received_splits_tensor = std::make_shared<NDArray>(*output_received_splits);
   }
 
-  auto ops_param = CreateMpiOpsParam(std::move(input_copies), std::move(output_copies),
-    std::move(outputs_vec), cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names), root_rank,
-    average, splits_tensor, received_splits_tensor, prescale_factor, postscale_factor);
+  auto ops_param = CreateMpiOpsParam(
+      std::move(input_copies), std::move(output_copies), std::move(outputs_vec),
+      cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names),
+      root_rank, average, splits_tensor, received_splits_tensor,
+      prescale_factor, postscale_factor, process_set_id);
 
   std::vector<void*> cpu_input_vars;
   std::vector<void*> cpu_output_vars;
@@ -467,7 +480,8 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
                                              int priority,
                                              double prescale_factor,
                                              double postscale_factor,
-                                             int num_tensors) {
+                                             int num_tensors,
+                                             int process_set_id) {
   MX_API_BEGIN();
 
 #if HAVE_ROCM
@@ -479,16 +493,20 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLREDUCE
   if (IsTensorOnCPU(inputs[0]) && IsTensorOnCPU(outputs[0])) {
-    PushHorovodOperation(OperationType::ALLREDUCE, inputs, outputs,
-                         name, priority, num_tensors, -1, average, nullptr, nullptr, prescale_factor, postscale_factor);
+    PushHorovodOperation(OperationType::ALLREDUCE, inputs, outputs, name,
+                         priority, num_tensors, process_set_id, -1, average,
+                         nullptr, nullptr, prescale_factor, postscale_factor,
+                         process_set_id);
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLREDUCE, inputs, outputs,
-                                  name, priority, num_tensors, -1, average, nullptr, nullptr, prescale_factor, postscale_factor);
+                                  name, priority, num_tensors, process_set_id,
+                                  -1, average, nullptr, nullptr,
+                                  prescale_factor, postscale_factor);
   }
 #else
-  PushHorovodOperation(OperationType::ALLREDUCE, inputs, outputs,
-                       name, priority, num_tensors, -1, average, nullptr,
-                       nullptr, prescale_factor, postscale_factor);
+  PushHorovodOperation(OperationType::ALLREDUCE, inputs, outputs, name,
+                       priority, num_tensors, process_set_id, -1, average,
+                       nullptr, nullptr, prescale_factor, postscale_factor);
 #endif
 
 #if HAVE_ROCM
@@ -504,20 +522,21 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
 
 extern "C" int horovod_mxnet_allgather_async(NDArray* input,
                                              NDArray* output,
-                                             const char* name, int priority) {
+                                             const char* name, int priority,
+                                             int process_set_id) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLGATHER
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLGATHER, &input, &output,
-                         name, priority, 1);
+                         name, priority, 1, process_set_id);
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLGATHER, &input, &output,
-                                  name, priority, 1);
+                                  name, priority, 1, process_set_id);
   }
 #else
   PushHorovodOperation(OperationType::ALLGATHER, &input, &output,
-                       name, priority, 1);
+                       name, priority, 1, process_set_id);
 #endif
 
   MX_API_END();
@@ -526,21 +545,22 @@ extern "C" int horovod_mxnet_allgather_async(NDArray* input,
 extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, int root_rank,
-                                             int priority) {
+                                             int priority,
+                                             int process_set_id) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_BROADCAST
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::BROADCAST, &input, &output,
-                         name, priority, 1, root_rank);
+                         name, priority, 1, process_set_id, root_rank);
 
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::BROADCAST, &input, &output,
-                                  name, priority, 1, root_rank);
+                                  name, priority, 1, process_set_id, root_rank);
   }
 #else
-  PushHorovodOperation(OperationType::BROADCAST, &input, &output,
-                       name, priority, 1, root_rank);
+  PushHorovodOperation(OperationType::BROADCAST, &input, &output, name,
+                       priority, 1, process_set_id, root_rank);
 #endif
 
   MX_API_END();
@@ -551,23 +571,25 @@ extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
                                             const char* name,
                                             NDArray* splits,
                                             NDArray* output_received_splits,
-                                            int priority) {
+                                            int priority,
+                                            int process_set_id) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLTOALL
   if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
     PushHorovodOperation(OperationType::ALLTOALL, &input, &output, name,
-                         priority, 1, -1, false, splits,
+                         priority, 1, process_set_id, -1, false, splits,
                          output_received_splits);
 
   } else {
     PushHorovodOperationCudaOnCPU(OperationType::ALLTOALL, &input, &output,
-                                  name, priority, 1, -1, false, splits,
-                                  output_received_splits);
+                                  name, priority, 1, process_set_id, -1, false,
+                                  splits, output_received_splits);
   }
 #else
   PushHorovodOperation(OperationType::ALLTOALL, &input, &output, name, priority,
-                       1, -1, false, splits, output_received_splits);
+                       1, process_set_id, -1, false, splits,
+                       output_received_splits);
 #endif
 
   MX_API_END();

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -51,6 +51,7 @@ struct MpiOpsParam {
   bool average;
   double prescale_factor;
   double postscale_factor;
+  int process_set_id;
   int del_count = 0;
 
   MpiOpsParam(std::vector<NDArraySharedPtr>&& input_tensors,
@@ -64,7 +65,8 @@ struct MpiOpsParam {
               NDArraySharedPtr splits_tensor,
               NDArraySharedPtr received_splits_tensor,
               double prescale_factor,
-              double postscale_factor)
+              double postscale_factor,
+              int process_set_id)
       : input_tensors(std::move(input_tensors)),
         output_tensors(std::move(output_tensors)),
         outputs(std::move(outputs)),
@@ -77,7 +79,8 @@ struct MpiOpsParam {
         received_splits_tensor(received_splits_tensor),
         average(average),
         prescale_factor(prescale_factor),
-        postscale_factor(postscale_factor) {
+        postscale_factor(postscale_factor),
+        process_set_id(process_set_id) {
   }
 };
 
@@ -92,10 +95,13 @@ inline MpiOpsParam* CreateMpiOpsParam(std::vector<NDArraySharedPtr>&& input_tens
                                       NDArraySharedPtr splits_tensor,
                                       NDArraySharedPtr received_splits_tensor,
                                       double prescale_factor,
-                                      double postscale_factor) {
-  return new MpiOpsParam(std::move(input_tensors), std::move(output_tensors), std::move(outputs),
-    cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names), root_rank, average,
-    splits_tensor, received_splits_tensor, prescale_factor, postscale_factor);
+                                      double postscale_factor,
+                                      int process_set_id) {
+  return new MpiOpsParam(
+      std::move(input_tensors), std::move(output_tensors), std::move(outputs),
+      cpu_input_tensors, cpu_output_tensors, op_type, std::move(op_names),
+      root_rank, average, splits_tensor, received_splits_tensor,
+      prescale_factor, postscale_factor, process_set_id);
 }
 
 void DeleteMpiOpsParam(void* param) {
@@ -109,20 +115,24 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
                                              int priority,
                                              double prescale_factor,
                                              double postscale_factor,
-                                             int num_tensors);
+                                             int num_tensors,
+                                             int process_set_id);
 extern "C" int horovod_mxnet_allgather_async(NDArray* input,
                                              NDArray* output,
-                                             const char* name, int priority);
+                                             const char* name, int priority,
+                                             int process_set_id);
 extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, int root_rank,
-                                             int priority);
+                                             int priority,
+                                             int process_set_id);
 extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
                                             NDArray* output,
                                             const char* name,
                                             NDArray* splits,
                                             NDArray* output_received_splits,
-                                            int priority);
+                                            int priority,
+                                            int process_set_id);
 
 } // namespace mxnet
 } // namespace horovod

--- a/test/parallel/test_mxnet.py
+++ b/test/parallel/test_mxnet.py
@@ -47,6 +47,9 @@ except ImportError:
     _skip_enqueue_errors = False
     HAS_MXNET = False
 
+# Set environment variable to enable adding/removing process sets after initializing Horovod.
+os.environ["HOROVOD_DYNAMIC_PROCESS_SETS"] = "1"
+
 
 @pytest.mark.skipif(not HAS_MXNET, reason='MXNet unavailable')
 class MXTests(unittest.TestCase):
@@ -311,6 +314,61 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
+    def test_horovod_allreduce_process_sets(self):
+        """Test that the allreduce correctly sums 1D, 2D, 3D tensors if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+
+        dtypes = self.filter_supported_types(['int32',   'int64',
+                                              'float32', 'float64'])
+        dims = [1, 2, 3]
+        ctx = self._current_context()
+        count = 0
+        shapes = [(), (17), (17, 17), (17, 17, 17)]
+        for dtype, dim in itertools.product(dtypes, dims):
+            # MXNet uses gpu_id as part of the seed, so to get identical seeds
+            # we must set a context.
+            mx.random.seed(1234, ctx=ctx)
+            even_rank_tensor = mx.nd.random.uniform(-100, 100, shape=shapes[dim],
+                                                    ctx=ctx)
+            odd_rank_tensor = mx.nd.random.uniform(-100, 100, shape=shapes[dim],
+                                                   ctx=ctx)
+            if rank in even_ranks:
+                tensor = even_rank_tensor.astype(dtype)
+                summed = hvd.allreduce(tensor, average=False, name=str(count), process_set=even_set)
+                multiplied = tensor * len(even_ranks)
+            elif rank in odd_ranks:
+                tensor = odd_rank_tensor.astype(dtype)
+                summed = hvd.allreduce(tensor, average=False, name=str(count), process_set=odd_set)
+                multiplied = tensor * len(odd_ranks)
+            count += 1
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            max_process_set_size = max(len(even_ranks), len(odd_ranks))
+            if max_process_set_size <= 3 or dtype in ['int32', 'int64']:
+                threshold = 0
+            elif max_process_set_size < 10:
+                threshold = 1e-4
+            elif max_process_set_size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert almost_equal(summed.asnumpy(), multiplied.asnumpy(), atol=threshold), \
+                f'hvd.allreduce produces incorrect results: {hvd.rank()} {count} {dtype} {dim}'
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
     def test_horovod_allreduce_type_error(self):
         """Test that the allreduce raises an error if different ranks try to
            send tensors of different type."""
@@ -503,6 +561,64 @@ class MXTests(unittest.TestCase):
                 for t1, t2 in zip(tensors, multiplied)]), \
                 f'hvd.grouped_allreduce_ produces incorrect results: {hvd.rank()} {count} {dtype} {dim}'
 
+    def test_horovod_grouped_allreduce_process_sets(self):
+        """Test that the grouped allreduce correctly sums 1D, 2D, 3D tensors if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+
+        dtypes = self.filter_supported_types(['int32',   'int64',
+                                              'float32', 'float64'])
+        dims = [1, 2, 3]
+        ctx = self._current_context()
+        count = 1
+        shapes = [(), (17), (17, 17), (17, 17, 17)]
+        for dtype, dim in itertools.product(dtypes, dims):
+            mx.random.seed(1234, ctx=ctx)
+
+            even_rank_tensors = [mx.nd.random.uniform(-100, 100, shape=shapes[dim],
+                                                      ctx=ctx) for _ in range(5)]
+            odd_rank_tensors = [mx.nd.random.uniform(-100, 100, shape=shapes[dim],
+                                                     ctx=ctx) for _ in range(5)]
+
+            if rank in even_ranks:
+                tensors = [tensor.astype(dtype) for tensor in even_rank_tensors]
+                multiplied = [tensor * len(even_ranks) for tensor in tensors]
+                summed = hvd.grouped_allreduce(tensors, average=False, name=str(count),
+                                               process_set=even_set)
+            elif rank in odd_ranks:
+                tensors = [tensor.astype(dtype) for tensor in odd_rank_tensors]
+                multiplied = [tensor * len(odd_ranks) for tensor in tensors]
+                summed = hvd.grouped_allreduce(tensors, average=False, name=str(count),
+                                               process_set=odd_set)
+            count += 1
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            max_process_set_size = max(len(even_ranks), len(odd_ranks))
+            if max_process_set_size <= 3 or dtype in ['int32', 'int64']:
+                threshold = 0
+            elif max_process_set_size < 10:
+                threshold = 1e-4
+            elif max_process_set_size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert all([almost_equal(t1.asnumpy(), t2.asnumpy(), atol=threshold)
+                for t1, t2 in zip(summed, multiplied)]), \
+                f'hvd.grouped_allreduce produces incorrect results: {hvd.rank()} {count} {dtype} {dim}'
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
     @unittest.skipUnless(has_gpu, "no gpu detected")
     @pytest.mark.skipif(_skip_enqueue_errors,
                         reason="Skip enqueue errors for MXNet version < 1.5.0")
@@ -648,6 +764,70 @@ class MXTests(unittest.TestCase):
                 print("comparison", hvd.rank(), tensor_dict[i] == root_dict[i])
             assert same(tensor_dict[i].asnumpy(), root_dict[i].asnumpy()), \
                 'hvd.broadcast_parameters produces incorrect broadcasted tensor'
+
+    def test_horovod_broadcast_process_sets(self):
+        """Test that the broadcast correctly broadcasts 1D, 2D, 3D tensors if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+        if rank in even_ranks:
+            set_size = len(even_ranks)
+            set_ranks = even_ranks
+            this_set = even_set
+        elif rank in odd_ranks:
+            set_size = len(odd_ranks)
+            set_ranks = odd_ranks
+            this_set = odd_set
+
+        dtypes = ['int32',   'int64',
+                  'float32', 'float64']
+        dims = [1, 2, 3]
+        ctx = self._current_context()
+        count = 0
+        shapes = [(), (17), (17, 17), (17, 17, 17)]
+        root_ranks = list(set_ranks)
+        for dtype, dim, root_rank in itertools.product(dtypes, dims,
+                                                       root_ranks):
+            tensor = mx.nd.ones(shapes[dim], ctx=ctx) * rank
+            root_tensor = mx.nd.ones(shapes[dim], ctx=ctx) * root_rank
+            tensor = tensor.astype(dtype)
+            root_tensor = root_tensor.astype(dtype)
+
+            broadcast_tensor = hvd.broadcast(tensor, root_rank=root_rank,
+                                             name=str(count),
+                                             process_set=this_set)
+            if rank != root_rank:
+                if same(tensor.asnumpy(), root_tensor.asnumpy()):
+                    print("broadcast", count, dtype, dim,
+                          mx.nd.max(tensor == root_tensor))
+                    print("tensor", hvd.rank(), tensor)
+                    print("root_tensor", hvd.rank(), root_tensor)
+                    print("comparison", hvd.rank(), tensor == root_tensor)
+                assert not same(tensor.asnumpy(), root_tensor.asnumpy()), \
+                    'hvd.broadcast modifies source tensor'
+            if not same(broadcast_tensor.asnumpy(), root_tensor.asnumpy()):
+                print("broadcast", count, dtype, dim)
+                print("broadcast_tensor", hvd.rank(), broadcast_tensor)
+                print("root_tensor", hvd.rank(), root_tensor)
+                print("comparison", hvd.rank(),
+                      broadcast_tensor == root_tensor)
+            assert same(broadcast_tensor.asnumpy(), root_tensor.asnumpy()), \
+                'hvd.broadcast produces incorrect broadcasted tensor'
+            count += 1
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
 
     def test_horovod_broadcast_error(self):
         """Test that the broadcast returns an error if any dimension besides
@@ -802,6 +982,49 @@ class MXTests(unittest.TestCase):
                 assert rank_tensor.min() == i
                 assert rank_tensor.max() == i
 
+    def test_horovod_allgather_process_sets(self):
+        """Test that the allgather correctly gathers 1D, 2D, 3D tensors if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+        if rank in even_ranks:
+            set_size = len(even_ranks)
+            set_ranks = even_ranks
+            this_set = even_set
+        elif rank in odd_ranks:
+            set_size = len(odd_ranks)
+            set_ranks = odd_ranks
+            this_set = odd_set
+
+        dtypes = ['int32',   'int64',
+                  'float32', 'float64']
+        dims = [1, 2, 3]
+        ctx = self._current_context()
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensor = mx.ndarray.ones(shape=[17] * dim, dtype=dtype, ctx=ctx) * rank
+            gathered = hvd.allgather(tensor, process_set=this_set)
+
+            assert list(gathered.shape) == [17 * set_size] + [17] * (dim - 1)
+
+            for i in range(set_size):
+                rank_tensor = gathered[i * 17:(i + 1) * 17]
+                assert list(rank_tensor.shape) == [17] * dim, \
+                    'hvd.allgather produces incorrect gathered shape'
+                value = set_ranks[i]
+                assert rank_tensor.min() == value, 'hvd.allgather produces incorrect gathered tensor'
+                assert rank_tensor.max() == value, 'hvd.allgather produces incorrect gathered tensor'
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
+
     def test_horovod_allgather_error(self):
         """Test that the allgather returns an error if any dimension besides
         the first is different among the tensors being gathered."""
@@ -946,6 +1169,60 @@ class MXTests(unittest.TestCase):
             assert collected.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
             assert collected.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
             assert collected.size == size * (size + 1) // 2 * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+
+
+    def test_horovod_alltoall_process_sets(self):
+        """Test that the alltoall correctly distributes 1D, 2D, and 3D tensors
+        if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # This test does not apply if NCCL version < 2.7.0
+        if hvd.nccl_built() and hvd.nccl_built() < 2700:
+            self.skipTest("NCCL-based Alltoall requires NCCL version >= 2.7.0.")
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+        if rank in even_ranks:
+            set_size = len(even_ranks)
+            set_ranks = even_ranks
+            this_set = even_set
+        elif rank in odd_ranks:
+            set_size = len(odd_ranks)
+            set_ranks = odd_ranks
+            this_set = odd_set
+
+        dtypes = ['int32',   'int64',
+                  'float32', 'float64']
+        dims = [1,2,3]
+        ctx = self._current_context()
+        for dtype, dim in itertools.product(dtypes, dims):
+            vals = []
+            for i in set_ranks:
+              vals += [i] * (rank + 1)
+
+            tensor = mx.ndarray.array(vals, dtype=dtype, ctx=ctx)
+            for _ in range(dim - 1):
+              tensor = mx.ndarray.expand_dims(tensor, axis=1)
+              tensor = mx.ndarray.concat(tensor, tensor, dim=1)
+
+            splits = mx.ndarray.array([rank + 1] * set_size, dtype='int32', ctx=ctx)
+            collected, received_splits = hvd.alltoall(tensor, splits, process_set=this_set)
+
+            assert collected.min() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.max() == rank, 'hvd.alltoall produces incorrect collected tensor'
+            assert collected.size == sum(rk + 1 for rk in set_ranks) * 2**(dim - 1), 'hvd.alltoall collected wrong number of values'
+            self.assertSequenceEqual(received_splits.asnumpy().tolist(), [rk + 1 for rk in set_ranks],
+                                     "hvd.alltoall returned incorrect received_splits")
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
 
     def test_horovod_alltoall_type_error(self):
         """Test that the alltoall returns an error if the tensor types differ

--- a/test/parallel/test_mxnet.py
+++ b/test/parallel/test_mxnet.py
@@ -1530,8 +1530,11 @@ class MXTests(unittest.TestCase):
         g = mx.random.uniform(shape=shape, ctx=ctx, dtype=np.float32)
         
         # Update that is only averaged over even_set
-        opt.update([0], [w], [g], [opt.create_state(0, w)])
-        
+        if LooseVersion(mx.__version__) >= LooseVersion('2.0.0'):
+            opt.update([0], [w], [g], [opt.create_state(0, w)])
+        else:
+            opt.update(0, w, g, opt.create_state(0, w))
+
         all_w = hvd.allgather(w, process_set=this_set)
         if this_set == even_set:
             for start in range(0, all_w.size, w.size):


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This is a straightforward extension of #2839, adding the process set feature to the MXNet API.

Included are the ops `allgather`, `allreduce`, `alltoall`, `broadcast`, and `grouped_allreduce`, as well as the `DistributedOptimizer`.

There's also the `DistributedTrainer` that I didn't look into. I don't have much experience working with MXNet, but it seems that a Gluon Trainer would be a higher level concept meant to operate on an entire neural net. In that case adding an overall `process_set` argument might not be the right call as users will typically want to non-globally aggregate the gradients for just a subset of their parameters, not for the entire model.
