### PR TITLE
Fix gradient and var name mismatch when num_groups > 0

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -464,6 +464,7 @@ if _LegacyOptimizer is not None:
             super(_DistributedOptimizer, self).__init__(name=name, use_locking=use_locking)
 
             self._optimizer = optimizer
+            self._groups = groups
             self._allreduce_grads = _make_allreduce_grads_fn(
                 name, device_dense, device_sparse, compression, sparse_as_dense, op,
                 gradient_predivide_factor, groups, process_set=process_set)
@@ -495,6 +496,8 @@ if _LegacyOptimizer is not None:
             """
             gradients = self._optimizer.compute_gradients(*args, **kwargs)
             grads, vars = zip(*gradients)
+            if self._groups is not None and not isinstance(self._groups, list) and self._groups > 0:
+                vars = [var for grad, var in zip(grads, vars) if grad is not None]
             if self._agg_helper:
                 avg_grads = self._agg_helper.compute_gradients(grads, vars)
             else:


### PR DESCRIPTION
## Checklist before submitting

- [x ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes [Mismatch of grads and vars in group allreduce](https://github.com/horovod/horovod/issues/3458)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
