### PR TITLE
Make TensorFlow output allocations asynchronous when using NCCL backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - MXNet: Updated allreduce functions to newer `op` API. ([#3299](https://github.com/horovod/horovod/pull/3299))
 
+- TF: Make TensorFlow output allocations asynchronous when using NCCL backend. ([#3464](https://github.com/horovod/horovod/pull/3464))
+
 ### Deprecated
 
 - MXNet: Deprecated `average` argument of allreduce functions. ([#3299](https://github.com/horovod/horovod/pull/3299))

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -325,9 +325,11 @@ public:
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) = 0;
   virtual Status AllocateOutput(TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) = 0;
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event = nullptr) = 0;
   virtual Status AllocateOutput(int output_index, TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) {
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event = nullptr) {
     if (output_index == 0) {
       return AllocateOutput(std::move(shape), tensor);
     } else {

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -95,12 +95,14 @@ MXOpContext::AllocatePersistent(int64_t size,
 }
 
 Status MXOpContext::AllocateOutput(TensorShape shape,
-                                   std::shared_ptr<Tensor>* tensor) {
+                                   std::shared_ptr<Tensor>* tensor,
+                                   std::shared_ptr<ReadyEvent>* event) {
   return MXOpContext::AllocateOutput(0, shape, tensor);
 }
 
 Status MXOpContext::AllocateOutput(int output_index, TensorShape shape,
-                                   std::shared_ptr<Tensor>* tensor) {
+                                   std::shared_ptr<Tensor>* tensor,
+                                   std::shared_ptr<ReadyEvent>* event) {
   int64_t* shape_array = new int64_t[shape.dims()];
   for (int idx = 0; idx < shape.dims(); idx++) {
     shape_array[idx] = shape.dim_size(idx);

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -57,9 +57,11 @@ public:
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) override;
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
   virtual Status AllocateOutput(int output_index, TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) override;
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;

--- a/horovod/tensorflow/xla_mpi_ops.cc
+++ b/horovod/tensorflow/xla_mpi_ops.cc
@@ -447,7 +447,8 @@ public:
 
   virtual common::Status
   AllocateOutput(common::TensorShape shape,
-                 std::shared_ptr<common::Tensor>* tensor) override;
+                 std::shared_ptr<common::Tensor>* tensor,
+                 std::shared_ptr<common::ReadyEvent>* event = nullptr) override;
 
   virtual common::Status
   AllocateZeros(int64_t num_elements, common::DataType dtype,
@@ -495,7 +496,8 @@ common::Status XLAOpContext::AllocatePersistent(
 
 common::Status
 XLAOpContext::AllocateOutput(common::TensorShape shape,
-                             std::shared_ptr<common::Tensor>* tensor) {
+                             std::shared_ptr<common::Tensor>* tensor,
+                             std::shared_ptr<common::ReadyEvent>* event) {
   // XLA must manage I/O buffers.
   return common::Status::PreconditionError(
       "AllocateOutput is not supported for XLA.");

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -113,12 +113,14 @@ TorchOpContext::AllocatePersistent(int64_t size,
 }
 
 Status TorchOpContext::AllocateOutput(TensorShape shape,
-                                      std::shared_ptr<Tensor>* tensor) {
+                                      std::shared_ptr<Tensor>* tensor,
+                                      std::shared_ptr<ReadyEvent>* event) {
   return TorchOpContext::AllocateOutput(0, shape, tensor);
 }
 
 Status TorchOpContext::AllocateOutput(int output_index, TensorShape shape,
-                                      std::shared_ptr<Tensor>* tensor) {
+                                      std::shared_ptr<Tensor>* tensor,
+                                      std::shared_ptr<ReadyEvent>* event) {
   std::vector<int64_t> shape_vector;
   shape_vector.reserve(shape.dims());
   for (int idx = 0; idx < shape.dims(); ++idx) {

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -59,9 +59,11 @@ public:
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) override;
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event) override;
   virtual Status AllocateOutput(int output_index, TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor) override;
+                                std::shared_ptr<Tensor>* tensor,
+                                std::shared_ptr<ReadyEvent>* event) override;
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -60,10 +60,10 @@ public:
                      std::shared_ptr<PersistentBuffer>* tensor) override;
   virtual Status AllocateOutput(TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event) override;
+                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
   virtual Status AllocateOutput(int output_index, TensorShape shape,
                                 std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event) override;
+                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
   virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
                                std::shared_ptr<Tensor>* tensor) override;
   virtual Framework framework() const override;


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Some developers have reported performance issues with the `alltoall` implementation in a TF workflow. With profiling, I found that one source of performance loss is in the implementation of the allocation of the output buffer in TF. In the current implementation, the output allocation triggers a device sync (https://github.com/horovod/horovod/blob/master/horovod/tensorflow/mpi_ops.cc#L341), which stalls the GPU launch pipeline and introduces some unneeded latency. This sync was also reported in #3457. This type of launch stalling and associated latency is particularly problematic for `alltoall` since it is typically used in the critical path of the model and usually is not overlapped with other work.

This PR uses CUDA events and CUDA stream wait operations to replace the CPU sync on output allocations for TF when using the NCCL backend. It is similar to work done in #2963 where CUDA events were used to replace CPU syncs for input data dependencies.

Beyond just `alltoall`, I extended this asynchronous handling of the output allocation to the other ops that would benefit (e.g., `allgather` and `reducescatter`). 