### PR TITLE
Make RayExecutor use the current placement group if one exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- By default, RayExecutor will now use the current placement group instead of always creating a new one.
+- By default, RayExecutor will now use the current placement group instead of always creating a new one. ([#3134](https://github.com/horovod/horovod/pull/3134))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- By default, RayExecutor will now use the current placement group instead of always creating a new one.
+
 ### Deprecated
 
 ### Removed

--- a/docs/mocks.py
+++ b/docs/mocks.py
@@ -60,6 +60,8 @@ MOCK_MODULES = [
     'ray',
     'ray.exceptions',
     'ray.services',
+    'ray.util',
+    'ray.util.placement_group',
 
     'tensorflow',
     'tensorflow.python',

--- a/horovod/ray/runner.py
+++ b/horovod/ray/runner.py
@@ -11,7 +11,7 @@ import logging
 from horovod.runner.common.util import secret, timeout, hosts
 from horovod.runner.http.http_server import RendezvousServer
 from horovod.ray.utils import detect_nics, nics_to_env_var, map_blocking
-from horovod.ray.strategy import ColocatedStrategy, PackStrategy, PGStrategy
+from horovod.ray.strategy import ColocatedStrategy, PGStrategy
 logger = logging.getLogger(__name__)
 
 
@@ -404,7 +404,7 @@ class _ExecutorDriver:
                     "`use_current_placement_group=False`."
                 )
             num_workers = self.num_workers or self.num_workers_per_host * self.num_hosts
-            return PackStrategy(
+            return PGStrategy(
                 settings=self.settings,
                 num_workers=num_workers,
                 use_gpu=self.use_gpu,

--- a/horovod/ray/runner.py
+++ b/horovod/ray/runner.py
@@ -398,13 +398,20 @@ class _ExecutorDriver:
             try:
                 # Will try to get the current PG, otherwise
                 # will raise RuntimeError
-                return PGStrategy(
+                strategy = PGStrategy(
                     settings=self.settings,
-                    num_workers=self.num_workers,
+                    num_workers=self.num_workers if self.num_workers else self.num_hosts *
+                    self.num_workers_per_host,
                     use_gpu=self.use_gpu,
                     cpus_per_worker=self.cpus_per_worker,
                     gpus_per_worker=self.gpus_per_worker
                 )
+                logger.info(
+                    "Found an existing placement group, inheriting. "
+                    "You can disable this behavior by setting "
+                    "`use_current_placement_group=False`."
+                )
+                return strategy
             except RuntimeError:
                 pass
         if self.num_workers:

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -231,7 +231,6 @@ class PGStrategy(BaseStrategy):
         return self._num_workers
 
     def create_workers(self):
-        # Placement group has started. Now create the workers.
         self.workers = []
         remote_cls = ray.remote(BaseHorovodWorker)
 

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -247,9 +247,6 @@ class PGStrategy(BaseStrategy):
 
             self.workers.append(worker)
 
-        print(self.workers)
-        print(self._placement_group_bundles)
-
         if self.use_gpu:
             node_ids = ray.get(
                 [worker.node_id.remote() for worker in self.workers])

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -136,6 +136,31 @@ class ColocatedStrategy(BaseStrategy):
         return self.workers, self.get_node_workers(self.workers)
 
 
+def _get_worker_gpus(workers):
+    node_ids = ray.get(
+        [worker.node_id.remote() for worker in workers])
+    gpus = ray.get(
+        [worker.get_gpu_ids.remote() for worker in workers])
+    node_workers = defaultdict(list)
+    node_id_to_gpus = defaultdict(list)
+    for worker, node_id, worker_gpu_ids in zip(workers, node_ids,
+                                               gpus):
+        node_workers[node_id].append(worker)
+        node_id_to_gpus[node_id].extend(worker_gpu_ids)
+
+    futures = []
+    for node_id, gpu_ids in node_id_to_gpus.items():
+        all_ids = ",".join([str(gpu_id) for gpu_id in gpu_ids])
+
+        for worker in node_workers[node_id]:
+            futures.append(
+                worker.update_env_vars.remote({
+                    "CUDA_VISIBLE_DEVICES":
+                    all_ids
+                }))
+    ray.get(futures)
+
+
 class PackStrategy(BaseStrategy):
     """Packs workers together but does not guarantee balanced hosts."""
 
@@ -180,28 +205,7 @@ class PackStrategy(BaseStrategy):
             self.workers.append(worker)
 
         if self.use_gpu:
-            node_ids = ray.get(
-                [worker.node_id.remote() for worker in self.workers])
-            gpus = ray.get(
-                [worker.get_gpu_ids.remote() for worker in self.workers])
-            node_workers = defaultdict(list)
-            node_id_to_gpus = defaultdict(list)
-            for worker, node_id, worker_gpu_ids in zip(self.workers, node_ids,
-                                                       gpus):
-                node_workers[node_id].append(worker)
-                node_id_to_gpus[node_id].extend(worker_gpu_ids)
-
-            futures = []
-            for node_id, gpu_ids in node_id_to_gpus.items():
-                all_ids = ",".join([str(gpu_id) for gpu_id in gpu_ids])
-
-                for worker in node_workers[node_id]:
-                    futures.append(
-                        worker.update_env_vars.remote({
-                            "CUDA_VISIBLE_DEVICES":
-                            all_ids
-                        }))
-            ray.get(futures)
+            _get_worker_gpus(self.workers)
         return self.workers, self.get_node_workers(self.workers)
 
 
@@ -247,28 +251,7 @@ class PGStrategy(BaseStrategy):
             self.workers.append(worker)
 
         if self.use_gpu:
-            node_ids = ray.get(
-                [worker.node_id.remote() for worker in self.workers])
-            gpus = ray.get(
-                [worker.get_gpu_ids.remote() for worker in self.workers])
-            node_workers = defaultdict(list)
-            node_id_to_gpus = defaultdict(list)
-            for worker, node_id, worker_gpu_ids in zip(self.workers, node_ids,
-                                                       gpus):
-                node_workers[node_id].append(worker)
-                node_id_to_gpus[node_id].extend(worker_gpu_ids)
-
-            futures = []
-            for node_id, gpu_ids in node_id_to_gpus.items():
-                all_ids = ",".join([str(gpu_id) for gpu_id in gpu_ids])
-
-                for worker in node_workers[node_id]:
-                    futures.append(
-                        worker.update_env_vars.remote({
-                            "CUDA_VISIBLE_DEVICES":
-                            all_ids
-                        }))
-            ray.get(futures)
+            _get_worker_gpus(self.workers)
         return self.workers, self.get_node_workers(self.workers)
 
     def shutdown(self):

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -173,20 +173,18 @@ class PGStrategy(BaseStrategy):
                 pg_strategy="PACK",
                 pg_timeout=self.settings.placement_group_timeout_s)
             self._created_placement_group = True
-        else:
-            bundles = self._placement_group_bundles
 
         # Placement group has started. Now create the workers.
         self.workers = []
         remote_cls = ray.remote(BaseHorovodWorker)
 
-        for bundle_index in range(len(bundles)):
+        for bundle_index in range(self.num_workers):
             remote_cls_with_options = remote_cls.options(
                 num_cpus=self.cpus_per_worker,
                 num_gpus=self.gpus_per_worker * int(self.use_gpu),
                 placement_group_capture_child_tasks=False,
                 placement_group=self.placement_group,
-                placement_group_bundle_index=bundle_index)
+                placement_group_bundle_index=bundle_index if self._created_placement_group else -1)
             worker = remote_cls_with_options.remote(
                 world_rank=bundle_index, world_size=self.num_workers)
 

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -76,8 +76,8 @@ class ColocatedStrategy(BaseStrategy):
         self.gpus_per_worker = gpus_per_worker or 1
 
     @property
-    def num_workers(self):
-        return self.num_hosts * self.num_workers_per_host
+    def num_workers(self) -> int:
+        return int(self.num_hosts * self.num_workers_per_host)
 
     def _resources_per_host(self):
         num_cpus = self.cpus_per_worker * self.num_workers_per_host
@@ -157,8 +157,8 @@ class PGStrategy(BaseStrategy):
         self._created_placement_group = False
 
     @property
-    def num_workers(self):
-        return self._num_workers
+    def num_workers(self) -> int:
+        return int(self._num_workers)
 
     def resources_per_worker(self):
         num_cpus = self.cpus_per_worker

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -136,30 +136,29 @@ class ColocatedStrategy(BaseStrategy):
         return self.workers, self.get_node_workers(self.workers)
 
 
-def _get_worker_gpus(workers):
-    node_ids = ray.get(
-        [worker.node_id.remote() for worker in workers])
-    gpus = ray.get(
-        [worker.get_gpu_ids.remote() for worker in workers])
-    node_workers = defaultdict(list)
-    node_id_to_gpus = defaultdict(list)
-    for worker, node_id, worker_gpu_ids in zip(workers, node_ids,
-                                               gpus):
-        node_workers[node_id].append(worker)
-        node_id_to_gpus[node_id].extend(worker_gpu_ids)
+def _setup_worker_gpus(workers):
+        node_ids = ray.get(
+            [worker.node_id.remote() for worker in workers])
+        gpus = ray.get(
+            [worker.get_gpu_ids.remote() for worker in workers])
+        node_workers = defaultdict(list)
+        node_id_to_gpus = defaultdict(list)
+        for worker, node_id, worker_gpu_ids in zip(workers, node_ids,
+                                                    gpus):
+            node_workers[node_id].append(worker)
+            node_id_to_gpus[node_id].extend(worker_gpu_ids)
 
-    futures = []
-    for node_id, gpu_ids in node_id_to_gpus.items():
-        all_ids = ",".join([str(gpu_id) for gpu_id in gpu_ids])
+        futures = []
+        for node_id, gpu_ids in node_id_to_gpus.items():
+            all_ids = ",".join([str(gpu_id) for gpu_id in gpu_ids])
 
-        for worker in node_workers[node_id]:
-            futures.append(
-                worker.update_env_vars.remote({
-                    "CUDA_VISIBLE_DEVICES":
-                    all_ids
-                }))
-    ray.get(futures)
-
+            for worker in node_workers[node_id]:
+                futures.append(
+                    worker.update_env_vars.remote({
+                        "CUDA_VISIBLE_DEVICES":
+                        all_ids
+                    }))
+        ray.get(futures)
 
 class PackStrategy(BaseStrategy):
     """Packs workers together but does not guarantee balanced hosts."""
@@ -205,7 +204,7 @@ class PackStrategy(BaseStrategy):
             self.workers.append(worker)
 
         if self.use_gpu:
-            _get_worker_gpus(self.workers)
+            _setup_worker_gpus(self.workers)
         return self.workers, self.get_node_workers(self.workers)
 
 
@@ -251,7 +250,7 @@ class PGStrategy(BaseStrategy):
             self.workers.append(worker)
 
         if self.use_gpu:
-            _get_worker_gpus(self.workers)
+            _setup_worker_gpus(self.workers)
         return self.workers, self.get_node_workers(self.workers)
 
     def shutdown(self):

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -235,7 +235,7 @@ class PGStrategy(BaseStrategy):
         self.workers = []
         remote_cls = ray.remote(BaseHorovodWorker)
 
-        for bundle_index in range(self.num_workers):
+        for worker_index in range(self.num_workers):
             remote_cls_with_options = remote_cls.options(
                 num_cpus=self.cpus_per_worker,
                 num_gpus=self.gpus_per_worker * int(self.use_gpu),
@@ -243,7 +243,7 @@ class PGStrategy(BaseStrategy):
                 placement_group=self.placement_group,
                 placement_group_bundle_index=-1)
             worker = remote_cls_with_options.remote(
-                world_rank=bundle_index, world_size=self.num_workers)
+                world_rank=worker_index, world_size=self.num_workers)
 
             self.workers.append(worker)
 

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -167,7 +167,7 @@ class PGStrategy(BaseStrategy):
 
     def create_workers(self):
         if not self.placement_group:
-            self.placement_group, bundles = create_placement_group(
+            self.placement_group, _ = create_placement_group(
                 resources_per_bundle=self.resources_per_worker(),
                 num_bundles=self.num_workers,
                 pg_strategy="PACK",
@@ -178,15 +178,15 @@ class PGStrategy(BaseStrategy):
         self.workers = []
         remote_cls = ray.remote(BaseHorovodWorker)
 
-        for bundle_index in range(self.num_workers):
+        for worker_index in range(self.num_workers):
             remote_cls_with_options = remote_cls.options(
                 num_cpus=self.cpus_per_worker,
                 num_gpus=self.gpus_per_worker * int(self.use_gpu),
                 placement_group_capture_child_tasks=False,
                 placement_group=self.placement_group,
-                placement_group_bundle_index=bundle_index if self._created_placement_group else -1)
+                placement_group_bundle_index=worker_index if self._created_placement_group else -1)
             worker = remote_cls_with_options.remote(
-                world_rank=bundle_index, world_size=self.num_workers)
+                world_rank=worker_index, world_size=self.num_workers)
 
             self.workers.append(worker)
 

--- a/horovod/ray/strategy.py
+++ b/horovod/ray/strategy.py
@@ -228,14 +228,14 @@ class PGStrategy(BaseStrategy):
 
     @property
     def num_workers(self):
-        return len(self._placement_group_bundles)
+        return self._num_workers
 
     def create_workers(self):
         # Placement group has started. Now create the workers.
         self.workers = []
         remote_cls = ray.remote(BaseHorovodWorker)
 
-        for bundle_index in range(len(self._placement_group_bundles)):
+        for bundle_index in range(self.num_workers):
             remote_cls_with_options = remote_cls.options(
                 num_cpus=self.cpus_per_worker,
                 num_gpus=self.gpus_per_worker * int(self.use_gpu),

--- a/test/single/test_ray.py
+++ b/test/single/test_ray.py
@@ -425,7 +425,8 @@ def test_horovod_train(ray_start_4_cpus, num_workers, num_hosts,
 @pytest.mark.skipif(
     not gloo_built(), reason='Gloo is required for Ray integration')
 def test_horovod_train_in_pg(ray_start_4_cpus):
-    pg, _ = create_placement_group({"CPU": 1, "GPU": 1}, 4, 30, "PACK")
+    pg, _ = create_placement_group(
+        {"CPU": 1, "GPU": int(torch.cuda.is_available())}, 4, 30, "PACK")
 
     @ray.remote(num_cpus=0, num_gpus=0, placement_group_capture_child_tasks=True, placement_group=pg)
     def remote_func():

--- a/test/single/test_ray.py
+++ b/test/single/test_ray.py
@@ -431,8 +431,6 @@ def test_horovod_train_in_pg(ray_start_4_cpus):
     @ray.remote
     class _Actor():
         def run(self):
-            print("run")
-
             def simple_fn(worker):
                 local_rank = _train()
                 return local_rank

--- a/test/single/test_ray.py
+++ b/test/single/test_ray.py
@@ -14,6 +14,7 @@ import torch
 from horovod.common.util import gloo_built
 from horovod.ray.runner import (Coordinator, MiniSettings, RayExecutor)
 from horovod.ray.worker import BaseHorovodWorker
+from horovod.ray.strategy import create_placement_group
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -419,6 +420,33 @@ def test_horovod_train(ray_start_4_cpus, num_workers, num_hosts,
     result = hjob.execute(simple_fn)
     assert set(result) == {0, 1, 2, 3}
     hjob.shutdown()
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+def test_horovod_train_in_pg(ray_start_4_cpus):
+    pg, _ = create_placement_group({"CPU": 1, "GPU": 1}, 4, 30, "PACK")
+
+    @ray.remote(num_cpus=0, num_gpus=0, placement_group_capture_child_tasks=True, placement_group=pg)
+    def remote_func():
+        def simple_fn(worker):
+            local_rank = _train()
+            return local_rank
+
+        setting = RayExecutor.create_settings(timeout_s=30)
+        hjob = RayExecutor(
+            setting,
+            num_workers=4,
+            num_hosts=None,
+            num_workers_per_host=None,
+            cpus_per_worker=1,
+            gpus_per_worker=1,
+            use_gpu=torch.cuda.is_available())
+        hjob.start()
+        result = hjob.execute(simple_fn)
+        assert set(result) == {0, 1, 2, 3}
+        hjob.shutdown()
+    ray.get(remote_func.remote())
 
 
 @pytest.mark.skipif(

--- a/test/single/test_ray.py
+++ b/test/single/test_ray.py
@@ -447,6 +447,7 @@ def test_horovod_train_in_pg(ray_start_4_cpus):
                 gpus_per_worker=int(torch.cuda.is_available()) or None,
                 use_gpu=torch.cuda.is_available())
             hjob.start()
+            assert not hjob.driver.strategy._created_placement_group
             result = hjob.execute(simple_fn)
             assert set(result) == {0, 1, 2, 3}
             hjob.shutdown()


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Adds a `PGStrategy` to `RayExecutor`, which will automatically capture the placement group should one be currently present, and use it for Horovod.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
