### PR TITLE
Fix  method name in MXNet2 test.

### DIFF
--- a/test/parallel/test_mxnet2.py
+++ b/test/parallel/test_mxnet2.py
@@ -152,8 +152,8 @@ class MX2Tests(MXTests, unittest.TestCase):
 
         data_gen = gen_random_dataset()
         for (src_data, dst_data) in data_gen:
-            src_data = src_data.as_in_ctx(ctx).astype(np.float32)
-            dst_data = dst_data.as_in_ctx(ctx).astype(np.float32)
+            src_data = src_data.as_in_context(ctx).astype(np.float32)
+            dst_data = dst_data.as_in_context(ctx).astype(np.float32)
             with mx.autograd.record():
                 pred = net(src_data)
                 loss = mx.np.abs(pred - dst_data).mean()


### PR DESCRIPTION

## Description
Replaces `as_in_ctx` calls with `as_in_context` calls in `test_mxnet2.py`.
