### PR TITLE
Fix finalization of ProcessSetTable and some test flakiness with PyTorch 1.10.1

### DIFF
--- a/horovod/common/process_set.cc
+++ b/horovod/common/process_set.cc
@@ -265,6 +265,11 @@ void ProcessSetTable::Finalize_(const Context& context, const Status& status) {
   LOG(TRACE, Get(0).controller->GetRank())
       << "Finalizing ProcessSetTable, global process set id 0";
   id_to_process_set_[0].Finalize(status);
+
+  next_id_ = 1;
+  while (!free_ids_.empty()) free_ids_.pop();  // Clear queue to be sure.
+  assert(ids_.size() == 1);
+  assert(id_to_process_set_.size() == 1);
 }
 
 #if HAVE_MPI

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -71,6 +71,7 @@ class TorchTests(unittest.TestCase):
     def tearDown(self):
         gloo_rank = int(os.getenv('HOROVOD_RANK', -1))
         if hvd.is_initialized() and not _is_mac and gloo_rank != -1:
+            hvd.barrier()
             hvd.shutdown()
 
     def convert_cpu_fp16_to_fp32(self, *values):

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -2159,14 +2159,14 @@ class TorchTests(unittest.TestCase):
 
             model_param_values = get_model_param_values(model)
             for name, model_param_value in model_param_values:
-                hvd.broadcast_(model_param_value, root_rank=0)
+                hvd.broadcast_(model_param_value, root_rank=0, name=name)
 
             opt_param_values_updated = []
             opt_param_values = get_optimizer_param_values(optimizer)
             for name, opt_param_value in opt_param_values:
                 is_tensor = torch.is_tensor(opt_param_value)
                 if is_tensor:
-                    hvd.broadcast_(opt_param_value, root_rank=0)
+                    hvd.broadcast_(opt_param_value, root_rank=0, name=f"{name}_tensor")
                 else:
                     opt_param_value = hvd.broadcast_object(opt_param_value, name=name)
                 opt_param_values_updated.append((name, opt_param_value))


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

I've been looking at some test failures in PR #3261, that popped up after rebasing to master: [CI logs for test-cpu-gloo-py3_7-tf2_7_0-keras2_7_0-torch1_10_1-mxnet1_9_0-pyspark2_4_8](https://github.com/horovod/horovod/runs/4700722148?check_suite_focus=true). As far as I can tell, these are not directly related to the proposed CMake changes. Perhaps the recent update to PyTorch 1.10.1 has made it more likely to run into them.

These related fixes come with this PR:

1. Properly reset internal state of `ProcessSetTable` when finalizing Horovod: In debug builds with Gloo, where Horovod is re-initialized after each torch test, an assertion would fail otherwise on such a re-init. Internal process set IDs now get more reasonable values, but I don't think this caused further bugs.
2. Add a synchronization barrier before `hvd.shutdown()` in `TorchTests.tearDown()`: In tests like  `test_horovod_alltoall_equal_split_length_error` it would be possible that rank 0 has already finished the test function and has triggered shutting down Horovod, before rank 1 has had a chance to call `alltoall` (which would exit quickly to report an error if the test worked as intended). Rank 1 would then crash.
3. Add explicit names to broadcast operations in `TorchTests::test_broadcast_state`: I am not sure, but hangs might have been caused by wrongly associated autogenerated names like `broadcast.noname.1114`.