### PR TITLE
add_history_in_lightning_estimator

### DIFF
--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -913,6 +913,39 @@ class SparkLightningTests(unittest.TestCase):
                 assert len(pred) == 1
                 assert pred.dtype == torch.float32
 
+    """
+    Test override trainer args.
+    """
+    def test_model_override_trainer_args(self):
+        from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
+
+        with spark_session('test_fit_model') as spark:
+            df = create_noisy_xor_data(spark)
+            model = create_xor_model()
+
+            with tempdir() as dir:
+
+                with local_store() as store:
+                    torch_estimator = hvd_spark.TorchEstimator(
+                        num_proc=2,
+                        store=store,
+                        model=model,
+                        input_shapes=[[-1, 2]],
+                        feature_cols=['features'],
+                        label_cols=['y'],
+                        validation=0.2,
+                        batch_size=4,
+                        epochs=2,
+                        verbose=2,
+                        trainer_args={'stochastic_weight_avg': True})
+
+                    torch_model = torch_estimator.fit(df)
+
+                    # TODO: Find a way to pass log metrics from remote, and assert base on the logger.
+                    trained_model = torch_model.getModel()
+                    pred = trained_model(torch.ones([1, 2], dtype=torch.int32))
+                    assert len(pred) == 1
+                    assert pred.dtype == torch.float32
 
 def check_fail(dir, rank, epoch, batch):
     if dir:


### PR DESCRIPTION
## Description
- Save the logged metrics as history, which will be saved in the output transformer. This is to match with behavior with keras estimator. And the history can be used for hp search. 
- Added a new arg "trainer_args" to override the lightning trainer args. 
- Change the progress bar to only refresh once per epoch. 
- Added unit test. 
