### PR TITLE
Call process_set._setup in init() to point to the correct native lib path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - fix the example of pytorch_lightning_mnist.py ([#3245](https://github.com/horovod/horovod/pull/3245))
 
+- Call _setup in remote trainers to point to the correct shared lib path ([#3258](https://github.com/horovod/horovod/pull/3258))
 ## [v0.23.0] - 2021-10-06
 
 ### Added

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -80,6 +80,9 @@ RUN if [[ ${SPARK_PACKAGE} != *"-preview"* ]]; then \
 # Updating to 1.7.0 to pass ray tests
 RUN pip install --no-cache-dir ray==1.7.0
 
+# Pin protobuf to 3.9.2 to make tensorflow 2.5.1 happy.
+RUN pip install --no-cache-dir protobuf==3.9.2
+
 # Install MPI.
 RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
         wget --progress=dot:mega -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/horovod/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz && \

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -227,7 +227,7 @@ RUN if [[ ${MPI_KIND} == "ONECCL" ]]; then \
     fi; \
     cd /horovod && \
     python setup.py sdist && \
-    bash -c "${HOROVOD_BUILD_FLAGS} HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray]"
+    bash -c "${HOROVOD_BUILD_FLAGS} HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray] protobuf==3.9.2"
 
 # Show the effective python package version to easily spot version differences
 RUN pip freeze | sort

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -80,9 +80,6 @@ RUN if [[ ${SPARK_PACKAGE} != *"-preview"* ]]; then \
 # Updating to 1.7.0 to pass ray tests
 RUN pip install --no-cache-dir ray==1.7.0
 
-# Pin protobuf to 3.9.2 to make tensorflow 2.5.1 happy.
-RUN pip install --no-cache-dir protobuf==3.9.2
-
 # Install MPI.
 RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
         wget --progress=dot:mega -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/horovod/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz && \
@@ -227,7 +224,7 @@ RUN if [[ ${MPI_KIND} == "ONECCL" ]]; then \
     fi; \
     cd /horovod && \
     python setup.py sdist && \
-    bash -c "${HOROVOD_BUILD_FLAGS} HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray] protobuf==3.9.2"
+    bash -c "${HOROVOD_BUILD_FLAGS} HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 HOROVOD_WITH_MXNET=1 pip install --no-cache-dir -v $(ls /horovod/dist/horovod-*.tar.gz)[spark,ray]"
 
 # Show the effective python package version to easily spot version differences
 RUN pip freeze | sort

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -39,7 +39,6 @@ else:
     check_installed_version('mxnet', mx.__version__)
 
 # import basic methods
-init = _basics.init
 shutdown = _basics.shutdown
 is_initialized = _basics.is_initialized
 start_timeline = _basics.start_timeline
@@ -60,6 +59,11 @@ ddl_built = _basics.ddl_built
 ccl_built = _basics.ccl_built
 cuda_built = _basics.cuda_built
 rocm_built = _basics.rocm_built
+
+def init(*args, **kwargs):
+    _basics.init(*args, **kwargs)
+    # Call set up again to make sure the basics is in sync
+    _setup_process_sets(_basics)
 
 dll_path = os.path.join(os.path.dirname(__file__),
                         'mpi_lib' + get_ext_suffix())

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -109,6 +109,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
 
         hvd = get_horovod()
         hvd.init()
+
         pin_gpu(hvd, tf, k)
 
         if not user_shuffle_buffer_size:
@@ -128,6 +129,9 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
 
         # Verbose mode 1 will print a progress bar
         verbose = user_verbose if hvd.rank() == 0 else 0
+
+        if verbose:
+            print(f"Shared lib path is pointing to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
 
         transform_spec = None
         if transformation:
@@ -226,12 +230,6 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
             else:
                 reader_factory = make_batch_reader
                 is_batch_reader = True
-
-            # Call _setup again in process set module to point shared lib to tensorflow's module
-            # since the lib path might be overwritten in remote trainer.
-            _horovod.common.process_sets._setup(_horovod.tensorflow.mpi_ops._basics)
-            if verbose:
-                print(f"Set shared lib path to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
 
             with reader_factory(remote_store.train_data_path,
                                 num_epochs=1,

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -227,6 +227,12 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                 reader_factory = make_batch_reader
                 is_batch_reader = True
 
+            # Call _setup again in process set module to point shared lib to tensorflow's module
+            # since the lib path might be overwritten in remote trainer.
+            _horovod.common.process_sets._setup(_horovod.tensorflow.mpi_ops._basics)
+            if verbose:
+                print(f"Set shared lib path to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
+
             with reader_factory(remote_store.train_data_path,
                                 num_epochs=1,
                                 cur_shard=hvd.rank(),

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -97,6 +97,8 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
     def train(serialized_model):
         import horovod.torch as hvd
+        import horovod as _horovod
+
         # Horovod: initialize library.
         hvd.init()
         _checkpoint_callback = None
@@ -215,6 +217,12 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                 trainer.profiler.filename = "profile"
 
             print(f"pytorch_lightning version={pl.__version__}")
+
+            # Call _setup again in process set module to point shared lib to torch's module
+            # since the lib path might be overwritten in remote trainer.
+            _horovod.common.process_sets._setup(_horovod.torch.mpi_ops._basics)
+            if verbose:
+                print(f"Set shared lib path to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
 
             dataset = data_module(train_dir=remote_store.train_data_path,
                                   val_dir=remote_store.val_data_path,

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -97,10 +97,14 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
     def train(serialized_model):
         import horovod.torch as hvd
-        import horovod as _horovod
 
         # Horovod: initialize library.
         hvd.init()
+
+        if verbose:
+            import horovod as _horovod
+            print(f"Shared lib path is pointing to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
+
         _checkpoint_callback = None
         require_checkpoint = False
 
@@ -217,12 +221,6 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                 trainer.profiler.filename = "profile"
 
             print(f"pytorch_lightning version={pl.__version__}")
-
-            # Call _setup again in process set module to point shared lib to torch's module
-            # since the lib path might be overwritten in remote trainer.
-            _horovod.common.process_sets._setup(_horovod.torch.mpi_ops._basics)
-            if verbose:
-                print(f"Set shared lib path to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
 
             dataset = data_module(train_dir=remote_store.train_data_path,
                                   val_dir=remote_store.val_data_path,

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -103,6 +103,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         from petastorm.pytorch import BatchedDataLoader, InMemBatchedDataLoader
         import torch
         import horovod.torch as hvd
+        import horovod as _horovod
 
         # Deserializing objects
         model_opt_state = torch.load(model_opt_state_serialized)
@@ -226,6 +227,12 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                 reader_factory_kwargs['pyarrow_serialize'] = True
             else:
                 reader_factory = make_batch_reader
+
+            # Call _setup again in process set module to point shared lib to torch's module
+            # since the lib path might be overwritten in remote trainer.
+            _horovod.common.process_sets._setup(_horovod.torch.mpi_ops._basics)
+            if user_verbose:
+                print(f"Set shared lib path to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")
 
             # Petastorm: read data from the store with the correct shard for this rank
             # setting num_epochs=None will cause an infinite iterator

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -57,7 +57,6 @@ else:
 _basics = _HorovodBasics(__file__, 'mpi_lib')
 
 # import basic methods
-init = _basics.init
 shutdown = _basics.shutdown
 is_initialized = _basics.is_initialized
 start_timeline = _basics.start_timeline
@@ -83,6 +82,11 @@ rocm_built = _basics.rocm_built
 Average = _basics.Average
 Sum = _basics.Sum
 Adasum = _basics.Adasum
+
+def init(*args, **kwargs):
+    _basics.init(*args, **kwargs)
+    # Call set up again to make sure the basics is in sync
+    _setup_process_sets(_basics)
 
 is_homogeneous = _basics.is_homogeneous
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -69,7 +69,9 @@ def shutdown(*args, **kwargs):
 def init(*args, **kwargs):
     global _handle_map
     _handle_map = {}
-    return _basics.init(*args, **kwargs)
+    _basics.init(*args, **kwargs)
+    # Call set up again to make sure the basics is in sync
+    _setup_process_sets(_basics)
 
 # import reduction op values
 Average = _basics.Average


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
In remote trainers of the horovod spark module, if multiple frameworks are imported in the same process, there's a chance that the _basics in horovod.common.process_set is pointing to the wrong shared lib path resulting in horovod not initialized error even after calling hvd.init(). This calls _setup again before fitting the model to make sure the shared lib is correct.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
