### PR TITLE
RayExecutor: Dynamic executor for elastic and static jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
+- Added Elastic keyword parameters to RayExecutor API: This API supports both static(non-elastic) and elastic horovod jobs. This resolves issue:
+[#3190](https://github.com/horovod/horovod/issues/3190).
 
 - TensorFlow: Added in-place broadcasting of variables. ([#3128](https://github.com/horovod/horovod/pull/3128))
 
 ### Changed
 
 ### Deprecated
-
+- Deprecated ElasticRayExecutor APIs in favor of the new RayExecutor API for issue: [#3190](https://github.com/horovod/horovod/issues/3190).
 ### Removed
 
 ### Fixed

--- a/docs/ray.rst
+++ b/docs/ray.rst
@@ -110,7 +110,7 @@ A unique feature of Ray is its support for `stateful Actors <https://docs.ray.io
 Elastic Ray Executor
 --------------------
 
-Ray also supports `elastic execution <elastic.rst>`_ via :ref:`the ElasticRayExecutor <horovod_ray_api>`. Similar to default Horovod, the difference between the non-elastic and elastic versions of Ray is that the hosts and number of workers is dynamically determined at runtime.
+Ray also supports `elastic execution <elastic.rst>`_ via :ref:`the RayExecutor <horovod_ray_api>`. Similar to default Horovod, the difference between the non-elastic and elastic versions of Ray is that the hosts and number of workers is dynamically determined at runtime.
 
 You must first set up `a Ray cluster`_. Ray clusters can support autoscaling for any cloud provider (AWS, GCP, Azure).
 
@@ -153,10 +153,12 @@ You can then attach to the underlying Ray cluster and execute the training funct
 .. code-block:: python
 
     import ray
+    from horovod.ray import RayExecutor
+
     ray.init(address="auto")  # attach to the Ray cluster
-    settings = ElasticRayExecutor.create_settings(verbose=True)
-    executor = ElasticRayExecutor(
-        settings, use_gpu=True, cpus_per_slot=2)
+    settings = RayExecutor.create_settings(verbose=True)
+    executor = RayExecutor(
+        settings, min_workers=1, use_gpu=True, cpus_per_slot=2)
     executor.start()
     executor.run(training_fn)
 

--- a/horovod/ray/adapter.py
+++ b/horovod/ray/adapter.py
@@ -1,0 +1,126 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Callable, Any, Optional, List
+from dataclasses import dataclass
+
+@dataclass
+class BaseParams:
+    cpus_per_worker: int = 1
+    use_gpu: bool = False
+    gpus_per_worker: Optional[int] = None
+    def __post_init__(self):
+        if self.gpus_per_worker and not self.use_gpu:
+            raise ValueError("gpus_per_worker is set, but use_gpu is False. "
+                             "use_gpu must be True if gpus_per_worker is "
+                             "set. ")
+        if self.use_gpu and isinstance(self.gpus_per_worker,
+                                  int) and self.gpus_per_worker < 1:
+            raise ValueError(
+                f"gpus_per_worker must be >= 1: Got {self.gpus_per_worker}.")
+        self.gpus_per_worker = self.gpus_per_worker or int(self.use_gpu)
+
+
+class Adapter(ABC):
+    """Adapter for executing Ray calls for various types(e.g. static and elastic)
+    Horovod jobs.
+    """
+    @abstractmethod
+    def start(self,
+              executable_cls: type = None,
+              executable_args: Optional[List] = None,
+              executable_kwargs: Optional[Dict] = None,
+              extra_env_vars: Optional[Dict] = None):
+        """Starts the Adapter
+
+        Args:
+            executable_cls (type): The class that will be created within
+                an actor (BaseHorovodWorker). This will allow Horovod
+                to establish its connections and set env vars.
+            executable_args (List): Arguments to be passed into the
+                worker class upon initialization.
+            executable_kwargs (Dict): Keyword arguments to be passed into the
+                worker class upon initialization.
+            extra_env_vars (Dict): Environment variables to be set
+                on the actors (worker processes) before initialization.
+        """
+        raise NotImplementedError("Method must be implemented in a subclass")
+
+    @abstractmethod
+    def execute(self, fn: Callable[["executable_cls"], Any],
+                callbacks: Optional[List[Callable]] = None) -> List[Any]:
+        """Executes the provided function on all workers.
+
+        Args:
+            fn: Target function to be invoked on every object.
+            callbacks: List of callables. Each callback must either
+                be a callable function or a class that implements __call__.
+                Every callback will be invoked on every value logged
+                by the rank 0 worker.
+
+        Returns:
+            Deserialized return values from the target function.
+        """
+        raise NotImplementedError("Method must be implemented in a subclass")
+
+    @abstractmethod
+    def run(self,
+        fn: Callable[[Any], Any],
+        args: Optional[List] = None,
+        kwargs: Optional[Dict] = None,
+        callbacks: Optional[List[Callable]] = None) -> List[Any]:
+        """Executes the provided function on all workers.
+
+        Args:
+            fn: Target function that can be executed with arbitrary
+                args and keyword arguments.
+            args: List of arguments to be passed into the target function.
+            kwargs: Dictionary of keyword arguments to be
+                passed into the target function.
+            callbacks: List of callables. Each callback must either
+                be a callable function or a class that implements __call__.
+                Every callback will be invoked on every value logged
+                by the rank 0 worker.
+
+        Returns:
+            Deserialized return values from the target function.
+        """
+        raise NotImplementedError("Method must be implemented in a subclass")
+
+    @abstractmethod
+    def run_remote(self,
+                   fn: Callable[[Any], Any],
+                   args: Optional[List] = None,
+                   kwargs: Optional[Dict] = None,
+                   callbacks: Optional[List[Callable]] = None):
+
+        """Executes the provided function on all workers.
+
+        Args:
+            fn: Target function that can be executed with arbitrary
+                args and keyword arguments.
+            args: List of arguments to be passed into the target function.
+            kwargs: Dictionary of keyword arguments to be
+                passed into the target function.
+
+        Returns:
+            list: List of ObjectRefs that you can run `ray.get` on to
+                retrieve values.
+        """
+        raise NotImplementedError("Method must be implemented in a subclass")
+
+    @abstractmethod
+    def execute_single(self,
+                       fn: Callable[["executable_cls"], Any]) -> List[Any]:
+        """Executes the provided function on the rank 0 worker (chief).
+
+        Args:
+            fn: Target function to be invoked on the chief object.
+
+        Returns:
+            Deserialized return values from the target function.
+        """
+        raise NotImplementedError("Method must be implemented in a subclass")
+
+    @abstractmethod
+    def shutdown(self):
+        """Destroys the adapter."""
+        raise NotImplementedError("Method must be implemented in a subclass")

--- a/test/single/test_ray_elastic_v2.py
+++ b/test/single/test_ray_elastic_v2.py
@@ -1,0 +1,371 @@
+"""Ray-Horovod Elastic training unit tests.
+
+This is currently not run on the Ray CI.
+"""
+from contextlib import contextmanager
+import psutil
+import os
+import socket
+
+import mock
+import pytest
+import ray
+
+from horovod.common.util import gloo_built
+from horovod.runner.elastic.discovery import HostDiscovery
+from horovod.ray.elastic_v2 import RayHostDiscovery
+from horovod.ray.runner import RayExecutor
+
+
+
+@pytest.fixture
+def ray_shutdown():
+    yield
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def ray_8_cpus():
+    ray.init(num_cpus=8, resources={
+        f"node:host-{i}": 1 for i in range(10)})
+    yield
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def ray_8_cpus_gpus():
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        if len(os.environ["CUDA_VISIBLE_DEVICES"].split(",")) < 8:
+            pytest.skip("Avoiding mismatched GPU machine.")
+    ray.init(num_cpus=8, num_gpus=8, resources={
+        f"node:host-{i}": 1 for i in range(10)})
+    try:
+        yield
+    finally:
+        # The code after the yield will run as teardown code.
+        ray.shutdown()
+
+
+class TestRayDiscoverySuite:
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_cpu_discovery(self, ray_shutdown):
+        ray.init(num_cpus=4, num_gpus=1)
+        discovery = RayHostDiscovery(cpus_per_worker=1)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert len(mapping) == 1
+        assert list(mapping.values()) == [4]
+
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_gpu_discovery(self, ray_shutdown):
+        ray.init(num_cpus=4, num_gpus=1)
+        discovery = RayHostDiscovery(use_gpu=True, cpus_per_worker=1)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert len(mapping) == 1
+        assert list(mapping.values()) == [1]
+
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_gpu_slot_discovery(self, ray_shutdown):
+        ray.init(num_cpus=4, num_gpus=4)
+        discovery = RayHostDiscovery(
+            use_gpu=True, cpus_per_worker=1, gpus_per_worker=2)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert len(mapping) == 1
+        assert list(mapping.values()) == [2]
+
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_multinode(self, monkeypatch):
+        def create_multi_node_mock():
+            host_names = ["host-1", "host-2", "host-3"]
+            resources = {"GPU": 2, "CPU": 8}
+
+            def create_node_entry(hostname):
+                return {
+                    "NodeManagerAddress": hostname,
+                    "Resources": resources.copy(),
+                    "alive": True
+                }
+
+            return map(create_node_entry, host_names)
+
+        monkeypatch.setattr(ray, "nodes", create_multi_node_mock)
+        discovery = RayHostDiscovery(use_gpu=True, cpus_per_worker=1)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert len(mapping) == 3
+        assert list(mapping.values()) == [2, 2, 2]
+
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_multinode_gpus_per_slot(self, monkeypatch):
+        def create_multi_node_mock():
+            host_names = ["host-1", "host-2", "host-3"]
+            resources = {"GPU": 2, "CPU": 8}
+
+            def create_node_entry(hostname):
+                return {
+                    "NodeManagerAddress": hostname,
+                    "Resources": resources.copy(),
+                    "alive": True
+                }
+
+            return map(create_node_entry, host_names)
+
+        monkeypatch.setattr(ray, "nodes", create_multi_node_mock)
+        discovery = RayHostDiscovery(use_gpu=True, gpus_per_worker=2)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert len(mapping) == 3
+        assert list(mapping.values()) == [1, 1, 1]
+
+    @pytest.mark.skipif(
+        not gloo_built(), reason='Gloo is required for Ray integration')
+    def test_multinode_mismatch(self, monkeypatch):
+        def create_multi_node_mock():
+            host_names = ["host-1", "host-2", "host-3"]
+            resources = {"CPU": 8}
+
+            def create_node_entry(hostname):
+                return {
+                    "NodeManagerAddress": hostname,
+                    "Resources": resources.copy(),
+                    "alive": True
+                }
+
+            return map(create_node_entry, host_names)
+
+        monkeypatch.setattr(ray, "nodes", create_multi_node_mock)
+        discovery = RayHostDiscovery(use_gpu=True, cpus_per_worker=1)
+        mapping = discovery.find_available_hosts_and_slots()
+        assert sum(mapping.values()) == 0
+
+
+class SimpleTestDiscovery(HostDiscovery):
+    def __init__(self, schedule):
+        self._schedule = schedule
+        self._generator = self.host_generator()
+
+    def host_generator(self):
+        for iters, hosts in self._schedule:
+            iters = iters or 500  # max
+            for i in range(iters):
+                yield hosts
+
+    def find_available_hosts_and_slots(self):
+        hostlist = next(self._generator)
+        hosts = {}
+        for item in hostlist:
+            host, slots = item.split(":")
+            slots = int(slots)
+            hosts[host] = slots
+        return hosts
+
+
+class StatusCallback:
+    def __init__(self):
+        self._journal = []
+
+    def __call__(self, info_dict):
+        self._journal.append(info_dict)
+
+    def fetch(self):
+        return self._journal.copy()
+
+
+def _create_training_function(iterations):
+    def training_fn():
+        import time
+        import torch
+        import horovod.torch as hvd
+        from horovod.ray import ray_logger
+
+        hvd.init()
+
+        model = torch.nn.Sequential(torch.nn.Linear(2, 2))
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        ray_logger.log({"started": True, "pid": os.getpid()})
+
+        @hvd.elastic.run
+        def train(state):
+            for state.epoch in range(state.epoch, iterations):
+                ray_logger.log({"training": True, "pid": os.getpid()})
+                time.sleep(0.1)
+                state.commit()  # triggers scale-up, scale-down
+            ray_logger.log({"finished": True, "pid": os.getpid()})
+
+        state = hvd.elastic.TorchState(
+            model, optimizer, batch=0, epoch=0, commits=0, rendezvous=0)
+        train(state)
+        return True
+
+    return training_fn
+
+
+@contextmanager
+def fault_tolerance_patches():
+    with mock.patch(
+            'horovod.runner.elastic.driver.DISCOVER_HOSTS_FREQUENCY_SECS',
+            0.1):
+        with mock.patch(
+                "horovod.runner.util.network.get_driver_ip",
+                return_value=socket.gethostbyname(socket.gethostname())):
+            yield
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+@pytest.mark.skip(reason='https://github.com/horovod/horovod/issues/3197')
+def test_fault_tolerance_hosts_added_and_removed(ray_8_cpus):
+    with fault_tolerance_patches():
+        discovery_schedule = [
+            (10, ['host-1:2']),
+            (30, ['host-1:2', 'host-2:1', 'host-3:1']),
+            (None, ['host-2:1']),
+        ]
+        nics = list(psutil.net_if_addrs().keys())[0]
+
+        settings = RayExecutor.create_settings(nics={nics})
+        settings.discovery = SimpleTestDiscovery(discovery_schedule)
+        executor = RayExecutor(
+            settings,
+            min_workers=1,
+            cpus_per_worker=1, override_discovery=False)
+
+        training_fn = _create_training_function(iterations=50)
+        executor.start()
+        trace = StatusCallback()
+        results = executor.run(training_fn, callbacks=[trace])
+        assert len(results) == 1
+
+        events = trace.fetch()
+        assert sum(int("started" in e) for e in events) == 4, events
+        assert sum(int("finished" in e) for e in events) == 1, events
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+@pytest.mark.skip(reason='https://github.com/horovod/horovod/issues/3197')
+def test_fault_tolerance_hosts_remove_and_add(ray_8_cpus):
+    with fault_tolerance_patches():
+        discovery_schedule = [
+            (10, ['host-1:2', 'host-2:1', 'host-3:2']),
+            (10, ['host-1:2']),
+            (None, ['host-1:2', 'host-4:1', 'host-5:1']),
+        ]
+        nics = list(psutil.net_if_addrs().keys())[0]
+
+        settings = RayExecutor.create_settings(nics={nics})
+        settings.discovery = SimpleTestDiscovery(discovery_schedule)
+        executor = RayExecutor(settings,
+            min_workers=1, cpus_per_worker=1, override_discovery=False)
+
+        training_fn = _create_training_function(iterations=30)
+        executor.start()
+        trace = StatusCallback()
+        results = executor.run(training_fn, callbacks=[trace])
+        assert len(results) == 4
+
+        events = trace.fetch()
+        assert sum(int("started" in e) for e in events) == 7, events
+        assert sum(int("finished" in e) for e in events) == 4, events
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+def test_max_np(ray_8_cpus):
+    with fault_tolerance_patches():
+        discovery_schedule = [
+            (10, ['host-1:2']),
+            (None, ['host-1:2', 'host-4:1', 'host-5:1']),
+        ]
+        nics = list(psutil.net_if_addrs().keys())[0]
+
+        settings = RayExecutor.create_settings(nics={nics})
+        settings.discovery = SimpleTestDiscovery(discovery_schedule)
+        executor = RayExecutor(settings,
+            min_workers=1, max_workers=2, cpus_per_worker=1, override_discovery=False)
+
+        training_fn = _create_training_function(iterations=20)
+        executor.start()
+        trace = StatusCallback()
+        results = executor.run(training_fn, callbacks=[trace])
+        assert len(results) == 2
+
+        events = trace.fetch()
+        assert sum(int("started" in e) for e in events) == 2, events
+        assert sum(int("finished" in e) for e in events) == 2, events
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+def test_min_np(ray_8_cpus):
+    with fault_tolerance_patches():
+        discovery_schedule = [
+            (10, ['host-1:1']),
+            (10, ['host-1:1', 'host-4:1', 'host-5:1']),
+            (None, ['host-1:1', 'host-4:1', 'host-5:1', 'host-6:1']),
+        ]
+        nics = list(psutil.net_if_addrs().keys())[0]
+
+        settings = RayExecutor.create_settings(nics={nics})
+        settings.discovery = SimpleTestDiscovery(discovery_schedule)
+        executor = RayExecutor(settings,
+            min_workers=4,
+            max_workers=4,
+            override_discovery=False
+        )
+
+        training_fn = _create_training_function(iterations=30)
+        executor.start()
+        trace = StatusCallback()
+        results = executor.run(training_fn, callbacks=[trace])
+        assert len(results) == 4
+
+        events = trace.fetch()
+        assert sum(int("started" in e) for e in events) == 4, events
+        assert sum(int("finished" in e) for e in events) == 4, events
+
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+def test_gpu_e2e(ray_8_cpus_gpus):
+    with fault_tolerance_patches():
+        discovery_schedule = [
+            (10, ['host-1:1']),
+            (10, ['host-1:1', 'host-4:1', 'host-5:1']),
+            (None, ['host-1:1', 'host-4:1', 'host-5:1', 'host-6:1']),
+        ]
+        nics = list(psutil.net_if_addrs().keys())[0]
+
+        settings = RayExecutor.create_settings(nics={nics})
+        settings.discovery = SimpleTestDiscovery(discovery_schedule)
+        executor = RayExecutor(settings,
+            min_workers=4, max_workers=4, gpus_per_worker=1, use_gpu=True, override_discovery=False)
+
+        training_fn = _create_training_function(iterations=30)
+        executor.start()
+        trace = StatusCallback()
+        results = executor.run(training_fn, callbacks=[trace])
+        assert len(results) == 4
+
+        events = trace.fetch()
+        assert sum(int("started" in e) for e in events) == 4, events
+        assert sum(int("finished" in e) for e in events) == 4, events
+
+@pytest.mark.skipif(
+    not gloo_built(), reason='Gloo is required for Ray integration')
+def test_both_num_workers_min_workers(ray_8_cpus):
+    settings = RayExecutor.create_settings()
+    with pytest.raises(ValueError, match=r"Both `min_workers` and `num_workers` provided."):
+        executor = RayExecutor(
+            settings,
+            min_workers=1,
+            num_workers=1,
+            cpus_per_worker=1)
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(sys.argv[1:] + ["-v", "-x", __file__]))


### PR DESCRIPTION
RayExecutor V2: Dynamic executor for elastic and static jobs

This resolves #3190 by adding elastic params to the RayExecutor API for horovod:
This API now supports both static(non-elastic) and elastic horovod jobs.

Example of static job(Identical to current RayExecutor):
```python
from horovod.ray import RayExecutor
ray.init()
hjob = RayExecutor(setting, num_workers=num_workers,
        use_gpu=True
    ))

executor.start()

def simple_fn():
    hvd.init()
    print("hvd rank", hvd.rank())
    return hvd.rank()

result = executor.run(simple_fn)
assert len(set(result)) == hosts * num_slots

executor.shutdown()
```
Example of an elastic job:
```python
from horovod.ray import RayExecutor
import horovod.torch as hvd

def training_fn():
    hvd.init()
    model = Model()
    torch.cuda.set_device(hvd.local_rank())

    @hvd.elastic.run
    def train(state):
        for state.epoch in range(state.epoch, epochs):
            ...
            state.commit()

    state = hvd.elastic.TorchState(model, optimizer, batch=0, epoch=0)
    state.register_reset_callbacks([on_state_reset])
    train(state)
    return

executor = RayExecutor(settings, min_workers=1, use_gpu=True, cpus_per_worker=2)
executor.start()
executor.run(training_fn)
```