### PR TITLE
skip environment variables with dot ('.')

### DIFF
--- a/horovod/runner/common/util/env.py
+++ b/horovod/runner/common/util/env.py
@@ -21,7 +21,7 @@ from horovod.runner.common.util import secret
 LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD', secret.HOROVOD_SECRET_KEY}
+IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD', secret.HOROVOD_SECRET_KEY, '.*\..*'}
 
 KUBEFLOW_MPI_EXEC = '/etc/mpi/kubexec.sh'
 


### PR DESCRIPTION
## Checklist before submitting

- [✓] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ NA ] Did you update the docs?
- [✓] Did you write any tests to validate this change?  
`horovodrun -np 1 -H localhost:1 FOO.BAR=1 echo hello` would fail without this change with `FOO.BAR=1: command not found`, and would succeed after this change
- [NA] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Bash doesn't support environment variables with dots. We can make them as non-exportable so the job will not fail with invalid environment variables.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
