### PR TITLE
[TF - Fix] Fix imports from tensorflow.python.keras with tf.__version__ >= 2.5.0

### DIFF
--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -265,3 +265,24 @@ def is_iterable(x):
     except TypeError:
         return False
     return True
+
+
+@_cache
+def is_version_greater_equal_than(ver, target):
+    from distutils.version import LooseVersion, StrictVersion
+    if any([not isinstance(_str, str) for _str in (ver, target)]):
+        raise ValueError("This function only accepts string arguments. \n"
+                         "Received:\n"
+                         "\t- ver (type {type_ver}: {val_ver})"
+                         "\t- target (type {type_target}: {val_target})".format(
+                            type_ver=(type(ver)),
+                            val_ver=ver,
+                            type_target=(type(target)),
+                            val_target=target,
+                         ))
+
+    if len(target.split(".")) != 3:
+        raise ValueError("We only accepts target version values in the form "
+                         "of: major.minor.patch. Received: {}".format(target))
+
+    return LooseVersion(ver) >= LooseVersion(target)

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -15,8 +15,17 @@
 
 import json
 
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras import optimizers
+import tensorflow as tf
+
+from horovod.common.util  import is_version_greater_equal_than
+
+if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+    from keras import backend as K
+    from keras import optimizers
+else:
+    from tensorflow.python.keras import backend as K
+    from tensorflow.python.keras import optimizers
+
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import serialization
 

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 
 from horovod.common.util  import is_version_greater_equal_than
 
-if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras import backend as K
     from keras import optimizers
 else:

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -19,7 +19,13 @@ import warnings
 import tensorflow as tf
 
 from tensorflow import keras
-from tensorflow.python.keras import backend as K
+
+from horovod.common.util  import is_version_greater_equal_than
+
+if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+    from keras import backend as K
+else:
+    from tensorflow.python.keras import backend as K
 
 from horovod.tensorflow import init
 from horovod.tensorflow import shutdown
@@ -247,4 +253,3 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
     return _impl.load_model(keras, wrap_optimizer, _OPTIMIZER_MODULES, filepath, custom_optimizers, custom_objects)
-

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -22,7 +22,7 @@ from tensorflow import keras
 
 from horovod.common.util  import is_version_greater_equal_than
 
-if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras import backend as K
 else:
     from tensorflow.python.keras import backend as K

--- a/horovod/tensorflow/keras/callbacks.py
+++ b/horovod/tensorflow/keras/callbacks.py
@@ -19,7 +19,7 @@ from tensorflow import keras
 
 from horovod.common.util  import is_version_greater_equal_than
 
-if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras import backend as K
 else:
     from tensorflow.python.keras import backend as K

--- a/horovod/tensorflow/keras/callbacks.py
+++ b/horovod/tensorflow/keras/callbacks.py
@@ -13,8 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 
+
+import tensorflow as tf
 from tensorflow import keras
-from tensorflow.python.keras import backend as K
+
+from horovod.common.util  import is_version_greater_equal_than
+
+if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+    from keras import backend as K
+else:
+    from tensorflow.python.keras import backend as K
 
 from horovod._keras import callbacks as _impl
 

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -72,9 +72,6 @@ def get_mock_fit_fn():
     return fit
 
 
-#PR3099 [https://github.com/horovod/horovod/pull/3099] doesn't fix
-#Tensorflow>=2.6.0 tests
-@pytest.mark.skipif(LooseVersion(tf.__version__) >= LooseVersion('2.6.0'), reason='TensorFlow>=2.6.0 tests')
 class SparkKerasTests(tf.test.TestCase):
     def __init__(self, *args, **kwargs):
         super(SparkKerasTests, self).__init__(*args, **kwargs)

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -29,7 +29,7 @@ from tensorflow import keras
 
 from horovod.common.util  import is_version_greater_equal_than
 
-if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras.optimizer_v2 import optimizer_v2
 else:
     from tensorflow.python.keras.optimizer_v2 import optimizer_v2

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -26,7 +26,13 @@ from distutils.version import LooseVersion
 import pytest
 
 from tensorflow import keras
-from tensorflow.python.keras.optimizer_v2 import optimizer_v2
+
+from horovod.common.util  import is_version_greater_equal_than
+
+if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+    from keras.optimizer_v2 import optimizer_v2
+else:
+    from tensorflow.python.keras.optimizer_v2 import optimizer_v2
 
 import horovod.tensorflow.keras as hvd
 

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -28,7 +28,7 @@ from tensorflow import keras
 
 from horovod.common.util  import is_version_greater_equal_than
 
-if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras import backend as K
     from keras.optimizer_v2 import optimizer_v2
 else:

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -25,8 +25,15 @@ import warnings
 
 from distutils.version import LooseVersion
 from tensorflow import keras
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.optimizer_v2 import optimizer_v2
+
+from horovod.common.util  import is_version_greater_equal_than
+
+if is_version_greater_equal_than(tf.__version__, "2.5.0"):
+    from keras import backend as K
+    from keras.optimizer_v2 import optimizer_v2
+else:
+    from tensorflow.python.keras import backend as K
+    from tensorflow.python.keras.optimizer_v2 import optimizer_v2
 
 import horovod.tensorflow.keras as hvd
 


### PR DESCRIPTION
Since Tensorflow 2.5, any import to `tensorflow.python.keras` is to be considered unstable / unsupported.

As a matter of fact, if you check the wheel manifest, starting with 2.5.0, Tensorflow directly depends on Keras:

```
Requires-Dist: numpy (~=1.19.2)
Requires-Dist: absl-py (~=0.10)
Requires-Dist: astunparse (~=1.6.3)
Requires-Dist: flatbuffers (~=1.12.0)
Requires-Dist: google-pasta (~=0.2)
Requires-Dist: h5py (~=3.1.0)
Requires-Dist: keras-preprocessing (~=1.1.2)
Requires-Dist: opt-einsum (~=3.3.0)
Requires-Dist: protobuf (>=3.9.2)
Requires-Dist: six (~=1.15.0)
Requires-Dist: termcolor (~=1.1.0)
Requires-Dist: typing-extensions (~=3.7.4)
Requires-Dist: wheel (~=0.35)
Requires-Dist: wrapt (~=1.12.1)
Requires-Dist: gast (==0.4.0)
Requires-Dist: tensorboard (~=2.5)
Requires-Dist: tensorflow-estimator (<2.6.0,>=2.5.0rc0)
Requires-Dist: keras-nightly (~=2.5.0.dev)                          # <============== Here
Requires-Dist: grpcio (~=1.34.0)
```

Due to the backward compatibility nature of HVD, we can't just remove the code. Hence, I am introducing conditional imports based on the value of `tf.__version__`