### PR TITLE
Change default fusion threshold from 64MB to 128MB in docs

### DIFF
--- a/docs/tensor-fusion.rst
+++ b/docs/tensor-fusion.rst
@@ -10,7 +10,7 @@ Tensor Fusion works by attempting to combine all the tensors that are ready to b
 one reduction operation. The algorithm of Tensor Fusion is as follows:
 
 1. Determine which tensors are ready to be reduced. Select first few tensors that fit in ``HOROVOD_FUSION_THRESHOLD`` bytes and have the same data type.
-2. Allocate fusion buffer of size ``HOROVOD_FUSION_THRESHOLD`` if it was not allocated before. Default fusion buffer size is 64 MB.
+2. Allocate fusion buffer of size ``HOROVOD_FUSION_THRESHOLD`` if it was not allocated before. Default fusion buffer size is 128 MB.
 3. Copy data of selected tensors into the fusion buffer.
 4. Execute the **allreduce** operation on the fusion buffer.
 5. Copy data from the fusion buffer into the output tensors.


### PR DESCRIPTION

According to: [Changed default cycle time from 5ms to 1ms and fusion threshold from 64MB to 128MB](https://github.com/horovod/horovod/pull/2468)