### PR TITLE
Fix mpi4py installation for setuptools >= 60.1.0

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -50,7 +50,7 @@ RUN apt-get update -qq && apt-get install -y python${PYTHON_VERSION} python${PYT
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python${PYTHON_VERSION/%.*/}
 RUN wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip install --no-cache-dir -U --force pip setuptools requests pytest mock pytest-forked parameterized
+RUN pip install --no-cache-dir -U --force pip "setuptools<60.1.0" requests pytest mock pytest-forked parameterized
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -50,7 +50,7 @@ RUN apt-get update -qq && apt-get install -y python${PYTHON_VERSION} python${PYT
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python${PYTHON_VERSION/%.*/}
 RUN wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip install --no-cache-dir -U --force pip "setuptools<60.1.0" requests pytest mock pytest-forked parameterized
+RUN pip install --no-cache-dir -U --force pip setuptools requests pytest mock pytest-forked parameterized
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh
@@ -126,12 +126,14 @@ RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
     fi
 
 # Install mpi4py.
+# This requires SETUPTOOLS_USE_DISTUTILS=stdlib as with setuptools>=60.1.0 installing mpi4py broke
+# https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
 RUN if [[ ${MPI_KIND} != "None" ]]; then \
         if [[ ${MPI_KIND} == "ONECCL" ]]; then \
             export I_MPI_ROOT=/usr/local/oneccl; \
             export MPICC=/usr/local/oneccl/bin/mpicc; \
         fi; \
-        pip install --no-cache-dir mpi4py; \
+        SETUPTOOLS_USE_DISTUTILS=stdlib pip install --no-cache-dir mpi4py; \
     fi
 
 # Install TensorFlow and Keras (releases).

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -55,7 +55,7 @@ RUN apt-get update -qq && apt-get install -y python${PYTHON_VERSION} python${PYT
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python${PYTHON_VERSION/%.*/}
 RUN wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
-RUN pip install --no-cache-dir -U --force pip setuptools requests pytest mock pytest-forked parameterized
+RUN pip install --no-cache-dir -U --force pip "setuptools<60.1.0" requests pytest mock pytest-forked parameterized
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -98,8 +98,10 @@ RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
 RUN echo NCCL_DEBUG=INFO >> /etc/nccl.conf
 
 # Install mpi4py.
+# This requires SETUPTOOLS_USE_DISTUTILS=stdlib as with setuptools>=60.1.0 installing mpi4py broke
+# https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
 RUN if [[ ${MPI_KIND} != "None" ]]; then \
-        pip install --no-cache-dir mpi4py; \
+        SETUPTOOLS_USE_DISTUTILS=stdlib pip install --no-cache-dir mpi4py; \
     fi
 
 # Install TensorFlow and Keras (releases).


### PR DESCRIPTION
Setuptools released 60.1.0 on 24th December, with that christmas present, installing mpi4py fails: https://github.com/mpi4py/mpi4py/issues/160

https://github.com/horovod/horovod/runs/4625980553?check_suite_focus=true#step:10:1790
```
2021-12-24T10:10:25.5324561Z #28 0.777 Collecting mpi4py
2021-12-24T10:10:25.5327643Z #28 0.809   Downloading mpi4py-3.1.3.tar.gz (2.5 MB)
2021-12-24T10:10:25.9847293Z #28 1.256   Installing build dependencies: started
2021-12-24T10:10:28.2403790Z #28 3.491   Installing build dependencies: finished with status 'done'
2021-12-24T10:10:28.2404676Z #28 3.495   Getting requirements to build wheel: started
2021-12-24T10:10:28.3908932Z #28 3.660   Getting requirements to build wheel: finished with status 'error'
2021-12-24T10:10:28.3910150Z #28 3.660   ERROR: Command errored out with exit status 1:
2021-12-24T10:10:28.3911786Z #28 3.660    command: /usr/bin/python /usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmphakks0h5
2021-12-24T10:10:28.3913521Z #28 3.660        cwd: /tmp/pip-install-ckf3j6ip/mpi4py_a364aad17b144d759c0e1ff9164c2c45
2021-12-24T10:10:28.3914552Z #28 3.660   Complete output (18 lines):
2021-12-24T10:10:28.3915250Z #28 3.660   Traceback (most recent call last):
2021-12-24T10:10:28.3916555Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
2021-12-24T10:10:28.3917485Z #28 3.660       main()
2021-12-24T10:10:28.3918642Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
2021-12-24T10:10:28.3919892Z #28 3.660       json_out['return_val'] = hook(**hook_input['kwargs'])
2021-12-24T10:10:28.3921313Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
2021-12-24T10:10:28.3922409Z #28 3.660       return hook(config_settings)
2021-12-24T10:10:28.3923686Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
2021-12-24T10:10:28.3924716Z #28 3.660       return self._get_build_requires(
2021-12-24T10:10:28.3926126Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/setuptools/build_meta.py", line 143, in _get_build_requires
2021-12-24T10:10:28.3927084Z #28 3.660       self.run_setup()
2021-12-24T10:10:28.3928247Z #28 3.660     File "/usr/local/lib/python3.8/dist-packages/setuptools/build_meta.py", line 158, in run_setup
2021-12-24T10:10:28.3929439Z #28 3.660       exec(compile(code, __file__, 'exec'), locals())
2021-12-24T10:10:28.3930214Z #28 3.660     File "setup.py", line 462, in <module>
2021-12-24T10:10:28.3930950Z #28 3.660       from mpidistutils import setup
2021-12-24T10:10:28.3932396Z #28 3.660     File "/tmp/pip-install-ckf3j6ip/mpi4py_a364aad17b144d759c0e1ff9164c2c45/conf/mpidistutils.py", line 29, in <module>
2021-12-24T10:10:28.3933607Z #28 3.660       cygcc_get_versions = cygcc.get_versions
2021-12-24T10:10:28.3935000Z #28 3.660   AttributeError: module 'setuptools._distutils.cygwinccompiler' has no attribute 'get_versions'
```

This fixes the installation for setuptools>=60.1.0.