### PR TITLE
Make docker fail on the first command that fails in RUN

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -515,7 +515,7 @@ def main():
                 '\n'.join([f'      - name: Test [attempt {attempt} of {attempts}]\n'
                            f'        id: test-{attempt}\n'
                            f'        continue-on-error: {"true" if attempt < attempts else "false"}\n'
-                           f'        if: always() && {"true" if attempt == 1 else f"steps.test-{attempt-1}.outcome == {failure}"}\n'
+                           f'        if: always() && steps.build.outcome == \'success\' && {"true" if attempt == 1 else f"steps.test-{attempt-1}.outcome == {failure}"}\n'
                            f'\n'
                            f'        run: |\n'
                            f'          export PATH=$(pyenv root)/shims:$PATH\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3437,7 +3437,7 @@ jobs:
       - name: Test [attempt 1 of 3]
         id: test-1
         continue-on-error: true
-        if: always() && true
+        if: always() && steps.build.outcome == 'success' && true
 
         run: |
           export PATH=$(pyenv root)/shims:$PATH
@@ -3456,7 +3456,7 @@ jobs:
       - name: Test [attempt 2 of 3]
         id: test-2
         continue-on-error: true
-        if: always() && steps.test-1.outcome == 'failure'
+        if: always() && steps.build.outcome == 'success' && steps.test-1.outcome == 'failure'
 
         run: |
           export PATH=$(pyenv root)/shims:$PATH
@@ -3475,7 +3475,7 @@ jobs:
       - name: Test [attempt 3 of 3]
         id: test-3
         continue-on-error: false
-        if: always() && steps.test-2.outcome == 'failure'
+        if: always() && steps.build.outcome == 'success' && steps.test-2.outcome == 'failure'
 
         run: |
           export PATH=$(pyenv root)/shims:$PATH

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -23,7 +23,7 @@ ARG CCL_PACKAGE=master
 ARG HOROVOD_BUILD_FLAGS=""
 
 # Set default shell to /bin/bash
-SHELL ["/bin/bash", "-cu"]
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Prepare to install specific g++ versions
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -24,7 +24,7 @@ ARG HOROVOD_BUILD_FLAGS="HOROVOD_GPU_OPERATIONS=NCCL"
 ARG HOROVOD_MIXED_INSTALL=0
 
 # Set default shell to /bin/bash
-SHELL ["/bin/bash", "-cu"]
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Prepare to install specific g++ versions
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -77,7 +77,7 @@ services:
     build:
       args:
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.6.2
-        KERAS_PACKAGE: keras==2.6.2
+        KERAS_PACKAGE: keras==2.6.0
         PYTORCH_PACKAGE: torch==1.9.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.10.1
         MXNET_PACKAGE: mxnet==1.8.0.post0
@@ -168,7 +168,7 @@ services:
         CUDNN_VERSION: 8.1.1.33-1+cuda11.2
         NCCL_VERSION_OVERRIDE: 2.8.4-1+cuda11.2
         TENSORFLOW_PACKAGE: tensorflow-gpu==2.6.2
-        KERAS_PACKAGE: keras==2.6.2
+        KERAS_PACKAGE: keras==2.6.0
         PYTORCH_PACKAGE: torch==1.9.1+cu111
         PYTORCH_LIGHTNING_PACKAGE: pytorch_lightning==1.3.8
         TORCHVISION_PACKAGE: torchvision==0.10.1+cu111


### PR DESCRIPTION
Currently, docker only fails if the last command in `RUN` fails, otherwise it keeps on building the image. The resulting image fails during tests (in the best case) and a thorough investigation of the build process is the consequence. There have been a lot of situations in the past where errors in the build process have been hidden by this, e.g. https://github.com/horovod/horovod/runs/4648818225?check_suite_focus=true#step:10:1588.

This makes the `RUN` command fail on the first bash command that fails, not only on the last one.

Related, macOS tests run even if the build step fails. This is also fixed here.