### PR TITLE
Make fork PRs publish test change stats

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -137,7 +137,18 @@ def main():
                '    runs-on: ubuntu-latest\n' \
                '    steps:\n' \
                '    - name: Debug Action\n' \
-               '      uses: hmarr/debug-action@v1.0.0\n' + \
+               '      uses: hmarr/debug-action@v1.0.0\n' \
+               '\n' \
+               '  event_file:\n' \
+               '    name: "Event File"\n' \
+               '    runs-on: ubuntu-latest\n' \
+               '    steps:\n' \
+               '    - name: Upload\n' \
+               '      uses: actions/upload-artifact@v2\n' \
+               '      with:\n' \
+               '        name: Event File\n' \
+               '        path: ${{ github.event_path }}\n' \
+               '\n' + \
                '\n'.join(jobs)
 
     def init_workflow_job() -> str:
@@ -515,60 +526,6 @@ def main():
                 f'          echo "::warning::Buildkite pipeline did not pass: ${{{{ steps.build.outputs.url }}}}"\n'
                 f'          exit 1\n')
 
-    def publish_unit_test_results(id: str, needs: List[str]) -> str:
-        return (f'  {id}:\n'
-                f'    name: "Publish Unit Tests Results"\n'
-                f'    needs: [{", ".join(needs)}]\n'
-                f'    runs-on: ubuntu-latest\n'
-                f'    # only run this job when the workflow is in success or failure state,\n'
-                f'    # not when it is in cancelled or skipped state\n'
-                f'    # only run this job on push events or when the event does not run in a fork repository\n'
-                f'    if: >\n'
-                f'      ( success() || failure() ) &&\n'
-                f"      needs.init-workflow.outputs.run_at_all == 'true' &&\n"
-                f'      ( github.event_name == \'push\' || ! github.event.head.repo.fork )\n'
-                f'\n'
-                f'    steps:\n'
-                f'      - name: Download GitHub Artifacts\n'
-                f'        uses: actions/download-artifact@v2\n'
-                f'        with:\n'
-                f'          path: artifacts\n'
-                f'\n'
-                f'      - name: Identify last run of each test\n'
-                f'        continue-on-error: true\n'
-                f'        run: |\n'
-                f'          declare -A last_runs\n'
-                f'          ls -d artifacts/Unit\\ Test\\ Results\\ */* | sort > runs.txt\n'
-                f'          while read run\n'
-                f'          do\n'
-                f'            test=${{run/%[_-]run[_-][0123456789]/}}\n'
-                f'            last_runs[$test]=$run\n'
-                f'          done < runs.txt\n'
-                f'\n'
-                f'          echo "LAST_RUNS<<EOF" >> $GITHUB_ENV\n'
-                f'          for test in "${{!last_runs[@]}}"\n'
-                f'          do\n'
-                f'            echo "${{last_runs[$test]}}" >&2\n'
-                f'            echo "${{last_runs[$test]}}/**/*.xml" >> $GITHUB_ENV\n'
-                f'          done\n'
-                f'          echo "EOF" >> $GITHUB_ENV\n'
-                f'        shell: bash\n'
-                f'\n'
-                f'      - name: Publish Unit Test Results\n'
-                f'        uses: EnricoMi/publish-unit-test-result-action@v1\n'
-                f'        if: always()\n'
-                f'        with:\n'
-                f'          check_name: Unit Test Results\n'
-                f'          files: "${{{{ env.LAST_RUNS }}}}"\n'
-                f'\n'
-                f'      - name: Publish Unit Test Results (with flaky tests)\n'
-                f'        uses: EnricoMi/publish-unit-test-result-action@v1\n'
-                f'        if: always()\n'
-                f'        with:\n'
-                f'          check_name: Unit Test Results (with flaky tests)\n'
-                f'          fail_on: errors\n'
-                f'          files: "artifacts/Unit Test Results */**/*.xml"\n')
-
     def publish_docker_images(needs: List[str], images: List[str]) -> str:
         if 'init-workflow' not in needs:
             needs.insert(0, 'init-workflow')
@@ -781,7 +738,6 @@ def main():
             build_and_test_macos(id='build-and-test-macos', name='Build and Test macOS', needs=['build-and-test']),
             trigger_buildkite_job(id='buildkite', name='Build and Test GPU (on Builtkite)', needs=['build-and-test'], mode='GPU NON HEADS'),
             trigger_buildkite_job(id='buildkite-heads', name='Build and Test GPU heads (on Builtkite)', needs=['buildkite'], mode='GPU HEADS'),
-            publish_unit_test_results(id='publish-test-results', needs=['build-and-test', 'build-and-test-heads', 'build-and-test-macos', 'buildkite', 'buildkite-heads']),
             publish_docker_images(needs=['build-and-test', 'buildkite'], images=['horovod', 'horovod-cpu', 'horovod-ray']),
             sync_files(needs=['init-workflow'])
         )

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -1,4 +1,8 @@
-name: CI (Fork)
+# publishes test results from the CI workflow
+# this has been moved out of the CI workflow into this workflow_run event to support PRs from fork repositories
+# this also publishes test results of PRs from horovod repositories
+# buildkite tests are only run here for fork repositories
+name: CI (Results)
 
 on:
   workflow_run:
