### PR TITLE
Disable those MXNet tests that fail with 2.0

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -204,7 +204,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly" ]]; then \
 
 # Install MXNet (nightly).
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly" ]]; then \
-        pip install --no-cache-dir --pre mxnet==2.0.0b20210620 -f https://dist.mxnet.io/python/all; \
+        pip install --no-cache-dir --pre mxnet -f https://dist.mxnet.io/python/all; \
     fi
 
 # Install Horovod.

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -176,7 +176,7 @@ RUN if [[ ${PYTORCH_PACKAGE} == "torch-nightly-cu"* ]]; then \
 
 # Install MXNet (nightly).
 RUN if [[ ${MXNET_PACKAGE} == "mxnet-nightly-cu"* ]]; then \
-        pip install --no-cache-dir --pre ${MXNET_PACKAGE/-nightly/}==2.0.0b20210620 -f https://dist.mxnet.io/python/${MXNET_PACKAGE/#mxnet-nightly-/}; \
+        pip install --no-cache-dir --pre ${MXNET_PACKAGE/-nightly/} -f https://dist.mxnet.io/python/${MXNET_PACKAGE/#mxnet-nightly-/}; \
     fi
 
 # Install Horovod.

--- a/test/parallel/test_mxnet.py
+++ b/test/parallel/test_mxnet.py
@@ -41,6 +41,10 @@ try:
     # those tests for versions earlier than 1.5.0.
     _skip_enqueue_errors = LooseVersion(mx.__version__) < LooseVersion('1.5.0')
 
+    # MXNet 2.0.0 has breaking changes so that some tests need to be adjusted
+    # https://github.com/horovod/horovod/issues/3061
+    _skip_mxnet2_breaking_changes = LooseVersion(mx.__version__) >= LooseVersion('2.0.0')
+
     HAS_MXNET = True
 except ImportError:
     has_gpu = False
@@ -898,6 +902,8 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
+    @pytest.mark.skipif(_skip_mxnet2_breaking_changes,
+                        reason="https://github.com/horovod/horovod/issues/3061")
     def test_horovod_broadcast_deferred_init_parameters(self):
         """Test that the deferred initialized parameters are broadcasted."""
         hvd.init()
@@ -1325,6 +1331,8 @@ class MXTests(unittest.TestCase):
         except (MXNetError, ValueError):
             pass
 
+    @pytest.mark.skipif(_skip_mxnet2_breaking_changes,
+                        reason="https://github.com/horovod/horovod/issues/3061")
     def test_two_trainer(self):
         """Test using horovod allreduce in MXNet Gluon trainer."""
         from mxnet import gluon
@@ -1384,8 +1392,8 @@ class MXTests(unittest.TestCase):
         except (MXNetError, RuntimeError):
             pass
 
-
     @unittest.skipUnless(has_gpu, "no gpu detected")
+    @unittest.skipIf(_skip_mxnet2_breaking_changes, "https://github.com/horovod/horovod/issues/3061")
     def test_gluon_trainer(self):
         """Test using horovod allreduce in MXNet Gluon trainer."""
         from mxnet import gluon


### PR DESCRIPTION
- Reverts #3034 and #3045 (partially)
- Disables two tests for MXNet >= 2.0
- See #3061

Superseeded by #3066