### PR TITLE
Fixing GPU and CPU tf head failures

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -1137,13 +1137,14 @@ public:
   }
 };
 
-REGISTER_KERNEL_BUILDER(Name("HorovodJoin")
-                            .Device(DEVICE_CPU)
-                            .HostMemory("output"),
-                        HorovodJoinOp);
 #if HOROVOD_GPU_ALLREDUCE
 REGISTER_KERNEL_BUILDER(Name("HorovodJoin")
                             .Device(DEVICE_GPU)
+                            .HostMemory("output"),
+                        HorovodJoinOp);
+#else
+REGISTER_KERNEL_BUILDER(Name("HorovodJoin")
+                            .Device(DEVICE_CPU)
                             .HostMemory("output"),
                         HorovodJoinOp);
 #endif

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -4051,8 +4051,6 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertSequenceEqual(ret_values, [ret] * size,
                                          msg="hvd.join() did not return the same value on each rank")
 
-    @pytest.mark.skipif(LooseVersion(tf.__version__) >=
-                        LooseVersion('2.9.0'), reason='https://github.com/horovod/horovod/issues/3422')
     def test_horovod_syncbn_gpu(self):
         """Test that the SyncBatchNormalization implementation is correct on GPU."""
         # Only do this test if there are GPUs available.
@@ -4085,8 +4083,8 @@ class TensorFlowTests(tf.test.TestCase):
             for x in x_list:
                 bn = tf.keras.layers.BatchNormalization(axis=1, fused=False)
                 sync_bn = hvd.SyncBatchNormalization(axis=1)
-                bn_func = bn.apply(x, training=True)
-                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True)
+                bn_func = bn(x, training=True)
+                sync_bn_func = sync_bn(tf.expand_dims(x[hvd.rank()], 0), training=True)
 
                 try:
                   init = tf.global_variables_initializer()
@@ -4100,8 +4098,6 @@ class TensorFlowTests(tf.test.TestCase):
                 self.assertAllClose(self.evaluate(sync_bn.moving_mean), self.evaluate(bn.moving_mean))
                 self.assertAllClose(self.evaluate(sync_bn.moving_variance), self.evaluate(bn.moving_variance))
 
-    @pytest.mark.skipif(LooseVersion(tf.__version__) >=
-                        LooseVersion('2.9.0'), reason='https://github.com/horovod/horovod/issues/3422')
     def test_horovod_syncbn_cpu(self):
         """Test that the SyncBatchNormalization implementation is correct on CPU."""
 
@@ -4131,8 +4127,8 @@ class TensorFlowTests(tf.test.TestCase):
             for x in x_list:
                 bn = tf.keras.layers.BatchNormalization(axis=1, fused=False)
                 sync_bn = hvd.SyncBatchNormalization(axis=1)
-                bn_func = bn.apply(x, training=True)
-                sync_bn_func = sync_bn.apply(tf.expand_dims(x[hvd.rank()], 0), training=True)
+                bn_func = bn(x, training=True)
+                sync_bn_func = sync_bn(tf.expand_dims(x[hvd.rank()], 0), training=True)
 
                 try:
                   init = tf.global_variables_initializer()


### PR DESCRIPTION
Signed-off-by: TJ <tix@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
The tf head gpu and cpu CIs have been failing for a while. These are caused by 2 issues:
1. CPU is failing because keras.layer removed .apply method, we can just use the __call__ convention to pass inputs to the layer
2. GPU is failing due to a recent change to kernel registration logic(which I haven't completely figured out). It looks like under some conditions, the GPU kernel is replaced by CPU kernel of the Join op which result in "fake" allreduces from the joined rank being allocated on the wrong device. This will cause a deadlock since other non-joined ranks are waiting indefinitely for the joined ranks to finish allreduce that's not happening on the same device. For Join op, I skip registering the cpu op when allreduce device is set to gpu.

Fixes # (issue).
https://github.com/horovod/horovod/issues/3422

## Review process to land 

1. All tests and other checks must succeed.
4. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
5. If any member of the technical steering committee requests changes, they must be addressed.
