### PR TITLE
Allow stderr of executed cmake python code appear in logs

### DIFF
--- a/cmake/Modules/FindMxnet.cmake
+++ b/cmake/Modules/FindMxnet.cmake
@@ -17,7 +17,7 @@ set(Mxnet_COMPILE_FLAGS "")
 
 set(ENV{PYTHONPATH} "${PROJECT_SOURCE_DIR}/cmake:$ENV{PYTHONPATH}")
 execute_process(COMMAND ${PY_EXE} -c "import os; import mxnet as mx; import build_utils; print(mx.__version__); print(mx.libinfo.find_include_path()); print(' '.join(mx.libinfo.find_lib_path())); print(build_utils.is_mx_mkldnn()); print(build_utils.is_mx_onednn()); print(build_utils.is_mx_cuda())"
-                OUTPUT_VARIABLE Mxnet_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                OUTPUT_VARIABLE Mxnet_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX REPLACE "\n" ";" Mxnet_OUTPUT "${Mxnet_OUTPUT}")
 list(LENGTH Mxnet_OUTPUT LEN)
 if (LEN EQUAL "6")

--- a/cmake/Modules/FindPytorch.cmake
+++ b/cmake/Modules/FindPytorch.cmake
@@ -15,7 +15,7 @@
 list(APPEND CMAKE_PREFIX_PATH ${Pytorch_ROOT})
 
 execute_process(COMMAND ${PY_EXE} -c "import torch; print(torch.__version__)"
-                OUTPUT_VARIABLE Pytorch_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                OUTPUT_VARIABLE Pytorch_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Pytorch REQUIRED_VARS Pytorch_VERSION VERSION_VAR Pytorch_VERSION)
 if(NOT PYTORCH_FOUND)
@@ -23,12 +23,12 @@ if(NOT PYTORCH_FOUND)
 endif()
 
 execute_process(COMMAND ${PY_EXE} -c "import torch; from torch.utils.cpp_extension import CUDA_HOME; print(True if ((torch.version.cuda is not None) and (CUDA_HOME is not None)) else False)"
-                OUTPUT_VARIABLE Pytorch_CUDA OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                OUTPUT_VARIABLE Pytorch_CUDA OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX REPLACE "No CUDA runtime[^\n]*\n?" "" Pytorch_CUDA "${Pytorch_CUDA}")
 string(TOUPPER "${Pytorch_CUDA}" Pytorch_CUDA)
 
 execute_process(COMMAND ${PY_EXE} -c "import torch; from torch.utils.cpp_extension import ROCM_HOME; print(True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False)"
-                OUTPUT_VARIABLE Pytorch_ROCM OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                OUTPUT_VARIABLE Pytorch_ROCM OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX REPLACE "No CUDA runtime[^\n]*\n?" "" Pytorch_ROCM "${Pytorch_ROCM}")
 string(TOUPPER "${Pytorch_ROCM}" Pytorch_ROCM)
 

--- a/cmake/Modules/FindTensorflow.cmake
+++ b/cmake/Modules/FindTensorflow.cmake
@@ -12,7 +12,7 @@
 list(APPEND CMAKE_PREFIX_PATH ${Tensorflow_ROOT})
 
 execute_process(COMMAND ${PY_EXE} -c "import tensorflow as tf; print(tf.__version__); print(tf.sysconfig.get_include()); print(' '.join(tf.sysconfig.get_link_flags())); print(' '.join(tf.sysconfig.get_compile_flags()))"
-                OUTPUT_VARIABLE Tensorflow_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                OUTPUT_VARIABLE Tensorflow_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX REPLACE "\n" ";" Tensorflow_OUTPUT "${Tensorflow_OUTPUT}")
 list(LENGTH Tensorflow_OUTPUT LEN)
 if (LEN EQUAL "4")


### PR DESCRIPTION
CMake executes Python code to detect installed frameworks. If that code fails, there is no trace in the logs, which makes identifying the cause very difficult. We only see it could not find the framework:

```
  #44 63.09     CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  #44 63.09       Could NOT find Mxnet (missing: Mxnet_LIBRARIES) (Required is at least
  #44 63.09       version "1.4.0")
  #44 63.09     Call Stack (most recent call first):
  #44 63.09       /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  #44 63.09       cmake/Modules/FindMxnet.cmake:65 (find_package_handle_standard_args)
  #44 63.09       horovod/mxnet/CMakeLists.txt:12 (find_package)
```

This allows errors from the Python code to leak into the build log:

```
  #44 63.07     Traceback (most recent call last):
  #44 63.07       File "<string>", line 1, in <module>
  #44 63.07       File "/usr/local/lib/python3.8/dist-packages/mxnet/__init__.py", line 23, in <module>
  #44 63.07         from .context import Context, current_context, cpu, gpu, cpu_pinned
  #44 63.07       File "/usr/local/lib/python3.8/dist-packages/mxnet/context.py", line 20, in <module>
  #44 63.07         from .base import _LIB
  #44 63.07       File "/usr/local/lib/python3.8/dist-packages/mxnet/base.py", line 293, in <module>
  #44 63.07         _LIB = _load_lib()
  #44 63.07       File "/usr/local/lib/python3.8/dist-packages/mxnet/base.py", line 284, in _load_lib
  #44 63.07         lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_LOCAL)
  #44 63.07       File "/usr/lib/python3.8/ctypes/__init__.py", line 369, in __init__
  #44 63.07         self._handle = _dlopen(self._name, mode)
  #44 63.07     OSError: libcusolver.so.10: cannot open shared object file: No such file or directory
  #44 63.09     CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  #44 63.09       Could NOT find Mxnet (missing: Mxnet_LIBRARIES) (Required is at least
  #44 63.09       version "1.4.0")
  #44 63.09     Call Stack (most recent call first):
  #44 63.09       /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  #44 63.09       cmake/Modules/FindMxnet.cmake:65 (find_package_handle_standard_args)
  #44 63.09       horovod/mxnet/CMakeLists.txt:12 (find_package)
```