### PR TITLE
PyTorch: Release Python GIL when yielding in foreground thread

### DIFF
--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -606,7 +606,10 @@ int PollHandle(int handle) { return handle_manager.PollHandle(handle) ? 1 : 0; }
 void WaitAndClear(int handle) {
   while (true) {
     if (handle_manager.PollHandle(handle)) break;
-    std::this_thread::yield();
+    {
+      py::gil_scoped_release release_python_gil;
+      std::this_thread::yield();
+    }
   }
   auto status = handle_manager.ReleaseHandle(handle);
   ThrowIfError(*status);


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3352. I've run the test suite from `tests/parallel/test_torch.py` 15 times in the environment described in the issue and did not encounter any hang.

I hope releasing the GIL here is not unsafe in any way.