### PR TITLE
Fix the mapping btw pyspark and numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix Horovod develop/editable install mode and incremental builds. ([#3074](https://github.com/horovod/horovod/pull/3074))
 - Estimator/Lightning: use lightning datamodule ([#3084](https://github.com/horovod/horovod/pull/3084))
+- Fix Horovod Spark StringType and numpy type mapping issue ([#3146](https://github.com/horovod/horovod/pull/3146))
 
 ## [v0.22.1] - 2021-06-10
 

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -132,7 +132,7 @@ def data_type_to_numpy(dtype):
     elif dtype == IntegerType:
         return np.int32
     elif dtype == StringType:
-        return np.uint8
+        return np.str
     elif dtype == FloatType:
         return np.float32
     elif dtype == BinaryType:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).
Horovod maps pyspark string type to numpy uint8 type. It blocks users using string type tensor input. I think originally the reason why we map string type to numpy uint8 is because tensorflow does not support string label. But with the mapping, horovod KerasModel would fail in transform stage anyway. And keras itself does not support string label (https://stackoverflow.com/questions/55970851/tensorflow-model-fit-does-not-work-with-strings-as-labels). We don't need to use the incorrect mapping to fail the transform

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
