### PR TITLE
Fix ignored cuda arch flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [Setup] Require fsspec >= 2010.07.0 ([#3451](https://github.com/horovod/horovod/pull/3451))
 
+- Fix ignored cuda arch flags ([#3462]((https://github.com/horovod/horovod/pull/3462))
+
 ## [v0.24.1] - 2022-03-03
 
 ### Fixed

--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -14,7 +14,6 @@ target_compile_options(horovod_cuda_kernels PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
                        SHELL:${HVD_NVCC_COMPILE_FLAGS}
                        -D_GLIBCXX_USE_CXX11_ABI=1
                        >)
-set_property(TARGET horovod_cuda_kernels PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
 # if we need compatible c++ abi, build a compatible version
 add_library(compatible_horovod_cuda_kernels cuda_kernels.cu)
@@ -22,4 +21,3 @@ target_compile_options(compatible_horovod_cuda_kernels PRIVATE $<$<COMPILE_LANGU
                        SHELL:${HVD_NVCC_COMPILE_FLAGS}
                        -D_GLIBCXX_USE_CXX11_ABI=0
                        >)
-set_property(TARGET compatible_horovod_cuda_kernels PROPERTY CUDA_SEPARABLE_COMPILATION ON)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

The cuda architecture flags were ignored during our build:
```
# cuobjdump -lelf mpi_lib_v2.cpython-38-x86_64-linux-gnu.so
ELF file    1: mpi_lib_v2.cpython-38-x86_64-linux-gnu.1.sm_52.cubin
ELF file    2: mpi_lib_v2.cpython-38-x86_64-linux-gnu.2.sm_35.cubin
ELF file    3: mpi_lib_v2.cpython-38-x86_64-linux-gnu.3.sm_50.cubin
ELF file    4: mpi_lib_v2.cpython-38-x86_64-linux-gnu.4.sm_60.cubin
ELF file    5: mpi_lib_v2.cpython-38-x86_64-linux-gnu.5.sm_61.cubin
ELF file    6: mpi_lib_v2.cpython-38-x86_64-linux-gnu.6.sm_70.cubin
ELF file    7: mpi_lib_v2.cpython-38-x86_64-linux-gnu.7.sm_80.cubin
```
Looking at the build output, nvcc was building the cuda object files with the good architecture flags but was doing device linking as a separate step (CUDA_SEPARABLE_COMPILATION) without any architecture flags.
We could add the flags to the extra device linking step but there is no reason to have a separated device linking step since all our device function calls are in the same compilation unit.
Therefore, this PR removes the `CUDA_SEPARABLE_COMPILATION` cmake setting so that we compile/dlink in one step with the good flags.

```
# cuobjdump -lelf mpi_lib_v2.cpython-38-x86_64-linux-gnu.so
ELF file    1: mpi_lib_v2.cpython-38-x86_64-linux-gnu.1.sm_35.cubin
ELF file    2: mpi_lib_v2.cpython-38-x86_64-linux-gnu.2.sm_50.cubin
ELF file    3: mpi_lib_v2.cpython-38-x86_64-linux-gnu.3.sm_60.cubin
ELF file    4: mpi_lib_v2.cpython-38-x86_64-linux-gnu.4.sm_61.cubin
ELF file    5: mpi_lib_v2.cpython-38-x86_64-linux-gnu.5.sm_70.cubin
ELF file    6: mpi_lib_v2.cpython-38-x86_64-linux-gnu.6.sm_80.cubin
ELF file    7: mpi_lib_v2.cpython-38-x86_64-linux-gnu.7.sm_35.cubin
ELF file    8: mpi_lib_v2.cpython-38-x86_64-linux-gnu.8.sm_37.cubin
ELF file    9: mpi_lib_v2.cpython-38-x86_64-linux-gnu.9.sm_50.cubin
ELF file   10: mpi_lib_v2.cpython-38-x86_64-linux-gnu.10.sm_52.cubin
ELF file   11: mpi_lib_v2.cpython-38-x86_64-linux-gnu.11.sm_53.cubin
ELF file   12: mpi_lib_v2.cpython-38-x86_64-linux-gnu.12.sm_60.cubin
ELF file   13: mpi_lib_v2.cpython-38-x86_64-linux-gnu.13.sm_61.cubin
ELF file   14: mpi_lib_v2.cpython-38-x86_64-linux-gnu.14.sm_62.cubin
ELF file   15: mpi_lib_v2.cpython-38-x86_64-linux-gnu.15.sm_70.cubin
ELF file   16: mpi_lib_v2.cpython-38-x86_64-linux-gnu.16.sm_72.cubin
ELF file   17: mpi_lib_v2.cpython-38-x86_64-linux-gnu.17.sm_75.cubin
ELF file   18: mpi_lib_v2.cpython-38-x86_64-linux-gnu.18.sm_80.cubin
ELF file   19: mpi_lib_v2.cpython-38-x86_64-linux-gnu.19.sm_86.cubin
```

Fixes #3460 #3461 
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
