### PR TITLE
Fixed spark keras "IsADirectoryError: [Errno 21] Is a directory: '/tmp/tmpn_eenlao/checkpoint'" error

### DIFF
--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -194,9 +194,17 @@ class AbstractFilesystemStore(Store):
         :return: the base 64 encoded model bytes of the checkpoint model.
         """
         from horovod.runner.common.util import codec
+        import tensorflow
+        from tensorflow import keras
+        from horovod.spark.keras.util import TFKerasUtil
 
-        model_bytes = self.read(ckpt_path)
-        return codec.dumps_base64(model_bytes)
+        if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
+            model_bytes = self.read(ckpt_path)
+            return codec.dumps_base64(model_bytes)
+        else:
+            with keras.utils.custom_object_scope(custom_objects):
+                model = keras.models.load_model(ckpt_path)
+            return TFKerasUtil.serialize_model(model)
 
     def write_text(self, path, text):
         with self.fs.open(self.get_localized_path(path), 'w') as f:

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -263,8 +263,13 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                             model = k.models.load_model(ckpt_file)
                     serialized_model = keras_utils.serialize_model(model)
                 else:
-                    with open(ckpt_file, 'rb') as f:
-                        serialized_model = codec.dumps_base64(f.read())
+                    if LooseVersion(tf.__version__) >= LooseVersion("2.0.0"):
+                        with k.utils.custom_object_scope(custom_objects):
+                            model = k.models.load_model(ckpt_file)
+                        serialized_model = keras_utils.serialize_model(model)
+                    else:    
+                        with open(ckpt_file, 'rb') as f:
+                            serialized_model = codec.dumps_base64(f.read())
 
                 return history.history, serialized_model, hvd.size()
     return train

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -72,7 +72,6 @@ def get_mock_fit_fn():
     return fit
 
 
-@pytest.mark.skipif(LooseVersion(tf.__version__) >= LooseVersion('2.0.0'), reason='TensorFlow v1 tests')
 class SparkKerasTests(tf.test.TestCase):
     def __init__(self, *args, **kwargs):
         super(SparkKerasTests, self).__init__(*args, **kwargs)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
While using horovod v0.22.1 with tensorflow v2.4.2, a checkpoint error occurs during training. The error logs have been mentioned in #2988. This pr fixes the issue with loading the saved checkpoints for tensorflow version greater than 2.0.0

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
