### PR TITLE
Use env to set environment vars in remote shell

### DIFF
--- a/horovod/runner/gloo_run.py
+++ b/horovod/runner/gloo_run.py
@@ -92,7 +92,8 @@ def _slot_info_to_command_fn(run_command, env):
         horovod_rendez_env = " ".join(
             [f"{k}={str(v)}" for k, v in env_vars.items()])
 
-        return '{horovod_env} {env} {run_command}' .format(
+        return '{shell} {horovod_env} {env} {run_command}' .format(
+            shell='env',
             horovod_env=horovod_rendez_env,
             env=' '.join(['%s=%s' % (key, quote(value)) for key, value in env.items()
                           if env_util.is_exportable(key)]),

--- a/test/integration/test_spark.py
+++ b/test/integration/test_spark.py
@@ -815,7 +815,8 @@ class SparkTests(unittest.TestCase):
             self.assertEqual(alloc_info.local_rank, alloc_info.rank)
 
             # command fully derived from alloc_info
-            expected_command = ('HOROVOD_HOSTNAME=[^ ]+ '
+            expected_command = ('env '
+                                'HOROVOD_HOSTNAME=[^ ]+ '
                                 'HOROVOD_RANK={rank} '
                                 'HOROVOD_SIZE={size} '
                                 'HOROVOD_LOCAL_RANK={local_rank} '


### PR DESCRIPTION
Some environment variables on the host that runs `horovodrun` might not be supported by the remote shell (#3487). Looks like `env` does support those.