### PR TITLE
Move apt-get into non-interactive mode

### DIFF
--- a/docker/horovod-cpu/Dockerfile
+++ b/docker/horovod-cpu/Dockerfile
@@ -12,6 +12,9 @@ ARG SPARK_PACKAGE=spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
 
 ARG PYTHON_VERSION=3.8
 
+# to avoid interaction with apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -10,6 +10,9 @@ ARG PYTORCH_VERSION=1.8.1+cu111
 ARG PYTORCH_LIGHTNING_VERSION=1.2.9
 ARG TORCHVISION_VERSION=0.9.1+cu111
 
+# to avoid interaction with apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -18,6 +18,9 @@ ARG SPARK_PACKAGE=spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
 
 ARG PYTHON_VERSION=3.8
 
+# to avoid interaction with apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
This fixes an issue introduced last minute by #3371. For some packages, `apt-get` requires user input and waits forever. With `DEBIAN_FRONTEND=noninteractive`, this is avoided.