### PR TITLE
Replaced use of tempfile.mktemp() with tempfile.mkstemp()

### DIFF
--- a/horovod/runner/js_run.py
+++ b/horovod/runner/js_run.py
@@ -126,7 +126,12 @@ def generate_jsrun_rankfile(settings, path=None):
             slots=settings.num_proc))
 
     # Generate rankfile
-    path = tempfile.mktemp() if path is None else path
+    # using mkstemp here instead of insecure mktemp.
+    # note that the caller is responsible for cleaning up this file
+    if path is None:
+        fd, path = tempfile.mkstemp()
+        fd.close()
+
     with open(path, 'w') as tmp:
         tmp.write('overlapping_rs: allow\n')
         tmp.write('cpu_index_using: logical\n')

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -640,7 +640,7 @@ class RunTests(unittest.TestCase):
         test(("HYDRA build details:\n"
               "    Version:           3.3a2\n"
               "    Configure options: 'MPICHLIB_CFLAGS=-g -O2'\n"), _MPICH_IMPL)
-        
+
         test("Intel(R) MPI", _IMPI_IMPL)
 
         test("Unknown MPI v1.00", _UNKNOWN_IMPL)

--- a/test/utils/common.py
+++ b/test/utils/common.py
@@ -112,15 +112,12 @@ def tempdir():
 
 @contextlib.contextmanager
 def temppath():
-    path = tempfile.mktemp()
+    dir_path = tempfile.TemporaryDirectory()
+    path = os.path.join(dir_path.name,'temp_test_file')
     try:
         yield path
     finally:
-        if os.path.exists(path):
-            if os.path.isfile(path):
-                os.remove(path)
-            else:
-                shutil.rmtree(path)
+        dir_path.cleanup()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This addresses use of tempfile.mktemp() which [is not secure](https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables). Another process may create a file with the same name in the time between the call to mktemp() and subsequent attempt to create the file by the first process.

## Checklist before submitting

- [x ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
