### PR TITLE
separate prediction from transform

### DIFF
--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -542,7 +542,7 @@ class TorchModel(HorovodModel, TorchEstimatorParamsWritable, TorchEstimatorParam
         else:
             return self._get_optimizer()
 
-    def _get_perdiction(self, model, row, feature_cols, input_shapes):
+    def _get_prediction(self, model, row, feature_cols, input_shapes):
         # Note: if the col is SparseVector, torch.tensor(col) correctly converts it to a
         # dense torch tensor.
         data = [torch.tensor([row[col]]).reshape(shape) for
@@ -578,13 +578,8 @@ class TorchModel(HorovodModel, TorchEstimatorParamsWritable, TorchEstimatorParam
             for row in rows:
                 fields = row.asDict().copy()
 
-                # # Note: if the col is SparseVector, torch.tensor(col) correctly converts it to a
-                # # dense torch tensor.
-                # data = [torch.tensor([row[col]]).reshape(shape) for
-                #         col, shape in zip(feature_cols, input_shapes)]
-
                 with torch.no_grad():
-                    preds = self._get_perdiction(model, row, feature_cols, input_shapes)
+                    preds = self._get_prediction(model, row, feature_cols, input_shapes)
 
                 if not isinstance(preds, list) and not isinstance(preds, tuple):
                     preds = [preds]


### PR DESCRIPTION
## Description
Lightning transformer, separate the model prediction function out of _transform function. So subclass can override the behaivor of how model is called. 