### PR TITLE
Increase build timeout to 40m on Buildkite

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -78,7 +78,7 @@ build_test() {
   echo "      push-retries: 5"
   echo "  - ecr#v1.2.0:"
   echo "      login: true"
-  echo "  timeout_in_minutes: 30"
+  echo "  timeout_in_minutes: 40"
   echo "  retry:"
   echo "    automatic: true"
   echo "  agents:"

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -9,7 +9,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -9,7 +9,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:
@@ -24,7 +24,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:
@@ -39,7 +39,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:
@@ -54,7 +54,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:
@@ -69,7 +69,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:
@@ -84,7 +84,7 @@ steps:
       push-retries: 5
   - ecr#v1.2.0:
       login: true
-  timeout_in_minutes: 30
+  timeout_in_minutes: 40
   retry:
     automatic: true
   agents:


### PR DESCRIPTION
Buildkite seems to timeout on building the GPU images:
- https://buildkite.com/horovod/horovod/builds?branch=master
- https://buildkite.com/horovod/horovod/builds/6517#c096ad84-17b0-498c-86da-1cc800f656fc

Giving it 10 more minutes to build.

@tgaddair the build time probably increased due to reducing the number of CPUs.