### PR TITLE
Skip TF>=2.6.0 tests for test_spark_keras.py

### DIFF
--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -72,6 +72,9 @@ def get_mock_fit_fn():
     return fit
 
 
+#PR3099 [https://github.com/horovod/horovod/pull/3099] doesn't fix
+#Tensorflow>=2.6.0 tests
+@pytest.mark.skipif(LooseVersion(tf.__version__) >= LooseVersion('2.6.0'), reason='TensorFlow>=2.6.0 tests')
 class SparkKerasTests(tf.test.TestCase):
     def __init__(self, *args, **kwargs):
         super(SparkKerasTests, self).__init__(*args, **kwargs)


### PR DESCRIPTION
[PR#3099](https://github.com/horovod/horovod/pull/3099) fixes checkpoint folder issue, but tests cannot pass for TF>=2.6.0.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