@@ -129,12 +133,10 @@ jobs:
     name: "Publish Unit Tests Results"
     needs: [buildkite, buildkite-heads]
     runs-on: ubuntu-latest
-    # only run if CI workflow ran on a fork
     if: >
       always() &&
       github.event.workflow_run.conclusion != 'skipped' &&
-      github.event.workflow_run.conclusion != 'cancelled' &&
-      github.event.workflow_run.head_repository.fork
+      github.event.workflow_run.conclusion != 'cancelled'
 
     steps:
       - name: Debug Action
@@ -160,8 +162,43 @@ jobs:
         with:
           path: artifacts
 
+      - name: Identify last run of each test
+        continue-on-error: true
+        run: |
+          declare -A last_runs
+          ls -d artifacts/Unit\ Test\ Results\ */* | sort > runs.txt
+          while read run
+          do
+            test=${run/%[_-]run[_-][0123456789]/}
+            last_runs[$test]=$run
+          done < runs.txt
+
+          echo "LAST_RUNS<<EOF" >> $GITHUB_ENV
+          for test in "${!last_runs[@]}"
+          do
+            echo "${last_runs[$test]}" >&2
+            echo "${last_runs[$test]}/**/*.xml" >> $GITHUB_ENV
+          done
+          echo "EOF" >> $GITHUB_ENV
+        shell: bash
+
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
         with:
+          check_name: Unit Test Results
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
           commit: ${{ github.event.workflow_run.head_sha }}
-          files: "artifacts/*/**/*.xml"
+          files: "${{ env.LAST_RUNS }}"
+
+      - name: Publish Unit Test Results (with flaky tests)
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          check_name: Unit Test Results (with flaky tests)
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: "artifacts/Unit Test Results */**/*.xml"
+          fail_on: errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,17 @@ jobs:
     steps:
     - name: Debug Action
       uses: hmarr/debug-action@v1.0.0
+
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
+
   init-workflow:
     name: "Init Workflow"
     runs-on: ubuntu-latest
@@ -3505,59 +3516,6 @@ jobs:
         run: |
           echo "::warning::Buildkite pipeline did not pass: ${{ steps.build.outputs.url }}"
           exit 1
-
-  publish-test-results:
-    name: "Publish Unit Tests Results"
-    needs: [build-and-test, build-and-test-heads, build-and-test-macos, buildkite, buildkite-heads]
-    runs-on: ubuntu-latest
-    # only run this job when the workflow is in success or failure state,
-    # not when it is in cancelled or skipped state
-    # only run this job on push events or when the event does not run in a fork repository
-    if: >
-      ( success() || failure() ) &&
-      needs.init-workflow.outputs.run_at_all == 'true' &&
-      ( github.event_name == 'push' || ! github.event.head.repo.fork )
-
-    steps:
-      - name: Download GitHub Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Identify last run of each test
-        continue-on-error: true
-        run: |
-          declare -A last_runs
-          ls -d artifacts/Unit\ Test\ Results\ */* | sort > runs.txt
-          while read run
-          do
-            test=${run/%[_-]run[_-][0123456789]/}
-            last_runs[$test]=$run
-          done < runs.txt
-
-          echo "LAST_RUNS<<EOF" >> $GITHUB_ENV
-          for test in "${!last_runs[@]}"
-          do
-            echo "${last_runs[$test]}" >&2
-            echo "${last_runs[$test]}/**/*.xml" >> $GITHUB_ENV
-          done
-          echo "EOF" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          check_name: Unit Test Results
-          files: "${{ env.LAST_RUNS }}"
-
-      - name: Publish Unit Test Results (with flaky tests)
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          check_name: Unit Test Results (with flaky tests)
-          fail_on: errors
-          files: "artifacts/Unit Test Results */**/*.xml"
 
   docker-config:
     name: Configure docker build


### PR DESCRIPTION
Test results are posted to the respective pull request:
![grafik](https://user-images.githubusercontent.com/44700269/135154525-5317c760-2225-437d-9664-847f53ec4cc8.png)

However, results from fork PRs currently lack a few features: change stats (`±0`), added, removed or newly skipped tests:
![grafik](https://user-images.githubusercontent.com/44700269/135154215-8901a362-b53e-4e90-a296-e6d759555f4b.png)

Most of our contributions come from forks nowadays so identifying changes in test coverage is important but very hard without these change stats.

This fix makes PRs from forks also have change statistics. Test results are now published by the `CI (Results)` workflow **only**. This works for fork PRs as well for PRs from the horovod repo, so that there is only one place that publishes results.