### PR TITLE
Fix hvd.barrier() tensor queue management and torch test failures from op name mismatches

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -273,12 +273,6 @@ ResponseList Controller::ComputeResponseList(bool this_process_requested_shutdow
 
         bool reduce = IncrementTensorCount(message, process_set.joined_size);
 
-        // For barrier request, if not ready to reduce, we add it back to tensor queue
-        // to process in the next cycle.
-        if(!reduce && message.request_type() == Request::BARRIER) {
-          tensor_queue_.PushMessageToQueue(message);
-        }
-
         stall_inspector_.RecordUncachedTensorStart(
             message.tensor_name(), message.request_rank(), size_);
         if (reduce) {

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -623,7 +623,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allreduce_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.barrier()
+        hvd.allreduce(torch.FloatTensor([1]), name="synch1")
         if rank > 0:
             hvd.allreduce_async(tensor, name='duplicate_name')
             try:
@@ -631,7 +631,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allreduce_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.allreduce(torch.FloatTensor([0]), name="synch")
+        hvd.allreduce(torch.FloatTensor([2]), name="synch2")
 
     def test_horovod_allreduce_grad(self):
         """Test the correctness of the allreduce gradient."""
@@ -1239,7 +1239,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allgather_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.barrier()
+        hvd.allreduce(torch.FloatTensor([1]), name="synch1")
         if rank > 0:
             hvd.allgather_async(tensor, name='duplicate_name')
             try:
@@ -1247,7 +1247,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allgather_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.allreduce(torch.FloatTensor([0]), name="synch")
+        hvd.allreduce(torch.FloatTensor([2]), name="synch2")
 
     def test_horovod_allgather_grad(self):
         """Test the correctness of the allgather gradient."""
@@ -1559,7 +1559,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.broadcast_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.barrier()
+        hvd.allreduce(torch.FloatTensor([1]), name="synch1")
         if rank > 0:
             hvd.broadcast_async(tensor, name='duplicate_name', root_rank=0)
             try:
@@ -1567,7 +1567,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.broadcast_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
-        hvd.allreduce(torch.FloatTensor([0]), name="synch")
+        hvd.allreduce(torch.FloatTensor([2]), name="synch2")
 
     def test_horovod_broadcast_grad(self):
         """Test the correctness of the broadcast gradient."""

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -2856,7 +2856,10 @@ class TorchTests(unittest.TestCase):
                 except (torch.FatalError, RuntimeError):
                     pass
 
-                ret = hvd.join(hvd.local_rank())
+                if torch.cuda.is_available():
+                    ret = hvd.join(hvd.local_rank())
+                else:
+                    ret = hvd.join()
 
             self.assertNotEqual(ret, first_join_rank,
                                 msg="The return value of hvd.join() may not be equal to first_join_rank")

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -631,6 +631,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allreduce_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
+        hvd.allreduce(torch.FloatTensor([0]), name="synch")
 
     def test_horovod_allreduce_grad(self):
         """Test the correctness of the allreduce gradient."""
@@ -1246,6 +1247,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.allgather_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
+        hvd.allreduce(torch.FloatTensor([0]), name="synch")
 
     def test_horovod_allgather_grad(self):
         """Test the correctness of the allgather gradient."""
@@ -1565,6 +1567,7 @@ class TorchTests(unittest.TestCase):
                 assert False, 'hvd.broadcast_async did not throw error'
             except (torch.FatalError, ValueError):
                 pass
+        hvd.allreduce(torch.FloatTensor([0]), name="synch")
 
     def test_horovod_broadcast_grad(self):
         """Test the correctness of the broadcast gradient."""


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

### 1) Fix PyTorch unit test failures from op name mismatches

When a Horovod operation is not given an explicit name in PyTorch code, it receives an automatically generated name that encodes an internal handle number. That handle, however, is a local concept and it can differ between Horovod processes if they enqueue different numbers of operations. Name mismatches then lead to stalls.

This situation was occasionally triggered in the PyTorch unit tests when running with MPI. For instance, I would see the following:
```
test_torch.py::TorchTests::test_horovod_broadcast_error 
[horovod/common/stall_inspector.cc:107] One or more tensors were submitted to be reduced, gathered or broadcasted by subset of ranks and are waiting for remainder of ranks for more than 60 seconds. This may indicate that different ranks are trying to submit different tensors or that only subset of ranks is submitting tensors, which will cause deadlock.
Missing ranks:
0: [broadcast.noname.3259]
1: [broadcast.duplicate_name, broadcast.noname.3260]
```
Here we see the influence of the previously executed test function: Rank 1 had enqueued one `broadcast.duplicate_name` more than rank 0. Then in this test the autogenerated names don't match up because the handles 3259 and 3260 are different, causing a stall.

Even without lingering duplicate_name ops such a stall could be triggered. For example I saw errors like the following in the CI logs for PR #3199, which were also caused by previous tests:
```
test_torch.py::TorchTests::test_horovod_reducescatter 
[horovod/common/stall_inspector.cc:107] One or more tensors were submitted to be reduced, gathered or broadcasted by subset of ranks and are waiting for remainder of ranks for more than 60 seconds. This may indicate that different ranks are trying to submit different tensors or that only subset of ranks is submitting tensors, which will cause deadlock. 
Missing ranks:
0: [reducescatter.noname.3236]
1: [reducescatter.noname.3234]

```
(When running with Gloo instead of MPI, Horovod is shut down and reinitialized between each test function, so we don't see these cross effects between separate tests as often).

To fix this situation I have rewritten the offending tests: Those that test duplicate name error handling and those that test `hvd.join()`. In the reformulated tests it is ensured that each rank always enqueues the same number of Horovod ops. This should prevent stalls in subsequent tests.

It remains an open question if a better mechanism could be found that generally avoids these name mismatches.

### 2) Fix `hvd.barrier()` tensor queue management

The rewritten `test_horovod_allreduce_duplicate_name_error` etc. now employ a `hvd.barrier()` call and that unveiled another bug.

If a `barrier` was enqueued together with an `allreduce`, the barrier request would erroneously be pushed again and again into the tensor queue in each cycle even after the barrier was completed. Additionally, this could cause a mismatch in `GetTensorEntriesFromResponse` where a tensor from the response would not be present in the tensor table. That mismatch caused segmentation faults in the `test_horovod_join_allgather` unit test although the situation was established earlier by an `hvd.barrier()` in the `test_horovod_allreduce_duplicate_name_error` unit test.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
