### PR TITLE
Fix apply() API change in TF 2.9 for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix imports from tensorflow.python.keras with tensorflow 2.6.0+ ([#3403](https://github.com/horovod/horovod/pull/3403))
 
+- Fix apply() API change in TF 2.9 for unit tests ([#3427](https://github.com/horovod/horovod/pull/3427))
+
 ## [v0.23.0] - 2021-10-06
 
 ### Added

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -4051,8 +4051,6 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertSequenceEqual(ret_values, [ret] * size,
                                          msg="hvd.join() did not return the same value on each rank")
 
-    @pytest.mark.skipif(LooseVersion(tf.__version__) >=
-                        LooseVersion('2.9.0'), reason='https://github.com/horovod/horovod/issues/3422')
     def test_horovod_syncbn_gpu(self):
         """Test that the SyncBatchNormalization implementation is correct on GPU."""
         # Only do this test if there are GPUs available.
@@ -4085,8 +4083,11 @@ class TensorFlowTests(tf.test.TestCase):
             for x in x_list:
                 bn = tf.keras.layers.BatchNormalization(axis=1, fused=False)
                 sync_bn = hvd.SyncBatchNormalization(axis=1)
-                bn_func = bn.apply(x, training=True)
-                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True)
+                # apply() API is removed in TF 2.9.0
+                bn_func = bn.apply(x, training=True) if LooseVersion(
+                    tf.__version__) < LooseVersion('2.9.0') else bn(x, training=True)
+                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True) if LooseVersion(
+                    tf.__version__) < LooseVersion('2.9.0') else sync_bn(tf.expand_dims(x[hvd.rank()], 0), training=True)
 
                 try:
                   init = tf.global_variables_initializer()
@@ -4100,8 +4101,6 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertAllClose(self.evaluate(sync_bn.moving_mean), self.evaluate(bn.moving_mean))
                 self.assertAllClose(self.evaluate(sync_bn.moving_variance), self.evaluate(bn.moving_variance))
 
-    @pytest.mark.skipif(LooseVersion(tf.__version__) >=
-                        LooseVersion('2.9.0'), reason='https://github.com/horovod/horovod/issues/3422')
     def test_horovod_syncbn_cpu(self):
         """Test that the SyncBatchNormalization implementation is correct on CPU."""
 
@@ -4131,8 +4130,11 @@ class TensorFlowTests(tf.test.TestCase):
             for x in x_list:
                 bn = tf.keras.layers.BatchNormalization(axis=1, fused=False)
                 sync_bn = hvd.SyncBatchNormalization(axis=1)
-                bn_func = bn.apply(x, training=True)
-                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True)
+                # apply() API is removed in TF 2.9.0
+                bn_func = bn.apply(x, training=True) if LooseVersion(
+                    tf.__version__) < LooseVersion('2.9.0') else bn(x, training=True)
+                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True) if LooseVersion(
+                    tf.__version__) < LooseVersion('2.9.0') else sync_bn(tf.expand_dims(x[hvd.rank()], 0), training=True)
 
                 try:
                   init = tf.global_variables_initializer()


### PR DESCRIPTION
TF 2.9 removed apply() API, use __call__() instead.

Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3422 .

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
