### PR TITLE
Change CMake syntax to be compatible with old versions of CMake

### DIFF
--- a/cmake/Modules/FindTensorflow.cmake
+++ b/cmake/Modules/FindTensorflow.cmake
@@ -22,7 +22,7 @@ if (LEN EQUAL "4")
     string(REPLACE " " ";" Tensorflow_LIBRARIES_LIST "${Tensorflow_LIBRARIES}")
     list(GET Tensorflow_LIBRARIES_LIST 0 Tensorflow_LIB_PATH_ARGUMENT)
     string(REGEX REPLACE "^-L" "" Tensorflow_LIB_PATH ${Tensorflow_LIB_PATH_ARGUMENT})
-    if (Tensorflow_VERSION VERSION_GREATER_EQUAL "2.6")
+    if (Tensorflow_VERSION VERSION_GREATER "2.6" OR Tensorflow_VERSION VERSION_EQUAL "2.6")
 #        # XLA implementations are in _pywrap_tensorflow_internal.so
         set(Tensorflow_LIBRARIES "${Tensorflow_LIBRARIES} ${Tensorflow_LIB_PATH}/python/_pywrap_tensorflow_internal.so")
     endif()


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Ubuntu 16.04 comes with CMake 3.5.1 by default. I tested that with this change Horovod builds successfully with TensorFlow in such a container.

We currently ask for version 2.8.12 or higher in the root `CMakeLists.txt`.