### PR TITLE
Support incremental rebuilds.

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -55,10 +55,16 @@ From *inside* the Horovod root directory, remove any previous build artifacts an
 .. code-block:: bash
 
     $ rm -rf build/ dist/
-    $ HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_TENSORFLOW=1 python setup.py install
+    $ HOROVOD_WITH_PYTORCH=1 \
+      HOROVOD_WITH_TENSORFLOW=1 \
+      HOROVOD_BUILD_IN_REPO="$PWD" \
+      python setup.py install
 
 Set ``HOROVOD_WITHOUT_[FRAMEWORK]=1`` to disable building Horovod plugins for that framework.
 This is useful when you’re testing a feature of one framework in particular and wish to save time.
+
+The ``HOROVOD_BUILD_IN_REPO`` enables incremental rebuilds by storing the intermediate build artifacts
+as subdirectories of the source repository, rather than in the temporary pip install directory.
 
 For a debug build with checked assertions etc. replace the invocation of setup.py by:
 

--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,21 @@ class custom_build_ext(build_ext):
             cmake_build_args += ['--'] + make_args
 
         cmake_build_dir = os.path.join(self.build_temp, config)
+        cmake_src_dir = self.extensions[0].cmake_lists_dir
+        repo_dir = os.getenv('HOROVOD_BUILD_IN_REPO')
+        if repo_dir:
+            new_build_dir = os.path.join(repo_dir, os.path.basename(cmake_build_dir))
+            print("replacing", cmake_build_dir, "with", new_build_dir)
+            cmake_build_dir = new_build_dir
+            print("replacing", cmake_src_dir, "with", repo_dir)
+            cmake_src_dir = repo_dir
+
         if not os.path.exists(cmake_build_dir):
             os.makedirs(cmake_build_dir)
 
         # Config and build the extension
         try:
-            subprocess.check_call([cmake_bin, self.extensions[0].cmake_lists_dir] + cmake_args,
+            subprocess.check_call([cmake_bin, cmake_src_dir] + cmake_args,
                                   cwd=cmake_build_dir)
             subprocess.check_call([cmake_bin, '--build', '.'] + cmake_build_args,
                                   cwd=cmake_build_dir)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change? *I tested incremental builds manually*
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Support a `HOROVOD_BUILD_IN_REPO` option that will cause the `cmake` commands to point to the repository for the source directory, and to a subdirectory of the repository for the build directory.  As a result, sequential builds can use pre-existing build artifacts to speed up build time.

On my machine, I see around 10x speedups when altering a C++ file:

|task |time  |
--- | ---
|clean build|130s|
|noop rebuild|6s|
|edit to common/operations.cc|12s|

Fixes #1520.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.