### PR TITLE
Deprecate use of np, min_np, max_np, replace with num_proc

### DIFF
--- a/docs/elastic.rst
+++ b/docs/elastic.rst
@@ -294,7 +294,7 @@ to allow Horovod to discover available hosts is to provide a ``--host-discovery-
 
 .. code-block:: bash
 
-    $ horovodrun -np 8 --host-discovery-script discover_hosts.sh python train.py
+    $ horovodrun --num-proc 8 --host-discovery-script discover_hosts.sh python train.py
 
 The host discovery script must have user executable permissions, and return one host with its available slots per line
 of the form: ``<hostname>:<slots>``.  For example:
@@ -314,23 +314,23 @@ Your discovery script may omit the ``:<slots>`` if you explicitly specify the nu
 
 .. code-block:: bash
 
-    $ horovodrun -np 8 --host-discovery-script discover_hosts.sh --slots 4 python train.py
+    $ horovodrun --num-proc 8 --host-discovery-script discover_hosts.sh --slots 4 python train.py
 
-The elastic training job will not start until at least ``-np`` slots are available for running worker processes.
+The elastic training job will not start until at least ``--num-proc`` slots are available for running worker processes.
 
 You can additionally specify the minimum and maximum number of processes to run with during the job:
 
 .. code-block:: bash
 
-    $ horovodrun -np 8 --min-np 4 --max-np 12 --host-discovery-script discover_hosts.sh python train.py
+    $ horovodrun --num-proc 8 --min-num-proc 4 --max-num-proc 12 --host-discovery-script discover_hosts.sh python train.py
 
-If the number of available slots falls below ``--min-np`` (due to host failure, preemption, etc.), then the job will
+If the number of available slots falls below ``--min-num-proc`` (due to host failure, preemption, etc.), then the job will
 pause waiting for more hosts to become available or until ``HOROVOD_ELASTIC_TIMEOUT`` (default: 600 seconds) has
-elapsed.  If unspecified, minimum np defaults to ``-np``.
+elapsed.  If unspecified, minimum np defaults to ``--num-proc``.
 
 The maximum np can be used to cap the number of processes (to prevent over-utilizing available resources) and to serve
 as a reference point for learning rate scales and data partitions (in cases where these need to be held constant
-regardless of the current number of workers).  If unspecified, maximum np also defaults to ``-np``.
+regardless of the current number of workers).  If unspecified, maximum np also defaults to ``--num-proc``.
 
 Instances that fail will be added to a blacklist, as they may have faulty hardware. Hosts will remain in blacklist for a configured cooldown period.
 After the cooldown period ends, the hosts will be whitelisted back. This is to account for transient failures, and cases where the same host
@@ -339,7 +339,7 @@ Cooldown periods can be configured with the ``--blacklist-cooldown-range`` param
 
 .. code-block:: bash
 
-    $ horovodrun -np 8 --blacklist-cooldown-range 10 100 --min-np 4 --max-np 12 --host-discovery-script discover_hosts.py python train.py
+    $ horovodrun --num-proc 8 --blacklist-cooldown-range 10 100 --min-num-proc 4 --max-num-proc 12 --host-discovery-script discover_hosts.py python train.py
 
 The above example configures the minimum cooldown period to 10 seconds and the maximum cooldown period to 100 seconds.
 The intial cooldown period would be 10 seconds. For repeat failures the cooldown period would grow with an exponential

--- a/docs/elastic.rst
+++ b/docs/elastic.rst
@@ -294,7 +294,7 @@ to allow Horovod to discover available hosts is to provide a ``--host-discovery-
 
 .. code-block:: bash
 
-    $ horovodrun --num-proc 8 --host-discovery-script discover_hosts.sh python train.py
+    $ horovodrun -np 8 --host-discovery-script discover_hosts.sh python train.py
 
 The host discovery script must have user executable permissions, and return one host with its available slots per line
 of the form: ``<hostname>:<slots>``.  For example:
@@ -314,23 +314,23 @@ Your discovery script may omit the ``:<slots>`` if you explicitly specify the nu
 
 .. code-block:: bash
 
-    $ horovodrun --num-proc 8 --host-discovery-script discover_hosts.sh --slots 4 python train.py
+    $ horovodrun -np 8 --host-discovery-script discover_hosts.sh --slots 4 python train.py
 
-The elastic training job will not start until at least ``--num-proc`` slots are available for running worker processes.
+The elastic training job will not start until at least ``-np`` slots are available for running worker processes.
 
 You can additionally specify the minimum and maximum number of processes to run with during the job:
 
 .. code-block:: bash
 
-    $ horovodrun --num-proc 8 --min-num-proc 4 --max-num-proc 12 --host-discovery-script discover_hosts.sh python train.py
+    $ horovodrun -np 8 --min-np 4 --max-np 12 --host-discovery-script discover_hosts.sh python train.py
 
-If the number of available slots falls below ``--min-num-proc`` (due to host failure, preemption, etc.), then the job will
+If the number of available slots falls below ``--min-np`` (due to host failure, preemption, etc.), then the job will
 pause waiting for more hosts to become available or until ``HOROVOD_ELASTIC_TIMEOUT`` (default: 600 seconds) has
-elapsed.  If unspecified, minimum np defaults to ``--num-proc``.
+elapsed.  If unspecified, minimum np defaults to ``-np``.
 
 The maximum np can be used to cap the number of processes (to prevent over-utilizing available resources) and to serve
 as a reference point for learning rate scales and data partitions (in cases where these need to be held constant
-regardless of the current number of workers).  If unspecified, maximum np also defaults to ``--num-proc``.
+regardless of the current number of workers).  If unspecified, maximum np also defaults to ``-np``.
 
 Instances that fail will be added to a blacklist, as they may have faulty hardware. Hosts will remain in blacklist for a configured cooldown period.
 After the cooldown period ends, the hosts will be whitelisted back. This is to account for transient failures, and cases where the same host
@@ -339,7 +339,7 @@ Cooldown periods can be configured with the ``--blacklist-cooldown-range`` param
 
 .. code-block:: bash
 
-    $ horovodrun --num-proc 8 --blacklist-cooldown-range 10 100 --min-num-proc 4 --max-num-proc 12 --host-discovery-script discover_hosts.py python train.py
+    $ horovodrun -np 8 --blacklist-cooldown-range 10 100 --min-np 4 --max-np 12 --host-discovery-script discover_hosts.py python train.py
 
 The above example configures the minimum cooldown period to 10 seconds and the maximum cooldown period to 100 seconds.
 The intial cooldown period would be 10 seconds. For repeat failures the cooldown period would grow with an exponential

--- a/horovod/ray/elastic.py
+++ b/horovod/ray/elastic.py
@@ -224,12 +224,10 @@ class ElasticRayExecutor:
             nics (set): Network interfaces that can be used for communication.
         """
         if min_np is not None:
-            if min_num_proc != 1:
-                min_num_proc = min_np
+            min_num_proc = min_np
             warnings.warn('min_np is deprecated, use min_num_proc instead', DeprecationWarning)
         if max_np is not None:
-            if max_num_proc is None:
-                max_num_proc = max_np
+            max_num_proc = max_np
             warnings.warn('max_np is deprecated, use max_num_proc instead', DeprecationWarning)
 
         start_timeout = timeout.Timeout(

--- a/horovod/ray/elastic_v2.py
+++ b/horovod/ray/elastic_v2.py
@@ -284,8 +284,8 @@ class ElasticAdapter(Adapter):
         self.driver = ElasticDriver(
             rendezvous=self.rendezvous,
             discovery=self.settings.discovery,
-            min_np=self.min_workers,
-            max_np=self.max_workers,
+            min_num_proc=self.min_workers,
+            max_num_proc=self.max_workers,
             timeout=self.elastic_timeout,
             reset_limit=self.reset_limit,
             cooldown_range=self.cooldown_range,

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -182,17 +182,13 @@ def run(
              The index of the list corresponds to the rank of each Horovod process.
     """
     if np is not None:
