### PR TITLE
Fix possible integer overflow in multiplication

### DIFF
--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -486,7 +486,7 @@ int64_t Controller::TensorFusionThresholdBytes() {
     // Ensuring that fusion buffer can hold a number of elements divisible by
     // FUSION_BUFFER_ATOMIC_UNIT for performance
     int double_size = GetTypeSize(HOROVOD_FLOAT64);
-    int64_t div = local_size_ * double_size * FUSION_BUFFER_ATOMIC_UNIT;
+    int64_t div = (int64_t)local_size_ * (int64_t)double_size * FUSION_BUFFER_ATOMIC_UNIT;
     return ((proposed_fusion_threshold + div - 1) / div) * div;
   }
   return proposed_fusion_threshold;

--- a/horovod/common/ops/adasum/adasum.h
+++ b/horovod/common/ops/adasum/adasum.h
@@ -298,8 +298,8 @@ private:
       nghrCountVec_index++;
 
       this->PointToPointSendRecv(
-          (char*)(&grad_buffer[sendOffset]), nghrCount * per_element_size,
-          (char*)(&recv_buffer[recvOffset]), myCount * per_element_size,
+          (char*)(&grad_buffer[sendOffset]), (int64_t)nghrCount * (int64_t)per_element_size,
+          (char*)(&recv_buffer[recvOffset]), (int64_t)myCount * (int64_t)per_element_size,
           horovod_datatype, neighbor_rank, tag, communicator, global_state);
       if ((rank & level) != 0) {
         grad_buffer = &grad_buffer[nghrCount];
@@ -329,8 +329,8 @@ private:
       } else {
         recv_buffer = &grad_buffer[-nghrCount];
       }
-      this->PointToPointSendRecv(grad_buffer, myCount * per_element_size,
-                                 recv_buffer, nghrCount * per_element_size,
+      this->PointToPointSendRecv(grad_buffer, (int64_t)myCount * (int64_t)per_element_size,
+                                 recv_buffer, (int64_t)nghrCount * (int64_t)per_element_size,
                                  horovod_datatype, neighbor_rank, tag,
                                  communicator, global_state);
       if ((rank & level) != 0) {

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -243,7 +243,7 @@ void AllgatherOp::MemcpyInFusionBuffer(
 
   auto& process_set =
       global_state_->process_set_table.Get(first_entry.process_set_id);
-  int64_t offset = displcmnts[process_set.controller->GetRank()] * element_size;
+  int64_t offset = (int64_t)displcmnts[process_set.controller->GetRank()] * (int64_t)element_size;
   for (auto& e : entries) {
     void* buffer_data_at_offset = (uint8_t*)buffer_data + offset;
     MemcpyEntryInFusionBuffer(entries, e, buffer_data_at_offset);


### PR DESCRIPTION
CodeQL identified a few integer multiplications that might overflow before cast to a larger type:

```
Multiplication result may overflow 'int' before it is converted to 'int64_t'.

This rule finds code that converts the result of an integer multiplication to a larger type.
Since the conversion applies after the multiplication, arithmetic overflow may still occur.
```

See [CWE-190](https://cwe.mitre.org/data/definitions/190.html) [CWE-192](https://cwe.mitre.org/data/definitions/192.html) [CWE-197](https://cwe.mitre.org/data/definitions/197.html) [CWE-681](https://cwe.mitre.org/data/definitions/681.html).

Fixes:
https://github.com/horovod/horovod/security/code-scanning/3
https://github.com/horovod/horovod/security/code-scanning/4
https://github.com/horovod/horovod/security/code-scanning/5
https://github.com/horovod/horovod/security/code-scanning/6
https://github.com/horovod/horovod/security/code-scanning/7
https://github.com/horovod/horovod/security/code-scanning/8

See: https://github.com/horovod/horovod/runs/4816240959