### PR TITLE
Fix jq query for CI (Fork) workflow

### DIFF
--- a/.github/workflows/ci-fork.yaml
+++ b/.github/workflows/ci-fork.yaml
@@ -27,7 +27,7 @@ jobs:
         id: workflow-conclusion
         run: |
           curl -s "${{ github.event.workflow_run.jobs_url }}" > workflow_run_jobs.json
-          conclusion=$(jq -r '.jobs[] | select(.name | startswith("Build and Test (") | .conclusion' workflow_run_jobs.json | sort | uniq | paste -sd "," -)
+          conclusion=$(jq -r '.jobs[] | select(.name | startswith("Build and Test (")) | .conclusion' workflow_run_jobs.json | sort | uniq | paste -sd "," -)
           echo "::set-output name=build-and-test::${conclusion}"
         shell: bash
 


### PR DESCRIPTION
The CI (Fork) workflow is broken, it cannot process the workflow result JSON because the jq query is broken.