### PR TITLE
Support for nccl on cuda 11.4

### DIFF
--- a/horovod/common/ops/adasum_gpu_operations.cc
+++ b/horovod/common/ops/adasum_gpu_operations.cc
@@ -288,7 +288,7 @@ AdasumGpuAllreduceOp::NcclHierarchical(std::vector<TensorTableEntry>& entries,
     }
   }
   if (num_elements_remaining > 0) {
-#if NCCL_MAJOR >= 2 && NCCL_MINOR >= 2 && NCCL_PATCH >= 12
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 2, 12)
     nccl_context_->ErrorCheck(
         "ncclBroadcast",
         ncclBroadcast(buffer_data_remainder, buffer_data_remainder,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -411,6 +411,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
   if (num_elements_remaining > 0) {
+#if NCCL_MAJOR >= 2 && NCCL_MINOR >= 2 && NCCL_PATCH >= 12
     nccl_context_->ErrorCheck("ncclBroadcast",
                               ncclBroadcast(buffer_data_remainder,
                                             buffer_data_remainder,
@@ -418,6 +419,14 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
                                             GetNCCLDataType(first_entry.tensor), root_rank,
                                             *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
                               *nccl_op_context_.nccl_comm_);
+#else
+    nccl_context_->ErrorCheck("ncclBcast",
+                              ncclBcast(buffer_data_remainder,
+                                        (size_t) num_elements_remaining,
+                                        GetNCCLDataType(first_entry.tensor), root_rank,
+                                        *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
+                              *nccl_op_context_.nccl_comm_);
+#endif
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);
     }
@@ -488,14 +497,24 @@ Status NCCLBroadcast::Execute(std::vector<TensorTableEntry>& entries,
 
   // We only use 'ncclChar' for this operation because the type format does not matter for a
   // broadcast, only the size of the data.
-  nccl_context_->ErrorCheck("ncclBroadcast",
-                            ncclBroadcast(data_ptr,
+#if NCCL_MAJOR >= 2 && NCCL_MINOR >= 2 && NCCL_PATCH >= 12
+    nccl_context_->ErrorCheck("ncclBroadcast",
+                              ncclBroadcast(data_ptr,
                                           data_ptr,
                                           e.tensor->shape().num_elements() *
                                           DataType_Size(e.tensor->dtype()),
                                           ncclChar, e.root_rank,
                                           *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
-                            *nccl_op_context_.nccl_comm_);
+                              *nccl_op_context_.nccl_comm_);
+#else
+    nccl_context_->ErrorCheck("ncclBcast",
+                              ncclBcast(data_ptr,
+                                        e.tensor->shape().num_elements() *
+                                        DataType_Size(e.tensor->dtype()),
+                                        ncclChar, e.root_rank,
+                                        *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
+                              *nccl_op_context_.nccl_comm_);
+#endif
   if (global_state_->timeline.Initialized()) {
     gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);
   }

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -411,7 +411,7 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
   if (num_elements_remaining > 0) {
-#if NCCL_MAJOR >= 2 && NCCL_MINOR >= 2 && NCCL_PATCH >= 12
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 2, 12)
     nccl_context_->ErrorCheck("ncclBroadcast",
                               ncclBroadcast(buffer_data_remainder,
                                             buffer_data_remainder,
@@ -497,7 +497,7 @@ Status NCCLBroadcast::Execute(std::vector<TensorTableEntry>& entries,
 
   // We only use 'ncclChar' for this operation because the type format does not matter for a
   // broadcast, only the size of the data.
-#if NCCL_MAJOR >= 2 && NCCL_MINOR >= 2 && NCCL_PATCH >= 12
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 2, 12)
     nccl_context_->ErrorCheck("ncclBroadcast",
                               ncclBroadcast(data_ptr,
                                           data_ptr,

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -411,11 +411,12 @@ NCCLHierarchicalAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     }
   }
   if (num_elements_remaining > 0) {
-    nccl_context_->ErrorCheck("ncclBcast",
-                              ncclBcast(buffer_data_remainder,
-                                        (size_t) num_elements_remaining,
-                                        GetNCCLDataType(first_entry.tensor), root_rank,
-                                        *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
+    nccl_context_->ErrorCheck("ncclBroadcast",
+                              ncclBroadcast(buffer_data_remainder,
+                                            buffer_data_remainder,
+                                            (size_t) num_elements_remaining,
+                                            GetNCCLDataType(first_entry.tensor), root_rank,
+                                            *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
                               *nccl_op_context_.nccl_comm_);
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);
@@ -487,12 +488,13 @@ Status NCCLBroadcast::Execute(std::vector<TensorTableEntry>& entries,
 
   // We only use 'ncclChar' for this operation because the type format does not matter for a
   // broadcast, only the size of the data.
-  nccl_context_->ErrorCheck("ncclBcast",
-                            ncclBcast(data_ptr,
-                                      e.tensor->shape().num_elements() *
-                                      DataType_Size(e.tensor->dtype()),
-                                      ncclChar, e.root_rank,
-                                      *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
+  nccl_context_->ErrorCheck("ncclBroadcast",
+                            ncclBroadcast(data_ptr,
+                                          data_ptr,
+                                          e.tensor->shape().num_elements() *
+                                          DataType_Size(e.tensor->dtype()),
+                                          ncclChar, e.root_rank,
+                                          *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream),
                             *nccl_op_context_.nccl_comm_);
   if (global_state_->timeline.Initialized()) {
     gpu_context_->RecordEvent(gpu_op_context_.event_queue, NCCL_BCAST, *gpu_op_context_.stream);


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

On cuda 11.4 and nccl 2.11.4, calling `ncclBcast` fails with the error "invalid argument". `ncclBcast` was deprecated starting in nccl version 2.2.12. Switching to the new API of `ncclBroadcast` fixes this error. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
