### PR TITLE
Estimator/Keras: use chkpt and logs path in remote store

### DIFF
--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -201,7 +201,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                 print(f"Training parameters: Epochs: {epochs}, Scaled lr: {scaled_lr}\n"
                       f"Train rows: {train_rows}, Train batch size: {batch_size}, Train_steps_per_epoch: {steps_per_epoch}\n"
                       f"Val rows: {val_rows}, Val batch size: {val_batch_size}, Val_steps_per_epoch: {validation_steps}\n"
-                      f"Checkpoint file: {ckpt_file}, Logs dir: {logs_dir}\n")
+                      f"Checkpoint file: {remote_store.checkpoint_path}, Logs dir: {remote_store.logs_path}\n")
             # In general, make_batch_reader is faster than make_reader for reading the dataset.
             # However, we found out that make_reader performs data transformations much faster than
             # make_batch_reader with parallel worker processes. Therefore, the default reader


### PR DESCRIPTION
Local checkpoint and logs files are pushed into remote store
destination. Print remote store path instead of local path in stdout.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
