### PR TITLE
Add barrier call to torch module to support easy synchronization for process sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added terminate_on_nan flag to Spark Lightning estimator. [#3088](https://github.com/horovod/horovod/issues/3088)
 
+- Added barrier() API to torch module to support simple synchronization among ranks and to achieve parity with PyTorch DDP and similar frameworks.
+
 ### Changed
 
 - By default, RayExecutor will now use the current placement group instead of always creating a new one. ([#3134](https://github.com/horovod/horovod/pull/3134))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added terminate_on_nan flag to Spark Lightning estimator. [#3088](https://github.com/horovod/horovod/issues/3088)
 
-- Added barrier() API to torch module to support simple synchronization among ranks and to achieve parity with PyTorch DDP and similar frameworks.
+- Added barrier() API to torch module to support simple synchronization among ranks and to achieve parity with PyTorch DDP and similar frameworks. [#3139](https://github.com/horovod/horovod/pull/3139)
 
 ### Changed
 

--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -150,7 +150,8 @@ class HorovodBasics(object):
 
     def is_initialized(self):
         """Returns True if Horovod is initialized"""
-        return self.MPI_LIB_CTYPES.horovod_is_initialized()
+        is_initialized = self.MPI_LIB_CTYPES.horovod_is_initialized()
+        return bool(is_initialized)
 
     def start_timeline(self, file_path, mark_cycles=False):
         """Creates a timeline file at `file_path` and begins recording.

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -153,6 +153,9 @@ namespace common {
 // Temporary tensor name for ranks that did Join().
 #define JOIN_TENSOR_NAME "join.noname"
 
+// Fixed tensor name for all barrier operations
+#define BARRIER_TENSOR_NAME "barrier.noname"
+
 // List of supported frameworks.
 enum Framework { TENSORFLOW, PYTORCH, MXNET, XLA };
 

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -304,12 +304,6 @@ ResponseList Controller::ComputeResponseList(bool this_process_requested_shutdow
 
           bool reduce =
               IncrementTensorCount(received_message, process_set.joined_size);
-          // For barrier request, if not ready to reduce, we add it back to tensor queue
-          // to process in the next cycle.
-          if(!reduce && received_message.request_type() == Request::BARRIER) {
-            Request barrier_msg = received_message;
-            tensor_queue_.PushMessageToQueue(barrier_msg);
-          }
 
           stall_inspector_.RecordUncachedTensorStart(
               received_message.tensor_name(), received_message.request_rank(),

--- a/horovod/common/message.cc
+++ b/horovod/common/message.cc
@@ -111,6 +111,9 @@ const std::string& Request::RequestType_Name(RequestType value) {
     case RequestType::ALLTOALL:
       static const std::string alltoall("ALLTOALL");
       return alltoall;
+    case RequestType::BARRIER:
+      static const std::string barrier("BARRIER");
+      return barrier;
     default:
       static const std::string unknown("<unknown>");
       return unknown;
@@ -300,6 +303,9 @@ const std::string& Response::ResponseType_Name(ResponseType value) {
     case ResponseType::ALLTOALL:
       static const std::string alltoall("ALLTOALL");
       return alltoall;
+    case ResponseType::BARRIER:
+      static const std::string barrier("BARRIER");
+      return barrier;
     case ResponseType::ERROR:
       static const std::string error("ERROR");
       return error;

--- a/horovod/common/message.h
+++ b/horovod/common/message.h
@@ -50,7 +50,7 @@ std::size_t DataType_Size(DataType value);
 class Request {
 public:
   enum RequestType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL = 5
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL = 5, BARRIER = 6
   };
 
 
@@ -153,7 +153,7 @@ private:
 class Response {
 public:
   enum ResponseType {
-    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL= 5, ERROR = 6
+    ALLREDUCE = 0, ALLGATHER = 1, BROADCAST = 2, JOIN = 3, ADASUM = 4, ALLTOALL= 5, BARRIER=6, ERROR = 7
   };
 
   static const std::string& ResponseType_Name(ResponseType value);

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -233,7 +233,8 @@ Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    StatusCallback callback,
                    int32_t process_set_id = 0);
 
-Status CallBarrier(int32_t process_set_id = 0);
+Status EnqueueBarrier(StatusCallback callback,
+                   int32_t process_set_id = 0);
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -233,6 +233,8 @@ Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    StatusCallback callback,
                    int32_t process_set_id = 0);
 
+Status CallBarrier(int32_t process_set_id = 0);
+
 } // namespace common
 } // namespace horovod
 

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -312,6 +312,22 @@ Status JoinOp::Execute(std::vector<TensorTableEntry>& entries,
   return Status::OK();
 }
 
+// Barrier
+BarrierOp::BarrierOp(HorovodGlobalState* global_state) : HorovodOp(global_state) {}
+
+Status BarrierOp::Execute(std::vector<TensorTableEntry>& entries,
+                       const Response& response) {
+  assert(entries.size() == 1);
+  int& process_set_id = entries[0].process_set_id;
+  auto& process_set = global_state_->process_set_table.Get(process_set_id);
+
+
+  process_set.controller->Barrier(Communicator::GLOBAL);
+  LOG(TRACE, global_state_->global_controller->GetRank()) << "Released from barrier.";
+
+  return Status::OK();
+}
+
 // Error
 ErrorOp::ErrorOp(HorovodGlobalState* global_state) : HorovodOp(global_state) {}
 

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -289,6 +289,15 @@ public:
                          const Response& response, ProcessSet& process_set);
 };
 
+class BarrierOp : public HorovodOp {
+public:
+  explicit BarrierOp(HorovodGlobalState* global_state);
+
+  virtual ~BarrierOp() = default;
+
+  virtual Status Execute(std::vector<TensorTableEntry>& entries, const Response& response);
+};
+
 class ErrorOp : public HorovodOp {
 public:
   explicit ErrorOp(HorovodGlobalState* global_state);

--- a/horovod/common/ops/operation_manager.h
+++ b/horovod/common/ops/operation_manager.h
@@ -33,6 +33,7 @@ public:
                    std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops,
                    std::shared_ptr<JoinOp> join_op,
                    std::vector<std::shared_ptr<AllreduceOp>> adasum_ops,
+                   std::shared_ptr<BarrierOp> barrier_op,
                    std::shared_ptr<ErrorOp> error_op);
 
   virtual ~OperationManager() = default;
@@ -52,6 +53,8 @@ public:
 
   Status ExecuteAdasum(std::vector<TensorTableEntry>& entries, const Response& response) const;
 
+  Status ExecuteBarrier(std::vector<TensorTableEntry>& entries, const Response& response) const;
+
   Status ExecuteOperation(std::vector<TensorTableEntry>& entries,
                           const Response& response,
                           ProcessSet& process_set) const;
@@ -65,6 +68,7 @@ private:
   std::vector<std::shared_ptr<AlltoallOp>> alltoall_ops_;
   std::shared_ptr<JoinOp> join_op_;
   std::vector<std::shared_ptr<AllreduceOp>> adasum_ops_;
+  std::shared_ptr<BarrierOp> barrier_op_;
   std::shared_ptr<ErrorOp> error_op_;
 };
 

--- a/horovod/common/response_cache.cc
+++ b/horovod/common/response_cache.cc
@@ -39,6 +39,8 @@ static Response::ResponseType RequestTypeToResponseType(Request::RequestType val
       return Response::ResponseType::ADASUM;
     case Request::RequestType::ALLTOALL:
       return Response::ResponseType::ALLTOALL;
+    case Request::RequestType::BARRIER:
+      return Response::ResponseType::BARRIER;
     default:
       throw std::logic_error("No corresponding ResponseType for provided RequestType.");
   }

--- a/horovod/common/tensor_queue.h
+++ b/horovod/common/tensor_queue.h
@@ -43,6 +43,8 @@ public:
 
   const TensorTableEntry& GetTensorEntry(const std::string& tensor_name) const;
 
+  bool IsTensorPresentInTable (const std::string& tensor_name) const;
+
   void PopMessagesFromQueue(std::deque<Request>& message_queue_buffer);
 
   void PushMessageToQueue(Request& message);

--- a/horovod/common/wire/message.fbs
+++ b/horovod/common/wire/message.fbs
@@ -38,7 +38,8 @@ enum RequestType:byte {
     ALLREDUCE = 0,
     ALLGATHER = 1,
     BROADCAST = 2,
-    JOIN = 3
+    JOIN = 3,
+    BARRIER = 4
 }
 table Request {
     // The request rank is necessary to create a consistent ordering of results,
@@ -81,7 +82,8 @@ enum ResponseType:byte {
     BROADCAST = 2,
     JOIN = 3,
     ADASUM = 4,
-    ERROR = 5
+    BARRIER = 5,
+    ERROR = 6
 }
 table Response {
     response_type:ResponseType;

--- a/horovod/common/wire/message_generated.h
+++ b/horovod/common/wire/message_generated.h
@@ -97,33 +97,36 @@ enum RequestType : int8_t {
   RequestType_ALLGATHER = 1,
   RequestType_BROADCAST = 2,
   RequestType_JOIN = 3,
+  RequestType_BARRIER = 4,
   RequestType_MIN = RequestType_ALLREDUCE,
-  RequestType_MAX = RequestType_JOIN
+  RequestType_MAX = RequestType_BARRIER
 };
 
-inline const RequestType (&EnumValuesRequestType())[4] {
+inline const RequestType (&EnumValuesRequestType())[5] {
   static const RequestType values[] = {
     RequestType_ALLREDUCE,
     RequestType_ALLGATHER,
     RequestType_BROADCAST,
-    RequestType_JOIN
+    RequestType_JOIN,
+    RequestType_BARRIER
   };
   return values;
 }
 
 inline const char * const *EnumNamesRequestType() {
-  static const char * const names[5] = {
+  static const char * const names[6] = {
     "ALLREDUCE",
     "ALLGATHER",
     "BROADCAST",
     "JOIN",
+    "BARRIER",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameRequestType(RequestType e) {
-  if (flatbuffers::IsOutRange(e, RequestType_ALLREDUCE, RequestType_JOIN)) return "";
+  if (flatbuffers::IsOutRange(e, RequestType_ALLREDUCE, RequestType_BARRIER)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesRequestType()[index];
 }
@@ -134,30 +137,33 @@ enum ResponseType : int8_t {
   ResponseType_BROADCAST = 2,
   ResponseType_JOIN = 3,
   ResponseType_ADASUM = 4,
-  ResponseType_ERROR = 5,
+  ResponseType_BARRIER = 5,
+  ResponseType_ERROR = 6,
   ResponseType_MIN = ResponseType_ALLREDUCE,
   ResponseType_MAX = ResponseType_ERROR
 };
 
-inline const ResponseType (&EnumValuesResponseType())[6] {
+inline const ResponseType (&EnumValuesResponseType())[7] {
   static const ResponseType values[] = {
     ResponseType_ALLREDUCE,
     ResponseType_ALLGATHER,
     ResponseType_BROADCAST,
     ResponseType_JOIN,
     ResponseType_ADASUM,
+    ResponseType_BARRIER,
     ResponseType_ERROR
   };
   return values;
 }
 
 inline const char * const *EnumNamesResponseType() {
-  static const char * const names[7] = {
+  static const char * const names[8] = {
     "ALLREDUCE",
     "ALLGATHER",
     "BROADCAST",
     "JOIN",
     "ADASUM",
+    "BARRIER",
     "ERROR",
     nullptr
   };

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -42,6 +42,7 @@ if _MPI_LIB_AVAILABLE:
     from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
     from horovod.torch.mpi_ops import alltoall, alltoall_async
     from horovod.torch.mpi_ops import join
+    from horovod.torch.mpi_ops import barrier
     from horovod.torch.mpi_ops import poll, synchronize
     from horovod.torch.mpi_ops import init, shutdown
     from horovod.torch.mpi_ops import is_initialized, start_timeline, stop_timeline

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -983,6 +983,10 @@ def barrier(process_set=global_process_set):
     """
 
     try:
-        mpi_lib.horovod_torch_barrier(process_set.process_set_id)
+        handle = mpi_lib.horovod_torch_barrier(process_set.process_set_id)
     except RuntimeError as e:
         raise HorovodInternalError(e)
+
+    _handle_map[handle] = (None, None)
+
+    synchronize(handle)

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -970,3 +970,19 @@ def join(device=-1) -> int:
     _handle_map[handle] = (None, output)
 
     return synchronize(handle).item()
+
+def barrier(process_set=global_process_set):
+    """
+    A function that acts as a simple sychronization point for ranks specified
+    in the given process group(default to global group). Ranks that reach
+    this function call will stall until all other ranks have reached.
+
+    Arguments:
+        process_set: Process set object to limit this operation to a subset of
+                     Horovod processes. Default is the global process set.
+    """
+
+    try:
+        mpi_lib.horovod_torch_barrier(process_set.process_set_id)
+    except RuntimeError as e:
+        raise HorovodInternalError(e)

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -618,6 +618,11 @@ void Reset() {
   handle_manager.Reset();
 }
 
+void Barrier(int process_set_id = 0) {
+  ThrowIfError(common::CheckInitialized());
+  auto status = CallBarrier(process_set_id);
+  ThrowIfError(status);
+}
 
 PYBIND11_MODULE(mpi_lib_v2, m) {
   // allreduce
@@ -788,6 +793,7 @@ PYBIND11_MODULE(mpi_lib_v2, m) {
   m.def("horovod_torch_poll", &PollHandle);
   m.def("horovod_torch_wait_and_clear", &WaitAndClear);
   m.def("horovod_torch_reset", &Reset);
+  m.def("horovod_torch_barrier", &Barrier);
 }
 
 } // namespace torch

--- a/test/parallel/test.py
+++ b/test/parallel/test.py
@@ -1,0 +1,3 @@
+import horovod.torch as hvd
+hvd.init()
+print(hvd.rank())

--- a/test/parallel/test.py
+++ b/test/parallel/test.py
@@ -1,3 +1,0 @@
-import horovod.torch as hvd
-hvd.init()
-print(hvd.rank())

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -3250,6 +3250,5 @@ class TorchTests(unittest.TestCase):
 
         self.assertTrue(barrier_time >= 5)
 
-
 if __name__ == "__main__":
    unittest.main()

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -120,7 +120,6 @@ class TorchTests(unittest.TestCase):
 
     def test_horovod_is_initialized(self):
         """Test that is_initialized returned by hvd.is_initialized() is correct."""
-        assert not hvd.is_initialized()
         hvd.init()
         assert hvd.is_initialized()
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Add barrier call to torch module to support easy synchronization for process sets. Existing methods that use other apis are either not well known or not designed to be a synchronization point. This also achieves parity with other distributed training frameworks. 

This also fixes a minor issue with is_initialized(). The horovod_is_initialized returns an atomic bool which will be interpreted as a random INT by ctypes on Mac. Changed it to return INT instead.

Fixes #3121  (issue).
https://github.com/horovod/horovod/issues/3121
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
