### PR TITLE
Remove MetricAverageCallback warning on tf >= 2.5

### DIFF
--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -54,7 +54,7 @@ class MetricAverageCallbackImpl(object):
         self.allreduce_ops = {}
         self.device = device
 
-        if LooseVersion(tf.__version__) >= LooseVersion("2.3"):
+        if LooseVersion("2.3") <= LooseVersion(tf.__version__) < LooseVersion("2.5"):
             warnings.warn(
                 "Some callbacks may not have access to the averaged metrics, "
                 "see https://github.com/horovod/horovod/issues/2440")


### PR DESCRIPTION
## Description

Fixes #2440 
Remove warning in MetricsAverageCallback after TF 2.5 after https://github.com/tensorflow/tensorflow/issues/41851
The keras history is now correct, however that doesn't seem to have fixed the progress bar (if that was working before...)