-        # only overrides num_proc if num_proc is not the default value
-        if num_proc == 1:
-            num_proc = np
+        num_proc = np
         warnings.warn('np is deprecated, use num_proc instead', DeprecationWarning)
     if min_np is not None:
-        if min_num_proc is None:
-            min_num_proc = min_np
+        min_num_proc = min_np
         warnings.warn('min_np is deprecated, use min_num_proc instead', DeprecationWarning)
     if max_np is not None:
-        if max_num_proc is None:
-            max_num_proc = max_np
+        max_num_proc = max_np
         warnings.warn('max_np is deprecated, use max_num_proc instead', DeprecationWarning)
 
     from .launch import _run

--- a/horovod/runner/common/util/hosts.py
+++ b/horovod/runner/common/util/hosts.py
@@ -97,7 +97,7 @@ def parse_hosts(hosts_string):
     return [HostInfo.from_string(host_string) for host_string in hosts_string.split(',')]
 
 
-def get_host_assignments(hosts, min_np, max_np=None):
+def get_host_assignments(hosts, min_num_proc, max_num_proc=None):
     """Assign hosts with process capacities (slots) to ranks in the Horovod process.
 
     This function will try to allocate as many as possible processes on the same host to leverage
@@ -105,10 +105,10 @@ def get_host_assignments(hosts, min_np, max_np=None):
 
     :param hosts: list of HostInfo objects describing host and slot capacity
     :type hosts: list[HostInfo]
-    :param min_np: minimum number of processes to be allocated
-    :type min_np: int
-    :param max_np: (optional) maximum number of processes to be allocated
-    :type max_np: int
+    :param min_num_proc: minimum number of processes to be allocated
+    :type min_num_proc: int
+    :param max_num_proc: (optional) maximum number of processes to be allocated
+    :type max_num_proc: int
     :return: a list of the allocation of process on hosts in a `SlotInfo` object.
     :rtype: list[SlotInfo]
     """
@@ -118,7 +118,7 @@ def get_host_assignments(hosts, min_np, max_np=None):
     for host_info in hosts:
         ranks = []
         for local_rank in range(host_info.slots):
-            if rank == max_np:
+            if rank == max_num_proc:
                 break
 
             ranks.append(rank)
@@ -130,9 +130,9 @@ def get_host_assignments(hosts, min_np, max_np=None):
         host_ranks.append((host_info, ranks))
 
     world_size = rank
-    if world_size < min_np:
+    if world_size < min_num_proc:
         raise ValueError('Requested more processes ({}) than there are available slots ({})'
-                         .format(min_np, world_size))
+                         .format(min_num_proc, world_size))
 
     alloc_list = []
     for host_info, ranks in host_ranks:

--- a/horovod/runner/elastic/driver.py
+++ b/horovod/runner/elastic/driver.py
@@ -67,26 +67,14 @@ class ResultsRecorder(object):
 
 
 class ElasticDriver(object):
-    def __init__(self,
-                 rendezvous,
+    def __init__(self, rendezvous,
                  discovery,
                  min_num_proc,
                  max_num_proc,
                  timeout=None,
                  reset_limit=None,
                  cooldown_range=None,
-                 verbose=0,
-                 # min_np is deprecated, use min_num_proc instead
-                 min_np=None,
-                 # max_np is deprecated, use max_num_proc instead
-                 max_np=None):
-        if min_np is not None:
-            min_num_proc = min_np
-            warnings.warn('min_np is deprecated, use min_num_proc instead', DeprecationWarning)
-        if max_np is not None:
-            max_num_proc = max_np
-            warnings.warn('max_np is deprecated, use max_num_proc instead', DeprecationWarning)
-
+                 verbose=0):
         self._rendezvous = rendezvous
         self._host_manager = HostManager(discovery, cooldown_range)
         self._min_num_proc = min_num_proc

--- a/horovod/runner/elastic/settings.py
+++ b/horovod/runner/elastic/settings.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import warnings
-
 from horovod.runner.common.util.settings import BaseSettings
 
 
@@ -26,10 +24,6 @@ class ElasticSettings(BaseSettings):
                  elastic_timeout,
                  reset_limit,
                  cooldown_range=None,
-                 # min_np is deprecated, use min_num_proc instead
-                 min_np=None,
-                 # max_np is deprecated, use max_num_proc instead
-                 max_np=None,
                  **kwargs):
         """
         :param discovery: object used to detect and manage available hosts
@@ -45,13 +39,6 @@ class ElasticSettings(BaseSettings):
         :param cooldown_range: maximum number of resets after which the job is terminated
         :type cooldown_range: int
         """
-        if min_np is not None:
-            min_num_proc = min_np
-            warnings.warn('min_np is deprecated, use min_num_proc instead', DeprecationWarning)
-        if max_np is not None:
-            max_num_proc = max_np
-            warnings.warn('max_np is deprecated, use max_num_proc instead', DeprecationWarning)
-
         super(ElasticSettings, self).__init__(elastic=True, **kwargs)
         self.discovery = discovery
         self.min_num_proc = min_num_proc

--- a/horovod/runner/elastic/settings.py
+++ b/horovod/runner/elastic/settings.py
@@ -13,18 +13,31 @@
 # limitations under the License.
 # ==============================================================================
 
+import warnings
+
 from horovod.runner.common.util.settings import BaseSettings
 
 
 class ElasticSettings(BaseSettings):
-    def __init__(self, discovery, min_np, max_np, elastic_timeout, reset_limit, cooldown_range=None, **kwargs):
+    def __init__(self,
+                 discovery,
+                 min_num_proc,
+                 max_num_proc,
+                 elastic_timeout,
+                 reset_limit,
+                 cooldown_range=None,
+                 # min_np is deprecated, use min_num_proc instead
+                 min_np=None,
+                 # max_np is deprecated, use max_num_proc instead
+                 max_np=None,
+                 **kwargs):
         """
         :param discovery: object used to detect and manage available hosts
         :type discovery: horovod.runner.elastic.discovery.HostDiscovery
-        :param min_np: minimum number of processes
-        :type min_np: int
-        :param max_np: maximum number of processes
-        :type max_np: int
+        :param min_num_proc: minimum number of processes
+        :type min_num_proc: int
+        :param max_num_proc: maximum number of processes
+        :type max_num_proc: int
         :param elastic_timeout: timeout for elastic initialisation after re-scaling in seconds
         :type elastic_timeout: int
         :param reset_limit: maximum number of resets after which the job is terminated
@@ -32,10 +45,17 @@ class ElasticSettings(BaseSettings):
         :param cooldown_range: maximum number of resets after which the job is terminated
         :type cooldown_range: int
         """
+        if min_np is not None:
+            min_num_proc = min_np
+            warnings.warn('min_np is deprecated, use min_num_proc instead', DeprecationWarning)
+        if max_np is not None:
+            max_num_proc = max_np
+            warnings.warn('max_np is deprecated, use max_num_proc instead', DeprecationWarning)
+
         super(ElasticSettings, self).__init__(elastic=True, **kwargs)
         self.discovery = discovery
-        self.min_np = min_np
-        self.max_np = max_np
+        self.min_num_proc = min_num_proc
+        self.max_num_proc = max_num_proc
         self.elastic_timeout = elastic_timeout
         self.reset_limit = reset_limit
         self.cooldown_range=cooldown_range

