### PR TITLE
Fix typo `avaiable` in MPI libs warning

### DIFF
--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -25,9 +25,9 @@ except:
         check_extension('horovod.torch', 'HOROVOD_WITH_PYTORCH',
                     __file__, 'mpi_lib', '_mpi_lib')
     except Exception as e:
-        # MPI libs are missing, but python applications are still avaiable.
+        # MPI libs are missing, but python applications are still available.
         print(e)
-        print("Warning! MPI libs are missing, but python applications are still avaiable.")
+        print("Warning! MPI libs are missing, but python applications are still available.")
         _MPI_LIB_AVAILABLE = False
 
 # only import following function when mpi is available.


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes typo — `avaiable` — in `Warning! MPI libs are missing, but python applications are still avaiable.`

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
