### PR TITLE
Job buildkite-heads accesses ci-workflow outputs, add it to the needs

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -112,7 +112,7 @@ jobs:
 
   buildkite-heads:
     name: "Build and Test GPU heads (on Builtkite)"
-    needs: [buildkite]
+    needs: [ci-workflow, buildkite]
     runs-on: ubuntu-latest
     # only run if CI workflow's build-and-test job succeeded and CI workflow ran on a fork
     if: >


### PR DESCRIPTION
The `buildkite-heads` job in `ci-results.yaml` accesses outputs of job `ci-workflow` but does not list it in its `needs`, so the string is empty, which makes the job fail on parsing the empty json string:
https://github.com/horovod/horovod/runs/3897640061?check_suite_focus=true

The `buildkite` job works perfectly well, which has access to `ci-workflow`:
https://github.com/horovod/horovod/runs/3896534243?check_suite_focus=true