### PR TITLE
Revert "Fix lightning and pytorch estimator loading from checkpoint"

### DIFF
--- a/horovod/spark/common/store.py
+++ b/horovod/spark/common/store.py
@@ -150,7 +150,6 @@ class Store(object):
             'checkpoint_filename': self.get_checkpoint_filename(),
             'logs_subdir': self.get_logs_subdir(),
             'get_local_output_dir': self.get_local_output_dir_fn(run_id),
-            'get_local_run_dir': self.get_local_run_dir_fn(run_id),
             'sync': self.sync_fn(run_id)
         }
 
@@ -248,22 +247,12 @@ class AbstractFilesystemStore(Store):
     def get_run_path(self, run_id):
         return os.path.join(self.get_runs_path(), run_id)
 
-    def get_checkpoint_dir(self, run_id):
-        return os.path.join(self.get_run_path(run_id), self.get_checkpoint_dirname()) \
+    def get_checkpoint_path(self, run_id):
+        return os.path.join(self.get_run_path(run_id), self.get_checkpoint_filename()) \
             if self._save_runs else None
 
-    def get_checkpoint_path(self, run_id):
-        if self._save_runs:
-            dirpath = self.get_checkpoint_dir(run_id)
-            if self.fs.exists(dirpath) and self.fs.isdir(dirpath):
-                return os.path.join(dirpath, self.get_checkpoint_filename())
-            else:
-                return os.path.join(self.get_run_path(run_id), self.get_checkpoint_filename())
-        else:
-            return None
-
     def get_checkpoints(self, run_id, suffix='.ckpt'):
-        checkpoint_dir = self.get_localized_path(self.get_checkpoint_dir(run_id))
+        checkpoint_dir = self.get_localized_path(self.get_checkpoint_path(run_id))
         filenames = self.fs.ls(checkpoint_dir)
         return sorted([name for name in filenames if name.endswith(suffix)])
 
@@ -273,9 +262,6 @@ class AbstractFilesystemStore(Store):
 
     def get_checkpoint_filename(self):
         return 'checkpoint'
-    
-    def get_checkpoint_dirname(self):
-        return 'checkpoints'
 
     def get_logs_subdir(self):
         return 'logs'
@@ -293,17 +279,6 @@ class AbstractFilesystemStore(Store):
         def local_run_path():
             with tempfile.TemporaryDirectory() as tmpdir:
                 yield tmpdir
-        return local_run_path
-
-    def get_local_run_dir_fn(self, run_id):
-        @contextlib.contextmanager
-        def local_run_path():
-            dirpath = os.path.join(tempfile._get_default_tempdir(),self.get_checkpoint_dir)
-            os.makedirs(dirpath, exist_ok=True)
-            try:
-                yield dirpath
-            finally:
-                shutil.rmtree(dirpath)
         return local_run_path
 
     def get_localized_path(self, path):

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -111,7 +111,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
         _checkpoint_callback = None
         require_checkpoint = False
 
-        with remote_store.get_local_run_dir() as run_output_dir:
+        with remote_store.get_local_output_dir() as run_output_dir:
             logs_path = os.path.join(run_output_dir, remote_store.logs_subdir)
             os.makedirs(logs_path, exist_ok=True)
             print(f"Made directory {logs_path} for horovod rank {hvd.rank()}")

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -198,7 +198,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
         else:
             steps_per_epoch = train_steps_per_epoch
 
-        with remote_store.get_local_run_dir() as run_output_dir:
+        with remote_store.get_local_output_dir() as run_output_dir:
             logs_dir = os.path.join(run_output_dir, remote_store.logs_subdir)
             log_writer = SummaryWriter(logs_dir) if hvd.rank() == 0 else None
             ckpt_file = os.path.join(run_output_dir, remote_store.checkpoint_filename)

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -217,6 +217,8 @@ class SparkLightningTests(unittest.TestCase):
 
     # TODO: Add this test back after checkpoint call back is supported
     def test_restore_from_checkpoint(self):
+        self.skipTest('There is a deadlock bug for checkpoint call back. ' +
+                      'Will add this test back when it is solved.')
 
         model = create_xor_model()
 
@@ -253,6 +255,8 @@ class SparkLightningTests(unittest.TestCase):
 
     # TODO: Add this test back after checkpoint call back is supported
     def test_legacy_restore_from_checkpoint(self):
+        self.skipTest('There is a deadlock bug for checkpoint call back. ' +
+                      'Will add this test back when it is solved.')
 
         model = create_legacy_xor_model()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)


### PR DESCRIPTION
Reverts horovod/horovod#3279

This is broken in multiple ways (#3288) which was not uncovered by testing because Spark tests were disabled for a while (#3263). Let's revert and do again now that Spark tests are back.