### PR TITLE
use trained model if no custom checkpoint call back is specified. 

### DIFF
--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -223,8 +223,9 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                     # One more file sync to push profiler result.
                     remote_store.sync(logs_path)
 
-                # rank 0 overwrites model with best checkpoint and returns.
-                best_model = model.load_from_checkpoint(_checkpoint_callback.best_model_path)
+                # Rank 0 overwrites model with best checkpoint and returns.
+                # Need to set strict=False for dynamically added layers.
+                best_model = model.load_from_checkpoint(_checkpoint_callback.best_model_path, strict=False)
                 serialized_checkpoint = io.BytesIO()
                 module = best_model if not is_legacy else best_model._model
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
In lightning estimator, we do not need to load from check point if only want to return the last weights. The model after trianer.fit already have them. 