### PR TITLE
Fine-tune Github CI workflow conditions

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -144,7 +144,9 @@ def main():
                 f'    name: "Init Workflow"\n'
                 f'    runs-on: ubuntu-latest\n'
                 f'    outputs:\n'
-                f'      run_builds_and_tests: ${{{{ steps.tests.output.needed }}}}\n'
+                f"      run_at_all: github.event_name != 'schedule' || github.repository == 'horovod/horovod'\n"
+                f"      # if we don't get a clear 'false', we fall back to building and testing\n"
+                f"      run_builds_and_tests: ${{{{ steps.tests.output.needed }}}} != 'false'\n"
                 f'\n'
                 f'    steps:\n'
                 f'      - name: Checkout\n'
@@ -193,7 +195,9 @@ def main():
         return (f'  {id}:\n'
                 f'    name: "{name} (${{{{ matrix.image }}}})"\n'
                 f'    needs: [{", ".join(needs)}]\n'
-                f'    if: needs.init-workflow.outputs.run_builds_and_tests != \'false\'\n'
+                f'    if: >\n'
+                f'      needs.init-workflow.outputs.run_at_all &&\n'
+                f'      needs.init-workflow.outputs.run_builds_and_tests\n'
                 f'    runs-on: ubuntu-latest\n'
                 f'\n'
                 f'    strategy:\n'
@@ -338,7 +342,9 @@ def main():
         return (f'  {id}:\n'
                 f'    name: "{name} (${{{{ matrix.image }}}}-macos)"\n'
                 f'    needs: [{", ".join(needs)}]\n'
-                f'    if: needs.init-workflow.outputs.run_builds_and_tests != \'false\'\n'
+                f'    if: >\n'
+                f'      needs.init-workflow.outputs.run_at_all &&\n'
+                f'      needs.init-workflow.outputs.run_builds_and_tests\n'
                 f'    runs-on: macos-latest\n'
                 f'\n'
                 f'    strategy:\n'
@@ -436,7 +442,8 @@ def main():
                 f'    runs-on: ubuntu-latest\n'
                 f'    if: >\n'
                 f'      github.repository == \'horovod/horovod\' &&\n'
-                f'      needs.init-workflow.outputs.run_builds_and_tests != \'false\' &&\n'
+                f'      needs.init-workflow.outputs.run_at_all &&\n'
+                f'      needs.init-workflow.outputs.run_builds_and_tests &&\n'
                 f'      ( github.event_name != \'pull_request\' || github.event.pull_request.head.repo.full_name == github.repository )\n'
                 f'\n'
                 f'    steps:\n'
@@ -489,6 +496,7 @@ def main():
                 f'    # only run this job on push events or when the event does not run in a fork repository\n'
                 f'    if: >\n'
                 f'      ( success() || failure() ) &&\n'
+                f'      needs.init-workflow.outputs.run_at_all &&\n'
                 f'      ( github.event_name == \'push\' || ! github.event.head.repo.fork )\n'
                 f'\n'
                 f'    steps:\n'
@@ -512,13 +520,14 @@ def main():
         return (f'  docker-config:\n'
                 f'    name: Configure docker build\n'
                 f'    needs: [{", ".join(needs)}]\n'
-                f"    # build-and-test-cpu, build-gpu and buildkite might have been skipped (needs.init-workflow.outputs.run_builds_and_tests == 'false')\n"
+                f"    # build-and-test-cpu, build-gpu and buildkite might have been skipped (! needs.init-workflow.outputs.run_builds_and_tests)\n"
                 f'    # buildkite might have been skipped (workflow runs for a fork PR)\n'
                 f'    # we still want to build docker images in these cases\n'
                 f'    if: >\n'
                 f'      always() &&\n'
-                f"      needs.init-workflow.result == 'success' && (\n"
-                f"        needs.init-workflow.outputs.run_builds_and_tests == 'false' ||\n"
+                f"      needs.init-workflow.result == 'success' &&\n"
+                f"      needs.init-workflow.outputs.run_at_all && (\n"
+                f"        ! needs.init-workflow.outputs.run_builds_and_tests ||\n"
                 f"        needs.build-and-test.result == 'success' &&\n"
                 f"        ( needs.buildkite.result == 'success' || needs.buildkite.result == 'skipped' )\n"
                 f'      )\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,7 +283,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         # AWS credentials are used to authenticate against AWS ECR to pull and push test images
         # We can only authenticate when running on Horovod repo (not a fork)
-        if: github.repository == 'horovod/horovod'
+        if: >
+          github.repository == 'horovod/horovod' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
         continue-on-error: true
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1799,7 +1801,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         # AWS credentials are used to authenticate against AWS ECR to pull and push test images
         # We can only authenticate when running on Horovod repo (not a fork)
-        if: github.repository == 'horovod/horovod'
+        if: >
+          github.repository == 'horovod/horovod' &&
+          ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
         continue-on-error: true
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -3336,8 +3340,9 @@ jobs:
     needs: [init-workflow, build-and-test]
     runs-on: ubuntu-latest
     if: >
+      github.repository == 'horovod/horovod' &&
       needs.init-workflow.outputs.run_builds_and_tests != 'false' &&
-      ( github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository )
+      ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
 
     steps:
       - name: Trigger Buildkite Pipeline
@@ -3368,12 +3373,14 @@ jobs:
           name: Unit Test Results - GPUs on Builtkite
           path: artifacts/Unit Test Results - GPUs on Buildkite/**/*.xml
 
-      - name: Escalate Buildkite job state
+      - name: Check Buildkite job state
         if: >
           always() &&
           steps.download.conclusion == 'success' &&
           steps.download.outputs.build-state != 'passed'
-        run: exit 1
+        run: |
+          echo "::warning::Buildkite pipeline did not pass: ${{ steps.build.outputs.url }}"
+          exit 1
 
   publish-test-results:
     name: "Publish Unit Tests Results"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
     name: "Init Workflow"
     runs-on: ubuntu-latest
     outputs:
-      run_builds_and_tests: ${{ steps.tests.output.needed }}
+      run_at_all: github.event_name != 'schedule' || github.repository == 'horovod/horovod'
+      # if we don't get a clear 'false', we fall back to building and testing
+      run_builds_and_tests: ${{ steps.tests.output.needed }} != 'false'
 
     steps:
       - name: Checkout
@@ -69,7 +71,9 @@ jobs:
   build-and-test:
     name: "Build and Test (${{ matrix.image }})"
     needs: [init-workflow]
-    if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
+    if: >
+      needs.init-workflow.outputs.run_at_all &&
+      needs.init-workflow.outputs.run_builds_and_tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -1729,7 +1733,9 @@ jobs:
   build-and-test-heads:
     name: "Build and Test heads (${{ matrix.image }})"
     needs: [init-workflow, build-and-test]
-    if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
+    if: >
+      needs.init-workflow.outputs.run_at_all &&
+      needs.init-workflow.outputs.run_builds_and_tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -3247,7 +3253,9 @@ jobs:
   build-and-test-macos:
     name: "Build and Test macOS (${{ matrix.image }}-macos)"
     needs: [init-workflow, build-and-test]
-    if: needs.init-workflow.outputs.run_builds_and_tests != 'false'
+    if: >
+      needs.init-workflow.outputs.run_at_all &&
+      needs.init-workflow.outputs.run_builds_and_tests
     runs-on: macos-latest
 
     strategy:
@@ -3341,7 +3349,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.repository == 'horovod/horovod' &&
-      needs.init-workflow.outputs.run_builds_and_tests != 'false' &&
+      needs.init-workflow.outputs.run_at_all &&
+      needs.init-workflow.outputs.run_builds_and_tests &&
       ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
 
     steps:
@@ -3391,6 +3400,7 @@ jobs:
     # only run this job on push events or when the event does not run in a fork repository
     if: >
       ( success() || failure() ) &&
+      needs.init-workflow.outputs.run_at_all &&
       ( github.event_name == 'push' || ! github.event.head.repo.fork )
 
     steps:
@@ -3409,13 +3419,14 @@ jobs:
   docker-config:
     name: Configure docker build
     needs: [init-workflow, build-and-test, buildkite]
-    # build-and-test-cpu, build-gpu and buildkite might have been skipped (needs.init-workflow.outputs.run_builds_and_tests == 'false')
+    # build-and-test-cpu, build-gpu and buildkite might have been skipped (! needs.init-workflow.outputs.run_builds_and_tests)
     # buildkite might have been skipped (workflow runs for a fork PR)
     # we still want to build docker images in these cases
     if: >
       always() &&
-      needs.init-workflow.result == 'success' && (
-        needs.init-workflow.outputs.run_builds_and_tests == 'false' ||
+      needs.init-workflow.result == 'success' &&
+      needs.init-workflow.outputs.run_at_all && (
+        ! needs.init-workflow.outputs.run_builds_and_tests ||
         needs.build-and-test.result == 'success' &&
         ( needs.buildkite.result == 'success' || needs.buildkite.result == 'skipped' )
       )


### PR DESCRIPTION
Some more fine-tuned conditions for the CI workflow:
- the `schedule` event should not run every day on our thousands of fork repos at all
- buildkite job should also be triggered on `schedule` event
- print out buildkite build url when those tests fail
- provide AWS ECR credentials only horovod repo and not for fork PRs