### PR TITLE
Fixes empty hostname returned from HostDiscoveryScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix the example of pytorch_lightning_mnist.py ([#3245](https://github.com/horovod/horovod/pull/3245))
 
 - Call _setup in remote trainers to point to the correct shared lib path ([#3258](https://github.com/horovod/horovod/pull/3258))
+
+- Fixes empty hostname returned from HostDiscoveryScript ([#3326](https://github.com/horovod/horovod/pull/3326))
+
 ## [v0.23.0] - 2021-10-06
 
 ### Added

--- a/horovod/runner/elastic/discovery.py
+++ b/horovod/runner/elastic/discovery.py
@@ -169,7 +169,9 @@ class HostDiscoveryScript(HostDiscovery):
             if ':' in line:
                 host, slots = line.split(':')
                 host_slots[host] = int(slots)
-            else:
+            # Make sure the host is not empty. The discovery script might
+            # return empty string when all workers are not ready or available.
+            elif host:
                 host_slots[host] = self._default_slots
         return host_slots
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes empty hostname returned from HostDiscoveryScript and make sure hostname is not empty.

Context:
When discovery script return nothing, HostDiscoveryScript will treat the empty result i.e. "" string as the available host. 
It will fail training job as launcher cannot ssh on the host with empty address. Discovery script can return nothing when no workers are available or new workers are not ready yet.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
