### PR TITLE
fix the issue when passing history from GPU to CPU

### DIFF
--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -439,13 +439,15 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         return store.read(last_ckpt_path)
 
     def _create_model(self, run_results, run_id, metadata):
-        serialized_checkpoint, history = run_results[0]
+        serialized_checkpoint = run_results[0]
         serialized_checkpoint.seek(0)
         best_checkpoint = torch.load(serialized_checkpoint, map_location=torch.device('cpu'))
 
         model = copy.deepcopy(self.getModel())
         model.load_state_dict(best_checkpoint['model'])
         model.eval()
+
+        history = best_checkpoint['logged_metrics']
 
         # Optimizer is part of the model no need to return it to transformer.
         # TODO: (Pengz) Update the latest state of the optimizer in the model for retraining.

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -248,15 +248,11 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                 serialized_checkpoint = io.BytesIO()
                 module = best_model if not is_legacy else best_model._model
 
-                # TODO: find a way to pass trainer.logged_metrics out.
-                output = {'model': module.state_dict()}
+                output = {'model': module.state_dict(), 'logged_metrics': trainer.logged_metrics}
 
                 torch.save(output, serialized_checkpoint)
 
-                # Save logged metrics as history, which will saved in transformer.
-                history = trainer.logged_metrics
-
-                return serialized_checkpoint, history
+                return serialized_checkpoint
     return train
 
 


### PR DESCRIPTION
## Description
Fix a error introduced in https://github.com/horovod/horovod/pull/3214
```RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False.```
is raised when getting the lightning estimator history from CPU.

Need to save it inside the checkpoint dict , which will be load with map_location=torch.device('cpu')

