### PR TITLE
[Setup] Require fsspec >= 2010.07.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- [Setup] Require fsspec >= 2010.07.0 ([#3451](https://github.com/horovod/horovod/pull/3451))
+
 ## [v0.24.1] - 2022-03-03
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ pytorch_require_list = ['torch', 'pytorch_lightning==1.3.8']
 mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
-spark_require_list = ['numpy', 'petastorm>=0.11.0', 'pyarrow>=0.15.0', 'fsspec']
+spark_require_list = ['numpy', 'petastorm>=0.11.0', 'pyarrow>=0.15.0', 'fsspec>=2021.07.0']
 # https://github.com/ray-project/ray/pull/17465
 ray_require_list = ['ray', 'aioredis<2']
 pytorch_spark_require_list = pytorch_require_list + \


### PR DESCRIPTION
Required by fsspec callback used in horovod/spark/common/store.py

Authored-by: Sammy Nah <sammy.nah@intel.com>
Signed-off-by: Chongxiao Cao <chongxiaoc@uber.com>


## Description

Fixes #3450.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
