### PR TITLE
Fix check status name and details link

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -81,8 +81,8 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "pending",
-            "context": "Build and Test GPU (on Builtkite)",
-            "target_url": "${{ github.event.workflow_run.html_url }}"
+            "context": "${{ github.event.workflow.name }} / Build and Test GPU (on Builtkite)",
+            "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
       - name: Trigger Buildkite Pipeline
@@ -133,8 +133,8 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "${{ job.status }}",
-            "context": "Build and Test GPU (on Builtkite)",
-            "target_url": "${{ github.event.workflow_run.html_url }}"
+            "context": "${{ github.event.workflow.name }} / Build and Test GPU (on Builtkite)",
+            "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
   buildkite-heads:
@@ -156,8 +156,8 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "pending",
-            "context": "Build and Test GPU heads (on Builtkite)",
-            "target_url": "${{ github.event.workflow_run.html_url }}"
+            "context": "${{ github.event.workflow.name }} / Build and Test GPU heads (on Builtkite)",
+            "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
       - name: Trigger Buildkite Pipeline
@@ -208,8 +208,8 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "${{ job.status }}",
-            "context": "Build and Test GPU heads (on Builtkite)",
-            "target_url": "${{ github.event.workflow_run.html_url }}"
+            "context": "${{ github.event.workflow.name }} / Build and Test GPU heads (on Builtkite)",
+            "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
   publish-test-results:

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -81,7 +81,7 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "pending",
-            "context": "${{ github.event.workflow.name }} / Build and Test GPU (on Builtkite)",
+            "context": "${{ env.GITHUB_WORKFLOW }} / Build and Test GPU (on Builtkite)",
             "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
@@ -133,7 +133,7 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "${{ job.status }}",
-            "context": "${{ github.event.workflow.name }} / Build and Test GPU (on Builtkite)",
+            "context": "${{ env.GITHUB_WORKFLOW }} / Build and Test GPU (on Builtkite)",
             "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
@@ -156,7 +156,7 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "pending",
-            "context": "${{ github.event.workflow.name }} / Build and Test GPU heads (on Builtkite)",
+            "context": "${{ env.GITHUB_WORKFLOW }} / Build and Test GPU heads (on Builtkite)",
             "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 
@@ -208,7 +208,7 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "state": "${{ job.status }}",
-            "context": "${{ github.event.workflow.name }} / Build and Test GPU heads (on Builtkite)",
+            "context": "${{ env.GITHUB_WORKFLOW }} / Build and Test GPU heads (on Builtkite)",
             "target_url": "https://github.com/horovod/horovod/actions/runs/${{ env.GITHUB_RUN_ID }}"
             }'
 

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -124,7 +124,8 @@ jobs:
           exit 1
 
       - name: Update check status
-        if: always()
+        # job status can be success, failure, or cancelled but status state only allows for error, failure, pending, or success
+        if: always() && job.status != 'cancelled'
         continue-on-error: true
         run: |
           curl --request POST \
@@ -199,7 +200,8 @@ jobs:
           exit 1
 
       - name: Update check status
-        if: always()
+        # job status can be success, failure, or cancelled but status state only allows for error, failure, pending, or success
+        if: always() && job.status != 'cancelled'
         continue-on-error: true
         run: |
           curl --request POST \


### PR DESCRIPTION
In #3270 the "CI (Results)" workflow that runs for fork PRs and executes the Buildkite GPU tests updates the check statuses of the PR to indicate that these tests are running or have finished. This could only be tested in master.

![grafik](https://user-images.githubusercontent.com/44700269/141259995-4964dabb-b065-4ec8-815f-acf265d3829c.png)

![grafik](https://user-images.githubusercontent.com/44700269/141258123-a083ef5a-97c7-4da3-a77d-bb932c102987.png)

The link of the check status now points to the "CI (Results)" workflow and not the triggering "CI" workflow. Further, the check status name is now prefixed with the workflow name "CI (Results) / ", so it aligns with other check status names. 