### PR TITLE
Spark/Keras: utilize num_parallel_calls for tf.data.Dataset.batch()

### DIFF
--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -85,9 +85,19 @@ class TFKerasUtil(object):
 
             # Decompress sparse data if necessary
             if has_sparse_col:
-                dataset = dataset.batch(1).map(reshape)
+                if LooseVersion(tf.__version__) >= LooseVersion("2.5.0"):
+                    dataset = dataset.batch(1,
+                                            num_parallel_calls=tf.data.AUTOTUNE,
+                                            deterministic=False).map(reshape)
+                else:
+                    dataset = dataset.batch(1).map(reshape)
 
-            dataset = dataset.batch(batch_size).map(prep_data_tf_keras)
+            if LooseVersion(tf.__version__) >= LooseVersion("2.5.0"):
+                dataset = dataset.batch(batch_size,
+                                        num_parallel_calls=tf.data.AUTOTUNE,
+                                        deterministic=False).map(prep_data_tf_keras)
+            else:
+                dataset = dataset.batch(batch_size).map(prep_data_tf_keras)
             if hasattr(tf.data, 'AUTOTUNE'):
                 dataset = dataset.prefetch(tf.data.AUTOTUNE)
             else:


### PR DESCRIPTION
Control the number of batches to compute asynchronously in parallel.

Co-authored-by: Rich Porter <rich.porter@uber.com>
Co-authored-by: Raajay Viswanathan <raajay@uber.com>
Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
