### PR TITLE
test_torch.py: add explicit join() for testing duplicated name errors

### DIFF
--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -612,6 +612,9 @@ class TorchTests(unittest.TestCase):
             assert False, 'hvd.allreduce_async did not throw error'
         except (torch.FatalError, ValueError):
             pass
+        if LooseVersion(torch.__version__) >= LooseVersion('1.10.0'):
+            # To fix https://github.com/horovod/horovod/issues/3149
+            hvd.join()
 
     def test_horovod_allreduce_grad(self):
         """Test the correctness of the allreduce gradient."""
@@ -1218,6 +1221,9 @@ class TorchTests(unittest.TestCase):
             assert False, 'hvd.allgather_async did not throw error'
         except (torch.FatalError, ValueError):
             pass
+        if LooseVersion(torch.__version__) >= LooseVersion('1.10.0'):
+            # To fix https://github.com/horovod/horovod/issues/3149
+            hvd.join()
 
     def test_horovod_allgather_grad(self):
         """Test the correctness of the allgather gradient."""
@@ -1528,6 +1534,9 @@ class TorchTests(unittest.TestCase):
             assert False, 'hvd.broadcast_async did not throw error'
         except (torch.FatalError, ValueError):
             pass
+        if LooseVersion(torch.__version__) >= LooseVersion('1.10.0'):
+            # To fix https://github.com/horovod/horovod/issues/3149
+            hvd.join()
 
     def test_horovod_broadcast_grad(self):
         """Test the correctness of the broadcast gradient."""


### PR DESCRIPTION
For torch nightly >=10.0, we need to add an explict join() call to avoid
hanging when testing duplicated name errors.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3149 .

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
