### PR TITLE
fix barrier seg fault and added test to mix it with multiple collectives

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -893,6 +893,10 @@ void Controller::FuseResponses(std::deque<Response>& responses,
       while (!responses.empty()) {
 
         auto& new_response = responses.front();
+        if (new_response.response_type() == Response::ResponseType::BARRIER ||
+            new_response.response_type() == Response::ResponseType::JOIN) {
+          break;
+        }
         assert(new_response.tensor_names().size() == 1);
         const auto& new_entry =
             tensor_queue_.GetTensorEntry(new_response.tensor_names()[0]);
@@ -981,14 +985,7 @@ bool Controller::IncrementTensorCount(const Request& msg, int joined_size) {
     timeline_.NegotiateStart(name, msg.request_type());
   } else {
     std::vector<Request>& messages = table_iter->second;
-    if(msg.request_type() == Request::BARRIER) {
-      if(tensor_queue_.IsTensorPresentInTable(name)) {
-        messages.push_back(msg);
-      }
-    }
-    else {
-      messages.push_back(msg);
-    }
+    messages.push_back(msg);
   }
 
   timeline_.NegotiateRankReady(name, msg.request_rank());

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -3311,10 +3311,6 @@ class TorchTests(unittest.TestCase):
         allreduce_tensor = torch.eye(5)
         allreduce_handle = hvd.allreduce_async(allreduce_tensor)
 
-        # Rank 0 sleeps for 3 seconds before synchronizing
-        if hvd.rank() == 0:
-            time.sleep(3)
-
         hvd.barrier()
 
         result = hvd.synchronize(allreduce_handle)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This is to fix the possible seg fault that happens when mixing barrier op with allgather. In TotalByteSizeOfAllgatherOutput function, it calculates the output size by accessing the tensor pointer of the response entry object, for ops like barrier or join whose tensor pointer is empty, horovod will seg fault.
Since the function only needs to be called when fusion is enabled, we simply skip the fusion calculation when op is join or barrier.
Added a new test for barrier that runs with multiple collectives to validate this change.
Fixes # (issue).
3308
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
