### PR TITLE
Fix mistake in keras LR scheduler callback

### DIFF
--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -107,10 +107,10 @@ class LearningRateScheduleCallbackImpl(object):
         self.current_epoch = None
 
         # set multiplier, which is a fn(epoch) and is the amount by which self.initial_lr is
-        # multiplied by on each batch / epoch begin (depending on whether you set staircase or not
+        # multiplied by on each batch / epoch begin (depending on whether you set staircase or not)
         if not callable(multiplier):
             # If multiplier is a constant, it corresponds to exponential decay
-            self.multiplier = lambda epoch: multiplier ** epoch
+            self.multiplier = lambda epoch: multiplier ** (epoch - start_epoch)
         else:
             self.multiplier = multiplier
 


### PR DESCRIPTION
 - Fixes issue when start_epoch != 0

## Checklist before submitting

- [Y] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [Y] Did you update the docs?
- [N] Did you write any tests to validate this change?  
- [N] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes mistake in keras LR scheduler callback when start_epoch != 0 and multiplier is a constant

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