--- a/horovod/runner/gloo_run.py
+++ b/horovod/runner/gloo_run.py
@@ -304,7 +304,7 @@ def launch_gloo_elastic(command, exec_command, settings, env, get_common_interfa
         _mkdir_p(settings.output_filename)
 
     driver = ElasticDriver(rendezvous, settings.discovery,
-                           settings.min_np, settings.max_np,
+                           settings.min_num_proc, settings.max_num_proc,
                            timeout=settings.elastic_timeout,
                            reset_limit=settings.reset_limit,
                            cooldown_range=settings.cooldown_range,

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -652,8 +652,8 @@ def _run_elastic(args):
                                     'may need to increase the --start-timeout '
                                     'parameter if you have too many servers.')
     settings = elastic_settings.ElasticSettings(discovery=discover_hosts,
-                                                min_np=args.min_num_proc or args.num_proc,
-                                                max_np=args.max_num_proc,
+                                                min_num_proc=args.min_num_proc or args.num_proc,
+                                                max_num_proc=args.max_num_proc,
                                                 elastic_timeout=args.elastic_timeout,
                                                 reset_limit=args.reset_limit,
                                                 cooldown_range=args.cooldown_range,

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -407,10 +407,10 @@ def parse_args():
     group_elastic.add_argument('--max-num-proc', action='store', dest='max_num_proc', type=int,
                                help='Maximum number of training processes, beyond which no additional '
                                     'processes will be created. If not specified, then will be unbounded.')
-    group_elastic.add_argument('--min-np', dest='min_num_proc', type=int,
+    group_elastic.add_argument('--min-np', dest='min_num_proc',
                                action=make_deprecated_int_action(override_args, False, '--min-num-proc', 'v1.0.0'),
                                help=argparse.SUPPRESS)
-    group_elastic.add_argument('--max-np', dest='max_num_proc', type=int,
+    group_elastic.add_argument('--max-np', dest='max_num_proc',
                                action=make_deprecated_int_action(override_args, False, '--max-num-proc', 'v1.0.0'),
                                help=argparse.SUPPRESS)
     group_elastic.add_argument('--slots-per-host', action='store', dest='slots', type=int,

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -213,17 +213,17 @@ def make_override_false_action(override_args):
     return make_override_bool_action(override_args, False)
 
 
-def make_deprecated_int_action(override_args, int_value, replacement_option, remove_version):
-    class StoreOverrideIntAction(argparse.Action):
+def make_deprecated_action(override_args, value, replacement_option, remove_version):
+    class StoreOverrideAction(argparse.Action):
         def __init__(self,
                      option_strings,
                      dest,
                      required=False,
                      help=None):
-            super(StoreOverrideIntAction, self).__init__(
+            super(StoreOverrideAction, self).__init__(
                 option_strings=option_strings,
                 dest=dest,
-                const=int_value,
+                const=value,
                 nargs=0,
                 default=None,
                 required=required,
@@ -237,33 +237,7 @@ def make_deprecated_int_action(override_args, int_value, replacement_option, rem
             override_args.add(self.dest)
             setattr(args, self.dest, self.const)
 
-    return StoreOverrideIntAction
-
-
-def make_deprecated_bool_action(override_args, bool_value, replacement_option):
-    class StoreOverrideBoolAction(argparse.Action):
-        def __init__(self,
-                     option_strings,
-                     dest,
-                     required=False,
-                     help=None):
-            super(StoreOverrideBoolAction, self).__init__(
-                option_strings=option_strings,
-                dest=dest,
-                const=bool_value,
-                nargs=0,
-                default=None,
-                required=required,
-                help=help)
-
-        def __call__(self, parser, args, values, option_string=None):
-            deprecated_option = '|'.join(self.option_strings)
-            warnings.warn(f'Argument {deprecated_option} has been replaced by {replacement_option} and will be removed in v0.21.0',
-                          DeprecationWarning)
-            override_args.add(self.dest)
-            setattr(args, self.dest, self.const)
-
-    return StoreOverrideBoolAction
+    return StoreOverrideAction
 
 
 def parse_args():
@@ -408,10 +382,10 @@ def parse_args():
                                help='Maximum number of training processes, beyond which no additional '
                                     'processes will be created. If not specified, then will be unbounded.')
     group_elastic.add_argument('--min-np', dest='min_num_proc',
-                               action=make_deprecated_int_action(override_args, False, '--min-num-proc', 'v1.0.0'),
+                               action=make_deprecated_action(override_args, False, '--min-num-proc', 'v1.0.0'),
                                help=argparse.SUPPRESS)
     group_elastic.add_argument('--max-np', dest='max_num_proc',
-                               action=make_deprecated_int_action(override_args, False, '--max-num-proc', 'v1.0.0'),
+                               action=make_deprecated_action(override_args, False, '--max-num-proc', 'v1.0.0'),
                                help=argparse.SUPPRESS)
     group_elastic.add_argument('--slots-per-host', action='store', dest='slots', type=int,
                                help='Number of slots for processes per host. Normally 1 slot per GPU per host. '
@@ -502,11 +476,11 @@ def parse_args():
                                          help='Timestamp each line of output to stdout, stderr, and stddiag.')
     group_logging_timestamp.add_argument('--log-hide-timestamp',
                                          dest='log_with_timestamp',
-                                         action=make_deprecated_bool_action(override_args, False, '--log-without-timestamp'),
+                                         action=make_deprecated_action(override_args, False, '--log-without-timestamp', 'v0.21.0'),
                                          help=argparse.SUPPRESS)
     group_logging_timestamp.add_argument('--no-log-hide-timestamp',
                                          dest='log_with_timestamp',
-                                         action=make_deprecated_bool_action(override_args, True, '--log-with-timestamp'),
+                                         action=make_deprecated_action(override_args, True, '--log-with-timestamp', 'v0.21.0'),
                                          help=argparse.SUPPRESS)
 
     group_hosts_parent = parser.add_argument_group('host arguments')

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -213,6 +213,33 @@ def make_override_false_action(override_args):
     return make_override_bool_action(override_args, False)
 
 
+def make_deprecated_int_action(override_args, int_value, replacement_option, remove_version):
+    class StoreOverrideIntAction(argparse.Action):
+        def __init__(self,
+                     option_strings,
+                     dest,
+                     required=False,
+                     help=None):
+            super(StoreOverrideIntAction, self).__init__(
+                option_strings=option_strings,
+                dest=dest,
+                const=int_value,
+                nargs=0,
+                default=None,
+                required=required,
+                help=help)
+
+        def __call__(self, parser, args, values, option_string=None):
+            deprecated_option = '|'.join(self.option_strings)
+            warnings.warn(f'Argument {deprecated_option} has been replaced by {replacement_option} '
+                          f'and will be removed in {remove_version}',
+                          DeprecationWarning)
+            override_args.add(self.dest)
+            setattr(args, self.dest, self.const)
+
+    return StoreOverrideIntAction
+
+
 def make_deprecated_bool_action(override_args, bool_value, replacement_option):
     class StoreOverrideBoolAction(argparse.Action):
         def __init__(self,
@@ -247,7 +274,7 @@ def parse_args():
     parser.add_argument('-v', '--version', action='version', version=horovod.__version__,
                         help='Shows Horovod version.')
 
-    np_arg = parser.add_argument('-np', '--num-proc', action='store', dest='np',
+    np_arg = parser.add_argument('-np', '--num-proc', action='store', dest='num_proc',
                                  type=int, required=not lsf.LSFUtils.using_lsf(),
                                  help='Total number of training processes. In elastic mode, '
                                       'number of processes required before training can start.')
@@ -373,13 +400,19 @@ def parse_args():
                                      '(default: 0.8')
 
     group_elastic = parser.add_argument_group('elastic arguments')
-    group_elastic.add_argument('--min-np', action='store', dest='min_np', type=int,
+    group_elastic.add_argument('--min-num-proc', action='store', dest='min_num_proc', type=int,
                                help='Minimum number of processes running for training to continue. If number of '
                                     'available processes dips below this threshold, then training will wait for '
                                     'more instances to become available. Defaults to --num-proc.')
-    group_elastic.add_argument('--max-np', action='store', dest='max_np', type=int,
+    group_elastic.add_argument('--max-num-proc', action='store', dest='max_num_proc', type=int,
                                help='Maximum number of training processes, beyond which no additional '
                                     'processes will be created. If not specified, then will be unbounded.')
+    group_elastic.add_argument('--min-np', dest='min_num_proc', type=int,
+                               action=make_deprecated_int_action(override_args, False, '--min-num-proc', 'v1.0.0'),
+                               help=argparse.SUPPRESS)
+    group_elastic.add_argument('--max-np', dest='max_num_proc', type=int,
+                               action=make_deprecated_int_action(override_args, False, '--max-num-proc', 'v1.0.0'),
+                               help=argparse.SUPPRESS)
     group_elastic.add_argument('--slots-per-host', action='store', dest='slots', type=int,
                                help='Number of slots for processes per host. Normally 1 slot per GPU per host. '
                                     'If slots are provided by the output of the host discovery script, then '
@@ -548,7 +581,7 @@ def _run_static(args):
                                      binding_args=args.binding_args,
                                      key=secret.make_secret_key(),
                                      start_timeout=tmout,
-                                     num_proc=args.np,
+                                     num_proc=args.num_proc,
                                      hosts=args.hosts,
                                      output_filename=args.output_filename,
                                      run_func_mode=args.run_func is not None,
@@ -561,8 +594,8 @@ def _run_static(args):
     fn_cache = None
     if not args.disable_cache:
         params = ''
-        if args.np:
-            params += str(args.np) + ' '
+        if args.num_proc:
+            params += str(args.num_proc) + ' '
         if args.hosts:
             params += str(args.hosts) + ' '
         if args.ssh_port:
@@ -606,9 +639,9 @@ def _run_static(args):
 
         try:
             _launch_job(args, settings, nics, command)
-            results = [None] * args.np
+            results = [None] * args.num_proc
             # TODO: make it parallel to improve performance
-            for i in range(args.np):
+            for i in range(args.num_proc):
                 results[i] = read_data_from_kvstore(driver_ip, run_func_server_port,
                                                     'runfunc_result', str(i))
             return results
@@ -645,12 +678,12 @@ def _run_elastic(args):
                                     'may need to increase the --start-timeout '
                                     'parameter if you have too many servers.')
     settings = elastic_settings.ElasticSettings(discovery=discover_hosts,
-                                                min_np=args.min_np or args.np,
-                                                max_np=args.max_np,
+                                                min_np=args.min_num_proc or args.num_proc,
+                                                max_np=args.max_num_proc,
                                                 elastic_timeout=args.elastic_timeout,
                                                 reset_limit=args.reset_limit,
                                                 cooldown_range=args.cooldown_range,
-                                                num_proc=args.np,
+                                                num_proc=args.num_proc,
                                                 verbose=2 if args.verbose else 0,
                                                 ssh_port=args.ssh_port,
                                                 ssh_identity_file=args.ssh_identity_file,
@@ -713,7 +746,7 @@ def run_controller(use_gloo, gloo_run, use_mpi, mpi_run, use_jsrun, js_run, verb
 
 
 def _is_elastic(args):
-    return args.host_discovery_script is not None or args.min_np is not None
+    return args.host_discovery_script is not None or args.min_num_proc is not None
 
 
 def _launch_job(args, settings, nics, command):
@@ -739,10 +772,10 @@ def _launch_job(args, settings, nics, command):
 def _run(args):
     # If LSF is used, use default values from job config
     if lsf.LSFUtils.using_lsf():
-        if not args.np:
-            args.np = lsf.LSFUtils.get_num_processes()
+        if not args.num_proc:
+            args.num_proc = lsf.LSFUtils.get_num_processes()
         if not args.hosts and not args.hostfile and not args.host_discovery_script:
-            args.hosts = ','.join('{host}:{np}'.format(host=host, np=lsf.LSFUtils.get_num_gpus())
+            args.hosts = ','.join(f'{host}:{lsf.LSFUtils.get_num_gpus()}'
                                   for host in lsf.LSFUtils.get_compute_hosts())
 
     # if hosts are not specified, either parse from hostfile, or default as
@@ -752,7 +785,7 @@ def _run(args):
             args.hosts = hosts.parse_host_files(args.hostfile)
         else:
             # Set hosts to localhost if not specified
-            args.hosts = 'localhost:{np}'.format(np=args.np)
+            args.hosts = f'localhost:{args.num_proc}'
 
     # Convert nics into set
     args.nics = set(args.nics.split(',')) if args.nics else None

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -394,7 +394,8 @@ def parse_args():
                                help='Maximum number of times that the training job can scale up or down '
                                     'the number of workers after which the job is terminated. (default: None)')
     group_elastic.add_argument('--blacklist-cooldown-range', action='store', dest='cooldown_range', type=int, nargs=2,
-                               help='Range of seconds(min, max) a failing host will remain in blacklist. (default: None)')
+                               help='Range of seconds (min, max) a failing host will remain in blacklist.'
+                                    'Example: --blacklist-cooldown-range 60 300 (default: None)')
 
     group_timeline = parser.add_argument_group('timeline arguments')
     group_timeline.add_argument('--timeline-filename', action=make_override_action(override_args),

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -213,17 +213,17 @@ def make_override_false_action(override_args):
     return make_override_bool_action(override_args, False)
 
 
-def make_deprecated_action(override_args, value, replacement_option, remove_version):
-    class StoreOverrideAction(argparse.Action):
+def make_deprecated_bool_action(override_args, bool_value, replacement_option, remove_version):
+    class StoreOverrideBoolAction(argparse.Action):
         def __init__(self,
                      option_strings,
                      dest,
                      required=False,
                      help=None):
-            super(StoreOverrideAction, self).__init__(
+            super(StoreOverrideBoolAction, self).__init__(
                 option_strings=option_strings,
                 dest=dest,
-                const=value,
+                const=bool_value,
                 nargs=0,
                 default=None,
                 required=required,
@@ -237,7 +237,7 @@ def make_deprecated_action(override_args, value, replacement_option, remove_vers
             override_args.add(self.dest)
             setattr(args, self.dest, self.const)
 
-    return StoreOverrideAction
+    return StoreOverrideBoolAction
 
 
 def parse_args():
@@ -374,19 +374,13 @@ def parse_args():
                                      '(default: 0.8')
 
     group_elastic = parser.add_argument_group('elastic arguments')
-    group_elastic.add_argument('--min-num-proc', action='store', dest='min_num_proc', type=int,
+    group_elastic.add_argument('--min-np', '--min-num-proc', action='store', dest='min_num_proc', type=int,
                                help='Minimum number of processes running for training to continue. If number of '
                                     'available processes dips below this threshold, then training will wait for '
                                     'more instances to become available. Defaults to --num-proc.')
-    group_elastic.add_argument('--max-num-proc', action='store', dest='max_num_proc', type=int,
+    group_elastic.add_argument('--max-np', '--max-num-proc', action='store', dest='max_num_proc', type=int,
                                help='Maximum number of training processes, beyond which no additional '
                                     'processes will be created. If not specified, then will be unbounded.')
-    group_elastic.add_argument('--min-np', dest='min_num_proc',
-                               action=make_deprecated_action(override_args, False, '--min-num-proc', 'v1.0.0'),
-                               help=argparse.SUPPRESS)
-    group_elastic.add_argument('--max-np', dest='max_num_proc',
-                               action=make_deprecated_action(override_args, False, '--max-num-proc', 'v1.0.0'),
-                               help=argparse.SUPPRESS)
     group_elastic.add_argument('--slots-per-host', action='store', dest='slots', type=int,
                                help='Number of slots for processes per host. Normally 1 slot per GPU per host. '
                                     'If slots are provided by the output of the host discovery script, then '
@@ -476,11 +470,11 @@ def parse_args():
                                          help='Timestamp each line of output to stdout, stderr, and stddiag.')
     group_logging_timestamp.add_argument('--log-hide-timestamp',
                                          dest='log_with_timestamp',
-                                         action=make_deprecated_action(override_args, False, '--log-without-timestamp', 'v0.21.0'),
+                                         action=make_deprecated_bool_action(override_args, False, '--log-without-timestamp', 'v0.21.0'),
                                          help=argparse.SUPPRESS)
     group_logging_timestamp.add_argument('--no-log-hide-timestamp',
                                          dest='log_with_timestamp',
-                                         action=make_deprecated_action(override_args, True, '--log-with-timestamp', 'v0.21.0'),
+                                         action=make_deprecated_bool_action(override_args, True, '--log-with-timestamp', 'v0.21.0'),
                                          help=argparse.SUPPRESS)
 
     group_hosts_parent = parser.add_argument_group('host arguments')

--- a/horovod/spark/driver/driver_service.py
+++ b/horovod/spark/driver/driver_service.py
@@ -85,11 +85,11 @@ class WaitForTaskShutdownRequest(object):
 class SparkDriverService(driver_service.BasicDriverService):
     NAME = 'driver service'
 
-    def __init__(self, initial_np, num_proc, fn, args, kwargs, key, nics):
+    def __init__(self, initial_num_proc, num_proc, fn, args, kwargs, key, nics):
         super(SparkDriverService, self).__init__(num_proc,
                                                  SparkDriverService.NAME,
                                                  key, nics)
-        self._initial_np = initial_np
+        self._initial_num_proc = initial_num_proc
         self._fn = fn
         self._args = args
         self._kwargs = kwargs
@@ -175,7 +175,7 @@ class SparkDriverService(driver_service.BasicDriverService):
     def wait_for_initial_registration(self, timeout):
         self._wait_cond.acquire()
         try:
-            while len(self._all_task_addresses) < self._initial_np:
+            while len(self._all_task_addresses) < self._initial_num_proc:
                 self.check_for_spark_job_failure()
                 self._wait_cond.wait(timeout.remaining())
                 timeout.check_time_out_for('Spark tasks to start')
@@ -185,7 +185,7 @@ class SparkDriverService(driver_service.BasicDriverService):
     def wait_for_task_to_task_address_updates(self, timeout):
         self._wait_cond.acquire()
         try:
-            while len(self._task_addresses_for_tasks) < self._initial_np:
+            while len(self._task_addresses_for_tasks) < self._initial_num_proc:
                 self.check_for_spark_job_failure()
                 self._wait_cond.wait(timeout.remaining())
                 timeout.check_time_out_for('Spark tasks to update task-to-task addresses')

--- a/test/integration/elastic_common.py
+++ b/test/integration/elastic_common.py
@@ -263,10 +263,10 @@ class BaseElasticTests:
         # Job should fail with reset_limit=1
         message = constants.RESET_LIMIT_EXCEEDED_MESSAGE.format(1)
         with pytest.raises(RuntimeError, match=message):
-            self._run(discovery_schedule, np=2, min_num_proc=2, max_num_proc=4, reset_limit=1)
+            self._run(discovery_schedule, num_proc=2, min_num_proc=2, max_num_proc=4, reset_limit=1)
 
         # Job should succeed with reset_limit=2
-        results = self._run(discovery_schedule, np=2, min_num_proc=2, max_num_proc=4, reset_limit=2)
+        results = self._run(discovery_schedule, num_proc=2, min_num_proc=2, max_num_proc=4, reset_limit=2)
         self.assertEqual(len(results), 3)
 
     @mock.patch('horovod.runner.elastic.driver.DISCOVER_HOSTS_FREQUENCY_SECS', 0.01)

--- a/test/integration/elastic_spark_common.py
+++ b/test/integration/elastic_spark_common.py
@@ -380,7 +380,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
                 cmd = ' '.join(command)
                 run_elastic(self._exec, (cmd,), env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                            num_proc=np, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
+                            num_proc=num_proc, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
                             stdout=sys.stdout, stderr=sys.stderr,
                             start_timeout=10, elastic_timeout=10, verbose=2,
                             prefix_output_with_timestamp=True)

--- a/test/integration/elastic_spark_common.py
+++ b/test/integration/elastic_spark_common.py
@@ -363,7 +363,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
     def _run(self, discovery_schedule=None, exit_schedule=None, hosts=None,
              discovery_wait=10, epoch_wait=None, epochs=None,
-             np=2, min_np=None, max_np=None, extra_conf=None):
+             num_proc=2, min_num_proc=None, max_num_proc=None, extra_conf=None):
         with temppath() as logfile:
             with spark_cluster(logfile=logfile, discovery_schedule=discovery_schedule,
                                hosts=hosts, extra_conf=extra_conf):
@@ -380,7 +380,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
                 cmd = ' '.join(command)
                 run_elastic(self._exec, (cmd,), env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                            num_proc=np, min_np=min_np, max_np=max_np,
+                            num_proc=np, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
                             stdout=sys.stdout, stderr=sys.stderr,
                             start_timeout=10, elastic_timeout=10, verbose=2,
                             prefix_output_with_timestamp=True)
@@ -400,7 +400,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         epochs = 10
         self.assertGreater(epochs, 0, 'test should not be trivial')
-        results = self._run(hosts=hosts, np=5, min_np=5, max_np=5, epochs=epochs)
+        results = self._run(hosts=hosts, num_proc=5, min_num_proc=5, max_num_proc=5, epochs=epochs)
 
         self.assertEqual(epochs, len(results))
 
@@ -424,8 +424,8 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         # don't wait for discovery of new hosts but have epochs be long enough to see hosts changes
         results = self._run(discovery_schedule=discovery_schedule, discovery_wait=0, epoch_wait=10,
-                            np=2, extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
-                                              conf.SPARK_CONF_BLACKLIST_DISABLED])
+                            num_proc=2, extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
+                                                    conf.SPARK_CONF_BLACKLIST_DISABLED])
 
         self.assertEqual(3, len(results))
 
@@ -484,8 +484,8 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         # don't wait for discovery of new hosts but have epochs be long enough to see hosts changes
         results = self._run(discovery_schedule=discovery_schedule, discovery_wait=0, epoch_wait=10,
-                            np=2, extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
-                                              conf.SPARK_CONF_BLACKLIST_DISABLED])
+                            num_proc=2, extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
+                                                    conf.SPARK_CONF_BLACKLIST_DISABLED])
 
         self.assertEqual(3, len(results))
 
@@ -515,7 +515,7 @@ class BaseElasticSparkTests(unittest.TestCase):
             str((1, 0)): [0],
         }
 
-        results = self._run(hosts=hosts, exit_schedule=exit_schedule, np=2,
+        results = self._run(hosts=hosts, exit_schedule=exit_schedule, num_proc=2,
                             extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                         conf.SPARK_CONF_BLACKLIST_DISABLED])
 
@@ -544,7 +544,7 @@ class BaseElasticSparkTests(unittest.TestCase):
         """
         Same as test_fault_tolerance_no_spark_blacklist except Spark blacklists the executor
         that has the failing task, so that there are not enough executors available after the
-        exception. Then, Horovod will timeout waiting for np=2 cores.
+        exception. Then, Horovod will timeout waiting for num_proc=2 cores.
         """
         hosts = 'host-1:1,host-2:1'
 
@@ -554,7 +554,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         message = 'Horovod detected that one or more processes exited with non-zero status'
         with pytest.raises(RuntimeError, match=message):
-            self._run(hosts=hosts, exit_schedule=exit_schedule, np=2,
+            self._run(hosts=hosts, exit_schedule=exit_schedule, num_proc=2,
                       extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                   conf.SPARK_CONF_BLACKLIST_ENABLED, setting])
 
@@ -566,7 +566,7 @@ class BaseElasticSparkTests(unittest.TestCase):
             str((1, 0)): [0],
         }
 
-        results = self._run(hosts=hosts, exit_schedule=exit_schedule, np=2, min_np=2, max_np=2,
+        results = self._run(hosts=hosts, exit_schedule=exit_schedule, num_proc=2, min_num_proc=2, max_num_proc=2,
                             extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                         conf.SPARK_CONF_BLACKLIST_DISABLED])
 
@@ -608,7 +608,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         message = 'Horovod detected that one or more processes exited with non-zero status'
         with pytest.raises(RuntimeError, match=message):
-            self._run(hosts=hosts, exit_schedule=exit_schedule, np=2,
+            self._run(hosts=hosts, exit_schedule=exit_schedule, num_proc=2,
                       extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                   conf.SPARK_CONF_BLACKLIST_ENABLED,
                                   conf.SPARK_CONF_DONT_REUSE_FAILED_EXECUTOR])
@@ -641,7 +641,7 @@ class BaseElasticSparkTests(unittest.TestCase):
             (None, ['host-1:1', 'host-2:1', 'host-3:1']),
         ]
 
-        results = self._run(discovery_schedule=discovery_schedule, np=1, min_np=1, max_np=5)
+        results = self._run(discovery_schedule=discovery_schedule, num_proc=1, min_num_proc=1, max_num_proc=5)
 
         self.assertEqual(3, len(results))
 
@@ -667,7 +667,7 @@ class BaseElasticSparkTests(unittest.TestCase):
             (None, ['host-2:1']),
         ]
 
-        results = self._run(discovery_schedule=discovery_schedule, np=3, min_np=1, max_np=4,
+        results = self._run(discovery_schedule=discovery_schedule, num_proc=3, min_num_proc=1, max_num_proc=4,
                             # TODO: remove these waits when discovery publishes failure right-away
                             #       currently, spark discovery does not know about failing nodes
                             #       test setup makes node wait for this change without these waits
@@ -696,7 +696,7 @@ class BaseElasticSparkTests(unittest.TestCase):
             str((2, 0)): [1],
         }
 
-        results = self._run(hosts=hosts, exit_schedule=exit_schedule, np=4, min_np=1,
+        results = self._run(hosts=hosts, exit_schedule=exit_schedule, num_proc=4, min_num_proc=1,
                             extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK])
 
         self.assertEqual(3, len(results))
@@ -729,7 +729,7 @@ class BaseElasticSparkTests(unittest.TestCase):
         }
 
         # it can take 5 seconds for a task to be restarted by Spark, so we make each epoch take 10s
-        results = self._run(hosts=hosts, exit_schedule=exit_schedule, epoch_wait=10, np=4, min_np=1,
+        results = self._run(hosts=hosts, exit_schedule=exit_schedule, epoch_wait=10, num_proc=4, min_num_proc=1,
                             extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                         conf.SPARK_CONF_BLACKLIST_DISABLED])
 
@@ -768,7 +768,7 @@ class BaseElasticSparkTests(unittest.TestCase):
 
         # it can take 5 seconds for a task to be restarted by Spark, so we make each epoch take 10s
         results = self._run(hosts=hosts, exit_schedule=exit_schedule,
-                            epoch_wait=10, epochs=2, np=4, min_np=1,
+                            epoch_wait=10, epochs=2, num_proc=4, min_num_proc=1,
                             extra_conf=[conf.SPARK_CONF_ALWAYS_RESTART_FAILED_TASK,
                                         conf.SPARK_CONF_BLACKLIST_ENABLED, setting])
 

--- a/test/integration/test_interactiverun.py
+++ b/test/integration/test_interactiverun.py
@@ -71,8 +71,8 @@ class InteractiveRunTests(unittest.TestCase):
         # we need two different hosts here, otherwise would need to give args.nics
         args.hosts = 'localhost:2,127.0.0.1:2'
         args.command = [sys.executable, '-V']
-        args.np = 2
-        args.min_np = 2
+        args.num_proc = 2
+        args.min_num_proc = 2
         args.verbose = True
 
         # no assertions, we are happy when there are no exceptions

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -577,7 +577,7 @@ class SparkLightningTests(unittest.TestCase):
 
         with spark_session('test_happy_run_elastic'):
             res = horovod.spark.run_elastic(fn, args=(2, 5, 4),
-                                            num_proc=2, min_np=2, max_np=2,
+                                            num_proc=2, min_num_proc=2, max_num_proc=2,
                                             start_timeout=10, verbose=2)
             self.assertListEqual([([0, 3, 0, 1, 1, 3, 0, 1], 0),
                                   ([0, 3, 0, 1, 1, 3, 0, 1], 1)], res)
@@ -602,7 +602,7 @@ class SparkLightningTests(unittest.TestCase):
                     pass
                 res = horovod.spark.run_elastic(fn, args=(2, 5, 5, dir),
                                                 env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                                                num_proc=2, min_np=2, max_np=2,
+                                                num_proc=2, min_num_proc=2, max_num_proc=2,
                                                 start_timeout=5, verbose=2)
                 self.assertListEqual([([0, 4, 0, 4, 1, 4, 0, 4], 0),
                                       ([0, 4, 0, 4, 1, 4, 0, 4], 1)], res)
@@ -626,7 +626,7 @@ class SparkLightningTests(unittest.TestCase):
                     pass
                 res = horovod.spark.run_elastic(fn, args=(2, 5, 5, dir),
                                                 env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                                                num_proc=2, min_np=2, max_np=2,
+                                                num_proc=2, min_num_proc=2, max_num_proc=2,
                                                 start_timeout=5, verbose=2)
                 self.assertListEqual([([0, 4, 0, 4, 1, 4, 0, 4], 0),
                                       ([0, 4, 0, 4, 1, 4, 0, 4], 1)], res)

--- a/test/integration/test_spark_torch.py
+++ b/test/integration/test_spark_torch.py
@@ -447,7 +447,7 @@ class SparkTorchTests(unittest.TestCase):
 
         with spark_session('test_happy_run_elastic'):
             res = horovod.spark.run_elastic(fn, args=(2, 5, 4),
-                                            num_proc=2, min_np=2, max_np=2,
+                                            num_proc=2, min_num_proc=2, max_num_proc=2,
                                             start_timeout=10, verbose=2)
             self.assertListEqual([([0, 3, 0, 1, 1, 3, 0, 1], 0),
                                   ([0, 3, 0, 1, 1, 3, 0, 1], 1)], res)
@@ -468,7 +468,7 @@ class SparkTorchTests(unittest.TestCase):
                     pass
                 res = horovod.spark.run_elastic(fn, args=(2, 5, 5, dir),
                                                 env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                                                num_proc=2, min_np=2, max_np=2,
+                                                num_proc=2, min_num_proc=2, max_num_proc=2,
                                                 start_timeout=5, verbose=2)
                 self.assertListEqual([([0, 4, 0, 4, 1, 4, 0, 4], 0),
                                       ([0, 4, 0, 4, 1, 4, 0, 4], 1)], res)
@@ -492,7 +492,7 @@ class SparkTorchTests(unittest.TestCase):
                     pass
                 res = horovod.spark.run_elastic(fn, args=(2, 5, 5, dir),
                                                 env={'HOROVOD_LOG_LEVEL': 'DEBUG'},
-                                                num_proc=2, min_np=2, max_np=2,
+                                                num_proc=2, min_num_proc=2, max_num_proc=2,
                                                 start_timeout=5, verbose=2)
                 self.assertListEqual([([0, 4, 0, 4, 1, 4, 0, 4], 0),
                                       ([0, 4, 0, 4, 1, 4, 0, 4], 1)], res)

--- a/test/integration/test_static_run.py
+++ b/test/integration/test_static_run.py
@@ -78,7 +78,7 @@ class StaticRunTests(unittest.TestCase):
                               .format(' and '.join(remote_hosts)))
 
         hargs = _HorovodArgs()
-        hargs.np = 4
+        hargs.num_proc = 4
         hargs.hosts = ','.join(['{}:2'.format(host) for host in hosts])
         hargs.use_gloo = controller == 'gloo'
         hargs.use_mpi = controller == 'mpi'
@@ -179,7 +179,7 @@ class StaticRunTests(unittest.TestCase):
                 self.assertEqual(0, exit_code)
             else:
                 actual = _run(hargs)
-                expected = list([(rank, hargs.np) for rank in range(hargs.np)]) if run == 'func' else None
+                expected = list([(rank, hargs.num_proc) for rank in range(hargs.num_proc)]) if run == 'func' else None
                 self.assertEqual(expected, actual)
 
     def do_test_run_with_controller_failure(self, controller, mode, run):

--- a/test/single/test_elastic_driver.py
+++ b/test/single/test_elastic_driver.py
@@ -68,7 +68,7 @@ class ElasticDriverTests(unittest.TestCase):
             rank_results[slot_info.rank] = (slot_info, updated_slot_info)
             return 0, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -99,7 +99,7 @@ class ElasticDriverTests(unittest.TestCase):
             rank_results[slot_info.rank] = (slot_info, updated_slot_info)
             return 0, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -145,7 +145,7 @@ class ElasticDriverTests(unittest.TestCase):
             rank_results[slot_info.rank] = (slot_info, updated_slot_info)
             return 0, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -211,7 +211,7 @@ class ElasticDriverTests(unittest.TestCase):
             driver.record_ready(slot_info.hostname, slot_info.local_rank)
             return 1, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -235,7 +235,7 @@ class ElasticDriverTests(unittest.TestCase):
             wait_for_one(events)
             return 1, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -270,7 +270,7 @@ class ElasticDriverTests(unittest.TestCase):
             rank_results[slot_info.rank] = (slot_info, updated_slot_info)
             return 0, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 
@@ -347,7 +347,7 @@ class ElasticDriverTests(unittest.TestCase):
             rank_results[slot_info.rank] = notification_receiver.events
             return 0, time.time()
 
-        driver.start(np=2, create_worker_fn=exec_command)
+        driver.start(num_proc=2, create_worker_fn=exec_command)
         res = driver.get_results().worker_results
         driver.stop()
 

--- a/test/single/test_elastic_driver.py
+++ b/test/single/test_elastic_driver.py
@@ -57,8 +57,8 @@ class ElasticDriverTests(unittest.TestCase):
         slots = {'host-1': 2, 'host-2': 2}
         discovery = FixedHosts(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         rank_results = {}
 
@@ -85,8 +85,8 @@ class ElasticDriverTests(unittest.TestCase):
         slots = {'host-1': 2, 'host-2': 2}
         discovery = FixedHosts(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         rank_results = {}
 
@@ -126,8 +126,8 @@ class ElasticDriverTests(unittest.TestCase):
             slots = {'host-1': 2, 'host-2': 2}
             discovery.set(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         rank_results = {}
 
@@ -173,12 +173,12 @@ class ElasticDriverTests(unittest.TestCase):
         mock_discovery = mock.Mock()
         mock_discovery.find_available_hosts_and_slots.side_effect = sequence(slots)
 
-        driver = ElasticDriver(mock.Mock(), mock_discovery, min_np=8, max_np=20)
-        driver.wait_for_available_slots(min_np=16)
+        driver = ElasticDriver(mock.Mock(), mock_discovery, min_num_proc=8, max_num_proc=20)
+        driver.wait_for_available_slots(min_num_proc=16)
         assert driver._host_manager.current_hosts.count_available_slots() >= 16
         driver.stop()
 
-        # Notify coordinator 2 times, as the first time we are below min_np and the existing host assignments
+        # Notify coordinator 2 times, as the first time we are below min_num_proc and the existing host assignments
         # are empty
         assert mock_get_worker_client.call_count == 2
         assert mock_get_coordinator_info.call_count == 2
@@ -192,8 +192,8 @@ class ElasticDriverTests(unittest.TestCase):
         mock_discovery = mock.Mock()
         mock_discovery.find_available_hosts_and_slots.side_effect = sequence(slots)
 
-        driver = ElasticDriver(mock.Mock(), mock_discovery, min_np=2, max_np=12)
-        driver.wait_for_available_slots(min_np=2, min_hosts=2)
+        driver = ElasticDriver(mock.Mock(), mock_discovery, min_num_proc=2, max_num_proc=12)
+        driver.wait_for_available_slots(min_num_proc=2, min_hosts=2)
 
         # Even though we only needed 2 slots, because we also needed 2 hosts, we will at least 12 slots total
         assert driver._host_manager.current_hosts.count_available_slots() >= 12
@@ -204,8 +204,8 @@ class ElasticDriverTests(unittest.TestCase):
         slots = {'host-1': 2, 'host-2': 2}
         discovery = FixedHosts(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         def exec_command(slot_info, events):
             driver.record_ready(slot_info.hostname, slot_info.local_rank)
@@ -224,8 +224,8 @@ class ElasticDriverTests(unittest.TestCase):
         slots = {'host-1': 2, 'host-2': 2}
         discovery = FixedHosts(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         def exec_command(slot_info, events):
             if slot_info.rank == 0:
@@ -251,8 +251,8 @@ class ElasticDriverTests(unittest.TestCase):
         slots = {'host-1': 2, 'host-2': 2}
         discovery = FixedHosts(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
 
         rank_results = {}
 
@@ -294,8 +294,8 @@ class ElasticDriverTests(unittest.TestCase):
         discovery = FixedHosts(slots)
 
         rendezvous = RendezvousServer()
-        driver = ElasticDriver(rendezvous, discovery, min_np=2, max_np=4)
-        driver.wait_for_available_slots(min_np=2)
+        driver = ElasticDriver(rendezvous, discovery, min_num_proc=2, max_num_proc=4)
+        driver.wait_for_available_slots(min_num_proc=2)
         handler = create_rendezvous_handler(driver)
 
         common_intfs = network.get_local_intfs()
@@ -382,8 +382,8 @@ class ElasticDriverTests(unittest.TestCase):
         discovery = mock.Mock()
         discovery.find_available_hosts_and_slots.side_effect = sequence(slots)
 
-        driver = ElasticDriver(mock.Mock(), discovery, min_np=8, max_np=12)
-        driver.wait_for_available_slots(min_np=16)
+        driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=8, max_num_proc=12)
+        driver.wait_for_available_slots(min_num_proc=16)
         driver.stop()
 
         # On the second call, we should see the number of slots dip below the minimum, but we still want to ensure
@@ -500,9 +500,9 @@ class ElasticDriverTests(unittest.TestCase):
 
         try:
             ElasticDriver._discover_hosts = wrapped_discover_hosts
-            driver = ElasticDriver(mock.Mock(), discovery, min_np=2, max_np=4)
+            driver = ElasticDriver(mock.Mock(), discovery, min_num_proc=2, max_num_proc=4)
             with pytest.raises(RuntimeError):
-                driver.wait_for_available_slots(min_np=2)
+                driver.wait_for_available_slots(min_num_proc=2)
             assert driver.finished()
         finally:
             ElasticDriver._discover_hosts = discover_hosts

--- a/test/single/test_ray_elastic.py
+++ b/test/single/test_ray_elastic.py
@@ -271,7 +271,7 @@ def test_fault_tolerance_hosts_added_and_removed(ray_8_cpus):
         ]
         nics = list(psutil.net_if_addrs().keys())[0]
 
-        settings = ElasticRayExecutor.create_settings(min_np=1, nics={nics})
+        settings = ElasticRayExecutor.create_settings(min_num_proc=1, nics={nics})
         settings.discovery = SimpleTestDiscovery(discovery_schedule)
         executor = ElasticRayExecutor(
             settings, cpus_per_slot=1, override_discovery=False)
@@ -299,7 +299,7 @@ def test_fault_tolerance_hosts_remove_and_add(ray_8_cpus):
         ]
         nics = list(psutil.net_if_addrs().keys())[0]
 
-        settings = ElasticRayExecutor.create_settings(min_np=1, nics={nics})
+        settings = ElasticRayExecutor.create_settings(min_num_proc=1, nics={nics})
         settings.discovery = SimpleTestDiscovery(discovery_schedule)
         executor = ElasticRayExecutor(
             settings, cpus_per_slot=1, override_discovery=False)
@@ -317,7 +317,7 @@ def test_fault_tolerance_hosts_remove_and_add(ray_8_cpus):
 
 @pytest.mark.skipif(
     not gloo_built(), reason='Gloo is required for Ray integration')
-def test_max_np(ray_8_cpus):
+def test_max_num_proc(ray_8_cpus):
     with fault_tolerance_patches():
         discovery_schedule = [
             (10, ['host-1:2']),
@@ -326,7 +326,7 @@ def test_max_np(ray_8_cpus):
         nics = list(psutil.net_if_addrs().keys())[0]
 
         settings = ElasticRayExecutor.create_settings(
-            min_np=1, max_np=2, nics={nics})
+            min_num_proc=1, max_num_proc=2, nics={nics})
         settings.discovery = SimpleTestDiscovery(discovery_schedule)
         executor = ElasticRayExecutor(
             settings, cpus_per_slot=1, override_discovery=False)
@@ -344,7 +344,7 @@ def test_max_np(ray_8_cpus):
 
 @pytest.mark.skipif(
     not gloo_built(), reason='Gloo is required for Ray integration')
-def test_min_np(ray_8_cpus):
+def test_min_num_proc(ray_8_cpus):
     with fault_tolerance_patches():
         discovery_schedule = [
             (10, ['host-1:1']),
@@ -354,7 +354,7 @@ def test_min_np(ray_8_cpus):
         nics = list(psutil.net_if_addrs().keys())[0]
 
         settings = ElasticRayExecutor.create_settings(
-            min_np=4, max_np=4, nics={nics})
+            min_num_proc=4, max_num_proc=4, nics={nics})
         settings.discovery = SimpleTestDiscovery(discovery_schedule)
         executor = ElasticRayExecutor(
             settings, cpus_per_slot=1, override_discovery=False)
@@ -382,7 +382,7 @@ def test_gpu_e2e(ray_8_cpus_gpus):
         nics = list(psutil.net_if_addrs().keys())[0]
 
         settings = ElasticRayExecutor.create_settings(
-            min_np=4, max_np=4, nics={nics})
+            min_num_proc=4, max_num_proc=4, nics={nics})
         settings.discovery = SimpleTestDiscovery(discovery_schedule)
         executor = ElasticRayExecutor(
             settings, gpus_per_slot=1, use_gpu=True, override_discovery=False)

--- a/test/single/test_ray_elastic_v2.py
+++ b/test/single/test_ray_elastic_v2.py
@@ -301,7 +301,7 @@ def test_fault_tolerance_hosts_remove_and_add_cooldown(ray_8_cpus):
 
 @pytest.mark.skipif(
     not gloo_built(), reason='Gloo is required for Ray integration')
-def test_max_np(ray_8_cpus):
+def test_max_num_proc(ray_8_cpus):
     with fault_tolerance_patches():
         discovery_schedule = [
             (10, ['host-1:2']),
@@ -327,7 +327,7 @@ def test_max_np(ray_8_cpus):
 
 @pytest.mark.skipif(
     not gloo_built(), reason='Gloo is required for Ray integration')
-def test_min_np(ray_8_cpus):
+def test_min_num_proc(ray_8_cpus):
     with fault_tolerance_patches():
         discovery_schedule = [
             (10, ['host-1:1']),

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -1133,8 +1133,8 @@ rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
 
     def test_get_host_assignments(self):
         hosts = parse_hosts('worker-0:2,worker-1:2')
-        np = 4
-        assignments = get_host_assignments(hosts, np)
+        num_proc = 4
+        assignments = get_host_assignments(hosts, num_proc)
 
         sizes = dict(size=4, local_size=2, cross_size=2)
         expected = [SlotInfo(hostname='worker-0', rank=0, local_rank=0, cross_rank=0, **sizes),
@@ -1145,9 +1145,9 @@ rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
 
     def test_get_host_assignments_elastic(self):
         hosts = parse_hosts('worker-0:2,worker-1:2')
-        min_np = 1
-        max_np = 2
-        assignments = get_host_assignments(hosts, min_np=min_np, max_np=max_np)
+        min_num_proc = 1
+        max_num_proc = 2
+        assignments = get_host_assignments(hosts, min_num_proc=min_num_proc, max_num_proc=max_num_proc)
 
         sizes = dict(size=2, local_size=2, cross_size=1)
         expected = [SlotInfo(hostname='worker-0', rank=0, local_rank=0, cross_rank=0, **sizes),
@@ -1156,8 +1156,8 @@ rank: 4: { hostname: host2; cpu: {0-3} ; gpu: * ; mem: * }
 
     def test_get_host_assignments_heterogeneous(self):
         hosts = parse_hosts('worker-0:1,worker-1:2')
-        np = 3
-        assignments = get_host_assignments(hosts, np)
+        num_proc = 3
+        assignments = get_host_assignments(hosts, num_proc)
 
         expected = [SlotInfo(hostname='worker-0', rank=0, local_rank=0, cross_rank=0,
                              size=3, local_size=1, cross_size=2),

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -76,6 +76,37 @@ class RunTests(unittest.TestCase):
             self.assertEqual(env.get(config_parser.HOROVOD_HIERARCHICAL_ALLREDUCE), '1')
             self.assertEqual(env.get(config_parser.HOROVOD_HIERARCHICAL_ALLGATHER), '1')
 
+    def test_elastic_args(self):
+        with override_args('horovodrun', '-np', '4',
+                           '--min-np', '2',
+                           '--max-np', '8'):
+            args = parse_args()
+            env = {}
+            config_parser.set_env_from_args(env, args)
+
+            self.assertEqual(args.num_proc, 4)
+            self.assertEqual(args.min_num_proc, 2)
+            self.assertEqual(args.max_num_proc, 8)
+
+        with override_args('horovodrun', '--num-proc', '4',
+                           '--min-num-proc', '2',
+                           '--max-num-proc', '8',
+                           '--slots-per-host', '1',
+                           '--elastic-timeout', '60',
+                           '--reset-limit', '10',
+                           '--blacklist-cooldown-range', '120', '600'):
+            args = parse_args()
+            env = {}
+            config_parser.set_env_from_args(env, args)
+
+            self.assertEqual(args.num_proc, 4)
+            self.assertEqual(args.min_num_proc, 2)
+            self.assertEqual(args.max_num_proc, 8)
+            self.assertEqual(args.slots, 1)
+            self.assertEqual(args.elastic_timeout, 60)
+            self.assertEqual(args.reset_limit, 10)
+            self.assertEqual(args.cooldown_range, [120, 600])
+
     def test_autotune_args(self):
         with override_args('horovodrun', '-np', '2',
                            '--autotune',

--- a/test/utils/spark_common.py
+++ b/test/utils/spark_common.py
@@ -121,11 +121,11 @@ def fn():
 
 
 @contextlib.contextmanager
-def spark_driver_service(num_proc, initial_np=None, fn=fn, args=(), kwargs={},
+def spark_driver_service(num_proc, initial_num_proc=None, fn=fn, args=(), kwargs={},
                          key=None, nics=None, verbose=2):
-    initial_np = initial_np or num_proc
+    initial_num_proc = initial_num_proc or num_proc
     key = key or secret.make_secret_key()
-    driver = SparkDriverService(initial_np, num_proc, fn, args, kwargs, key, nics)
+    driver = SparkDriverService(initial_num_proc, num_proc, fn, args, kwargs, key, nics)
     client = SparkDriverClient(driver.addresses(), key, verbose)
 
     try:


### PR DESCRIPTION
Horovod uses `np` and `num_proc` synonymously across APIs, but not consistently one or the other.

This deprecates the use of `np` in favour of the more meaningful `num_proc`. The `np` variants are kept in public APIs to avoid breaking user code, while a deprecation warning is given. The deprecated variants should be removed in `v1.0.0` or `v1.1.0`.