### PR TITLE
Add timeout to docker build

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -721,6 +721,7 @@ def main():
                 f'\n'
                 f'      - name: Build and push\n'
                 f'        uses: docker/build-push-action@v2\n'
+                f'        timeout-minutes: 60\n'
                 f'        with:\n'
                 f'          context: .\n'
                 f'          file: ./docker/${{{{ matrix.docker-image }}}}/Dockerfile\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3723,6 +3723,7 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v2
+        timeout-minutes: 60
         with:
           context: .
           file: ./docker/${{ matrix.docker-image }}/Dockerfile


### PR DESCRIPTION
Docker images are built at the end of our pipeline. If they get stuck, they run for 6 hours, cannot be cancelled and block newer commits in the branch. This reduces the timeout to 1h.