### PR TITLE
Fix lightning and pytorch estimator loading from checkpoint

### DIFF
--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -150,6 +150,7 @@ class Store(object):
             'checkpoint_filename': self.get_checkpoint_filename(),
             'logs_subdir': self.get_logs_subdir(),
             'get_local_output_dir': self.get_local_output_dir_fn(run_id),
+            'get_local_run_dir': self.get_local_run_dir_fn(run_id),
             'sync': self.sync_fn(run_id)
         }
 
@@ -247,12 +248,22 @@ class AbstractFilesystemStore(Store):
     def get_run_path(self, run_id):
         return os.path.join(self.get_runs_path(), run_id)
 
-    def get_checkpoint_path(self, run_id):
-        return os.path.join(self.get_run_path(run_id), self.get_checkpoint_filename()) \
+    def get_checkpoint_dir(self, run_id):
+        return os.path.join(self.get_run_path(run_id), self.get_checkpoint_dirname()) \
             if self._save_runs else None
 
+    def get_checkpoint_path(self, run_id):
+        if self._save_runs:
+            dirpath = self.get_checkpoint_dir(run_id)
+            if self.fs.exists(dirpath) and self.fs.isdir(dirpath):
+                return os.path.join(dirpath, self.get_checkpoint_filename())
+            else:
+                return os.path.join(self.get_run_path(run_id), self.get_checkpoint_filename())
+        else:
+            return None
+
     def get_checkpoints(self, run_id, suffix='.ckpt'):
-        checkpoint_dir = self.get_localized_path(self.get_checkpoint_path(run_id))
+        checkpoint_dir = self.get_localized_path(self.get_checkpoint_dir(run_id))
         filenames = self.fs.ls(checkpoint_dir)
         return sorted([name for name in filenames if name.endswith(suffix)])
 
@@ -262,6 +273,9 @@ class AbstractFilesystemStore(Store):
 
     def get_checkpoint_filename(self):
         return 'checkpoint'
+    
+    def get_checkpoint_dirname(self):
+        return 'checkpoints'
 
     def get_logs_subdir(self):
         return 'logs'
@@ -279,6 +293,17 @@ class AbstractFilesystemStore(Store):
         def local_run_path():
             with tempfile.TemporaryDirectory() as tmpdir:
                 yield tmpdir
+        return local_run_path
+
+    def get_local_run_dir_fn(self, run_id):
+        @contextlib.contextmanager
+        def local_run_path():
+            dirpath = os.path.join(tempfile._get_default_tempdir(),self.get)
+            os.makedirs(dirpath, exist_ok=True)
+            try:
+                yield dirpath
+            finally:
+                shutil.rmtree(dirpath)
         return local_run_path
 
     def get_localized_path(self, path):

--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -298,7 +298,7 @@ class AbstractFilesystemStore(Store):
     def get_local_run_dir_fn(self, run_id):
         @contextlib.contextmanager
         def local_run_path():
-            dirpath = os.path.join(tempfile._get_default_tempdir(),self.get)
+            dirpath = os.path.join(tempfile._get_default_tempdir(),self.get_checkpoint_dir)
             os.makedirs(dirpath, exist_ok=True)
             try:
                 yield dirpath

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -262,7 +262,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
             if hvd.rank() == 0:
                 if remote_store.saving_runs and trainer.profiler:
                     # One more file sync to push profiler result.
-                    remote_store.sync(run_output_dir)
+                    remote_store.sync(logs_path)
 
                 # rank 0 overwrites model with best checkpoint and returns.
                 if require_checkpoint:

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -111,7 +111,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
         _checkpoint_callback = None
         require_checkpoint = False
 
-        with remote_store.get_local_output_dir() as run_output_dir:
+        with remote_store.get_local_run_dir() as run_output_dir:
             logs_path = os.path.join(run_output_dir, remote_store.logs_subdir)
             os.makedirs(logs_path, exist_ok=True)
             print(f"Made directory {logs_path} for horovod rank {hvd.rank()}")
@@ -262,7 +262,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
             if hvd.rank() == 0:
                 if remote_store.saving_runs and trainer.profiler:
                     # One more file sync to push profiler result.
-                    remote_store.sync(logs_path)
+                    remote_store.sync(run_output_dir)
 
                 # rank 0 overwrites model with best checkpoint and returns.
                 if require_checkpoint:

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -198,7 +198,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         else:
             steps_per_epoch = train_steps_per_epoch
 
-        with remote_store.get_local_output_dir() as run_output_dir:
+        with remote_store.get_local_run_dir() as run_output_dir:
             logs_dir = os.path.join(run_output_dir, remote_store.logs_subdir)
             log_writer = SummaryWriter(logs_dir) if hvd.rank() == 0 else None
             ckpt_file = os.path.join(run_output_dir, remote_store.checkpoint_filename)

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -198,8 +198,6 @@ class SparkLightningTests(unittest.TestCase):
 
     # TODO: Add this test back after checkpoint call back is supported
     def test_restore_from_checkpoint(self):
-        self.skipTest('There is a deadlock bug for checkpoint call back. ' +
-                      'Will add this test back when it is solved.')
 
         model = create_xor_model()
 
@@ -236,8 +234,6 @@ class SparkLightningTests(unittest.TestCase):
 
     # TODO: Add this test back after checkpoint call back is supported
     def test_legacy_restore_from_checkpoint(self):
-        self.skipTest('There is a deadlock bug for checkpoint call back. ' +
-                      'Will add this test back when it is solved.')
 
         model = create_legacy_xor_model()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3268. Creating named temporary output directories which are later copied to run path, then fetching the checkpoints from this named directory in run path to ensure latest checkpoints are fetched in multiple iterations.
