### PR TITLE
Build Horovod with temporarily installed CMake if necessary

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,9 +100,6 @@ jobs:
         sed -i -e "s%^# setup ssh service$%${command//$'\n'/\\n}\n\n# setup ssh service%" Dockerfile.test.?pu
 
         command=$(cat <<EOF
-        # Install recent CMake
-        RUN pip install --no-cache-dir -U cmake~=3.13.0
-
         # Setup CodeQL tracing
         RUN mkdir -p /home/runner/work/horovod
         RUN ln -s /horovod /home/runner/work/horovod/horovod

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,6 +100,9 @@ jobs:
         sed -i -e "s%^# setup ssh service$%${command//$'\n'/\\n}\n\n# setup ssh service%" Dockerfile.test.?pu
 
         command=$(cat <<EOF
+        # Install recent CMake
+        RUN pip install --no-cache-dir -U cmake~=3.13.0
+
         # Setup CodeQL tracing
         RUN mkdir -p /home/runner/work/horovod
         RUN ln -s /horovod /home/runner/work/horovod/horovod

--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -36,6 +36,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         wget \
         ca-certificates \
+        cmake \
         openssh-client \
         openssh-server \
         git \
@@ -56,9 +57,6 @@ RUN wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py && python get-
 # pinning pip to 21.0.0 as 22.0.0 cannot fetch pytorch packages from html linl
 # https://github.com/pytorch/pytorch/issues/72045
 RUN pip install --no-cache-dir -U --force pip~=21.0.0 setuptools requests pytest mock pytest-forked parameterized
-
-# Install recent CMake.
-RUN pip install --no-cache-dir -U cmake~=3.13.0
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -38,6 +38,7 @@ RUN CUDNN_MAJOR=$(cut -d '.' -f 1 <<< "${CUDNN_VERSION}"); \
     apt-get update -qq && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         wget \
         ca-certificates \
+        cmake \
         openssh-client \
         openssh-server \
         git \
@@ -61,9 +62,6 @@ RUN wget --progress=dot:mega https://bootstrap.pypa.io/get-pip.py && python get-
 # pinning pip to 21.0.0 as 22.0.0 cannot fetch pytorch packages from html linl
 # https://github.com/pytorch/pytorch/issues/72045
 RUN pip install --no-cache-dir -U --force pip~=21.0.0 "setuptools<60.1.0" requests pytest mock pytest-forked parameterized
-
-# Install recent CMake.
-RUN pip install --no-cache-dir -U cmake~=3.13.0
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -59,6 +59,7 @@ services:
       args:
         # Tensorflow 1.15.5 is only available for Python 3.7
         # Python 3.7 is only available on Ubuntu 18.04
+        # On Ubuntu 18.04 our setup.py will pull in a recent CMake and use that only to build Horovod
         UBUNTU_VERSION: 18.04
         PYTHON_VERSION: 3.7
         # there is no tensorflow-cpu>1.15.0, so we use tensorflow==1.15.5

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -17,6 +17,7 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
+        cmake \
         g++-7 \
         git \
         curl \
@@ -54,9 +55,6 @@ RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
-
-# Install recent CMake.
-RUN pip install --no-cache-dir -U cmake~=3.13.0
 
 # Install PyTorch, TensorFlow, Keras and MXNet
 RUN pip install --no-cache-dir torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION}

--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         build-essential \
         g++-7 \
         git \
-        gpg \
         curl \
         vim \
         wget \

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -17,7 +17,6 @@ RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install
         build-essential \
         wget \
         git \
-        gpg \
         curl \
         rsync \
         vim \

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -15,15 +15,13 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
         build-essential \
+        cmake \
         wget \
         git \
         curl \
         rsync \
         vim \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
-
-# Install recent CMake.
-RUN pip install --no-cache-dir -U cmake~=3.13.0
 
 # Install PyTorch
 RUN pip install --no-cache-dir \

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
         build-essential \
         g++-7 \
         git \
-        gpg \
         curl \
         vim \
         wget \

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -23,6 +23,7 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
+        cmake \
         g++-7 \
         git \
         curl \
@@ -66,9 +67,6 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py && \
     pip install --no-cache-dir -U --force pip~=21.0.0
-
-# Install recent CMake.
-RUN pip install --no-cache-dir -U cmake~=3.13.0
 
 # Install PyTorch, TensorFlow, Keras and MXNet
 RUN pip install --no-cache-dir \

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,8 +17,9 @@ For best performance on GPU:
 
 - `NCCL 2 <https://developer.nvidia.com/nccl>`__
 
-If Horovod in unable to find the CMake binary, you may need to set ``HOROVOD_CMAKE`` in your environment before
-installing.
+If Horovod cannot find CMake 3.13 or newer, the build script will attempt to pull in a recent CMake binary and run it
+from a temporary location.  To select a specific binary you can also set ``HOROVOD_CMAKE`` in your environment before
+installing Horovod.
 
 Horovod does not support Windows.
 
@@ -246,7 +247,7 @@ Possible values are given in curly brackets: {}.
 * ``HOROVOD_GPU_BROADCAST`` - {NCCL, MPI}. Framework to use for GPU tensor broadcast.
 * ``HOROVOD_ALLOW_MIXED_GPU_IMPL`` - {1}. Allow Horovod to install with NCCL allreduce and MPI GPU allgather / broadcast.  Not recommended due to a possible deadlock.
 * ``HOROVOD_CPU_OPERATIONS`` - {MPI, GLOO, CCL}. Framework to use for CPU tensor allreduce, allgather, and broadcast.
-* ``HOROVOD_CMAKE`` - path to the CMake binary used to build Gloo (not required when using MPI).
+* ``HOROVOD_CMAKE`` - path to the CMake binary used to build Horovod.
 * ``HOROVOD_WITH_TENSORFLOW`` - {1}. Require Horovod to install with TensorFlow support enabled.
 * ``HOROVOD_WITHOUT_TENSORFLOW`` - {1}. Skip installing TensorFlow support.
 * ``HOROVOD_WITH_PYTORCH`` - {1}. Require Horovod to install with PyTorch support enabled.

--- a/setup.py
+++ b/setup.py
@@ -78,12 +78,12 @@ def get_cmake_bin():
 
     if cmake_installed_version < LooseVersion("3.13.0"):
         print("Could not find a recent CMake to build Horovod. "
-              "Attempting to install CMake 3.13 to a temporary location via pip.")
+              "Attempting to install CMake 3.13 to a temporary location via pip.", flush=True)
         cmake_temp_dir = tempfile.TemporaryDirectory(prefix="horovod-cmake-tmp")
         atexit.register(cmake_temp_dir.cleanup)
         try:
             _ = subprocess.check_output(["pip", "install", "--target", cmake_temp_dir.name, "cmake~=3.13.0"])
-        except OSError:
+        except Exception:
             raise RuntimeError("Failed to install temporary CMake. "
                                "Please update your CMake to 3.13+ or set HOROVOD_CMAKE appropriately.")
         cmake_bin = os.path.join(cmake_temp_dir.name, "bin", "run_cmake")


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This is a follow-up to PR #3261, which would require users of many distros to install a recent CMake from an external source (like `pip`).

If such a situation is identified in `setup.py`, we can automatically install a sufficiently recent CMake to a temporary directory and use that to build Horovod. That directory is cleaned up afterwards and the user or system environment is not affected. If `HOROVOD_CMAKE` is set, only that CMake binary is used without any change of behavior.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
