### PR TITLE
Fix json output in CI for test results

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -51,8 +51,9 @@ jobs:
         do
           gh api "$url" > "pr.zip"
           unzip -o "pr.zip"
-          cat pr.json
           echo "::set-output name=json::$(cat pr.json)"
+          cat pr.json
+          echo
         done
 
         if [[ ! -e "pr.json" ]]


### PR DESCRIPTION
The `ci-results.yaml` can only be tested in master, and it turned out that the `pr-json` output is not properly set.

The job first printed the json string for debug purposes via `cat pr.json` and then set the output through `echo ...`. There is no newline in the json file so the echo got appended to the json output and thus not picked up by GitHub actions runner:

    { "merge_sha": "db94c8a71c9171f101b7144632f3f4c3697789f3", "base_sha": "8c6e4b855f6451750a82e6ab50a0452100434c27"
    , "head_sha": "6df11cfa7060a675c8812d65ca23d685d0b4995d" }::set-output name=json::{ "merge_sha": "db94c8a71c9171f
    101b7144632f3f4c3697789f3", "base_sha": "8c6e4b855f6451750a82e6ab50a0452100434c27", "head_sha": "6df11cfa7060a675
    c8812d65ca23d685d0b4995d" }

This fixes this.