### PR TITLE
CMake: skip TF XLA support for OSX

### DIFF
--- a/cmake/Modules/FindTensorflow.cmake
+++ b/cmake/Modules/FindTensorflow.cmake
@@ -21,8 +21,10 @@ if (LEN EQUAL "4")
     list(GET Tensorflow_OUTPUT 2 Tensorflow_LIBRARIES)
     string(REPLACE " " ";" Tensorflow_LIBRARIES_LIST "${Tensorflow_LIBRARIES}")
     list(GET Tensorflow_LIBRARIES_LIST 0 Tensorflow_LIB_PATH)
-    if (Tensorflow_VERSION VERSION_GREATER_EQUAL "2.6")
+    if ((Tensorflow_VERSION VERSION_GREATER_EQUAL "2.6") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
         # XLA implementations are in _pywrap_tensorflow_internal.so
+        # See https://github.com/horovod/horovod/issues/3132
+        # _pywrap_tensorflow_internal.so is not working correctly for linking on OSX
         set(Tensorflow_LIBRARIES "${Tensorflow_LIBRARIES} ${Tensorflow_LIB_PATH}/python/ -l:_pywrap_tensorflow_internal.so")
     endif()
     message("Tensorflow_LIBRARIES := ${Tensorflow_LIBRARIES}")

--- a/horovod/tensorflow/CMakeLists.txt
+++ b/horovod/tensorflow/CMakeLists.txt
@@ -59,7 +59,11 @@ set(Tensorflow_CXX11 ${Tensorflow_CXX11} PARENT_SCOPE)
 
 # TF SOURCES
 list(APPEND TF_SOURCES "${PROJECT_SOURCE_DIR}/horovod/tensorflow/mpi_ops.cc")
-list(APPEND TF_SOURCES "${PROJECT_SOURCE_DIR}/horovod/tensorflow/xla_mpi_ops.cc")
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # See https://github.com/horovod/horovod/issues/3132
+  # Disable XLA for OSX
+  list(APPEND TF_SOURCES "${PROJECT_SOURCE_DIR}/horovod/tensorflow/xla_mpi_ops.cc")
+endif()
 
 # Create library
 set_output_dir()


### PR DESCRIPTION
_pywrap_tensorflow_internal.so is missing on OSX.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3132 .

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
