### PR TITLE
Fix error in keras Learning Rate Scheduler

### DIFF
--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -106,9 +106,11 @@ class LearningRateScheduleCallbackImpl(object):
         self.steps_per_epoch = steps_per_epoch
         self.current_epoch = None
 
+        # set multiplier, which is a fn(epoch) and is the amount by which self.initial_lr is
+        # multiplied by on each batch / epoch begin (depending on whether you set staircase or not
         if not callable(multiplier):
-            self.staircase = True
-            self.multiplier = lambda epoch: multiplier
+            # If multiplier is a constant, it corresponds to exponential decay
+            self.multiplier = lambda epoch: multiplier ** epoch
         else:
             self.multiplier = multiplier
 


### PR DESCRIPTION
 - When the LearningRateScheduleCallback is initialized with multiplier = constant, it does not work correctly (there is no learning rate decay): more specifically learning rates = initial_lr * multiplier, initial_lr * multiplier, initial_lr * multiplier,... whereas the expectation it decays as  initial_lr,  initial_lr * multiplier,  initial_lr * multiplier^2 and such
 - Another nit is when multiplier = constant, there is no need to enforce that staircase = True. The change made to fix the above mistake can handle staircase = False as well

## Checklist before submitting

- [Y] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [Y] Did you update the docs?
- [N] Did you write any tests to validate this change?  
- [N] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes issue identified in Uber, which uses this repository. If multiplier is set to a constant, we realized by looking at the learning rate logs that it remained a constant equal to initial_lr * multiplier.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
