### PR TITLE
Run buildkite jobs in parallel

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -225,7 +225,7 @@ def main():
                 f'      - name: Configure Buildkite Build\n'
                 f'        id: config-buildkite\n'
                 f'        env:\n'
-                f'          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}\n'
+                f'          GITHUB_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}\n'
                 f'        run: |\n'
                 f'          branch="${{{{ github.event.pull_request.head.ref || github.ref }}}}"\n'
                 f'          branch="${{branch#"refs/heads/"}}"\n'

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -558,7 +558,7 @@ def main():
                 f'        env:\n'
                 f'          PIPELINE: "horovod/horovod"\n'
                 f'          # COMMIT is taken from GITHUB_SHA\n'
-                f'          BRANCH: "${{{{ needs.init-workflow.outputs.buildkite-branch-label }}}}"\n'
+                f'          BRANCH: "${{{{ needs.init-workflow.outputs.buildkite-branch-label }}}} ({mode})"\n'
                 f'          # empty MESSAGE will be filled by Buildkite from commit message\n'
                 f'          MESSAGE: "${{{{ needs.init-workflow.outputs.buildkite-message }}}}"\n'
                 f'          BUILDKITE_API_ACCESS_TOKEN: ${{{{ secrets.BUILDKITE_TOKEN }}}}\n'
@@ -802,7 +802,7 @@ def main():
             build_and_test_images(id='build-and-test-heads', name='Build and Test heads', needs=['build-and-test'], images=allhead_images, parallel_images='', tests_per_image=tests_per_image, tests=tests),
             build_and_test_macos(id='build-and-test-macos', name='Build and Test macOS', needs=['build-and-test']),
             trigger_buildkite_job(id='buildkite', name='Build and Test GPU (on Builtkite)', needs=['build-and-test'], mode='GPU NON HEADS'),
-            trigger_buildkite_job(id='buildkite-heads', name='Build and Test GPU heads (on Builtkite)', needs=['buildkite'], mode='GPU HEADS'),
+            trigger_buildkite_job(id='buildkite-heads', name='Build and Test GPU heads (on Builtkite)', needs=['build-and-test'], mode='GPU HEADS'),
             publish_docker_images(needs=['build-and-test', 'buildkite'], images=['horovod', 'horovod-cpu', 'horovod-ray']),
             sync_files(needs=['init-workflow'])
         )

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Download and Extract Artifacts
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p artifacts && cd artifacts
 

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -91,8 +91,8 @@ jobs:
         env:
           PIPELINE: "horovod/horovod"
           COMMIT: "${{ fromJSON( needs.ci-workflow.outputs.pr-json ).merge_sha }}"
-          BRANCH: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
-          MESSAGE: "${{ github.event.workflow_run.head_commit.message }} (release versions)"
+          BRANCH: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} (GPU NON HEADS)"
+          MESSAGE: "${{ github.event.workflow_run.head_commit.message }}"
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU NON HEADS\"}"
 
@@ -140,7 +140,7 @@ jobs:
 
   buildkite-heads:
     name: "Build and Test GPU heads (on Builtkite)"
-    needs: [ci-workflow, buildkite]
+    needs: [ci-workflow]
     runs-on: ubuntu-latest
     # only run if CI workflow's build-and-test job succeeded and CI workflow ran on a fork
     if: >
@@ -167,8 +167,8 @@ jobs:
         env:
           PIPELINE: "horovod/horovod"
           COMMIT: "${{ fromJSON( needs.ci-workflow.outputs.pr-json ).merge_sha }}"
-          BRANCH: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
-          MESSAGE: "${{ github.event.workflow_run.head_commit.message }} (head versions)"
+          BRANCH: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} (GPU HEADS)"
+          MESSAGE: "${{ github.event.workflow_run.head_commit.message }}"
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU HEADS\"}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3152,7 +3152,7 @@ jobs:
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA
-          BRANCH: "${{ needs.init-workflow.outputs.buildkite-branch-label }}"
+          BRANCH: "${{ needs.init-workflow.outputs.buildkite-branch-label }} (GPU NON HEADS)"
           # empty MESSAGE will be filled by Buildkite from commit message
           MESSAGE: "${{ needs.init-workflow.outputs.buildkite-message }}"
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
@@ -3187,7 +3187,7 @@ jobs:
 
   buildkite-heads:
     name: "Build and Test GPU heads (on Builtkite)"
-    needs: [init-workflow, buildkite]
+    needs: [init-workflow, build-and-test]
     runs-on: ubuntu-latest
     if: >
       github.repository == 'horovod/horovod' &&
@@ -3202,7 +3202,7 @@ jobs:
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA
-          BRANCH: "${{ needs.init-workflow.outputs.buildkite-branch-label }}"
+          BRANCH: "${{ needs.init-workflow.outputs.buildkite-branch-label }} (GPU HEADS)"
           # empty MESSAGE will be filled by Buildkite from commit message
           MESSAGE: "${{ needs.init-workflow.outputs.buildkite-message }}"
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Configure Buildkite Build
         id: config-buildkite
         env:
-          GITHUB_TOKEN: ${secrets.GITHUB_TOKEN}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           branch="${{ github.event.pull_request.head.ref || github.ref }}"
           branch="${branch#"refs/heads/"}"


### PR DESCRIPTION
Buildkite uses the branch not literally but merely as an id to identify concurrent builds. This runs HEAD and non HEAD buildkite jobs in parallel by giving them individual branch names. This way way do not wait for the HEAD job because this now runs in parallel to the non HEAD job, which takes longer anyway. This should shave off an hour from the entire CI workflow.

Old job dependency:
![grafik](https://user-images.githubusercontent.com/44700269/142826714-4401b480-79ee-425e-a4e6-be0c2b9cd1b3.png)
https://github.com/horovod/horovod/actions/runs/1487590026

New job dependency:
![grafik](https://user-images.githubusercontent.com/44700269/142826588-54b00da7-6061-4911-8db7-d81e4b186932.png)
https://github.com/horovod/horovod/actions/runs/1486597919
