### PR TITLE
Fixes empty hostname returned from HostDiscoveryScript

### DIFF
--- a/test/single/test_elastic_discovery.py
+++ b/test/single/test_elastic_discovery.py
@@ -37,6 +37,9 @@ class HostDiscoveryScriptTests(unittest.TestCase):
         ["host-1:2", {"host-1": 2}],
         ["host-1\nhost-5", {"host-1": DEFAULT_SLOTS, "host-5": DEFAULT_SLOTS}],
         ["host-1:2\nhost-4:3", {"host-1": 2, "host-4": 3}],
+        ["\nhost-1:2\nhost-4:3", {"host-1": 2, "host-4": 3}],
+        ["host-1:2\n\nhost-4:3", {"host-1": 2, "host-4": 3}],
+        ["host-1:2\nhost-4:3\n", {"host-1": 2, "host-4": 3}],
     ])
     def test_find_available_hosts_and_slots(
             self, script_result, expected_hosts_and_slots):

--- a/test/single/test_elastic_discovery.py
+++ b/test/single/test_elastic_discovery.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import mock
+from parameterized import parameterized
+
+from horovod.runner.elastic.discovery import HostDiscoveryScript
+
+# Mocked default slots for testing.
+DEFAULT_SLOTS = mock.Mock()
+
+
+class HostDiscoveryScriptTests(unittest.TestCase):
+    """
+    Tests for host discovery script in horovod.elastic.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(HostDiscoveryScriptTests, self).__init__(*args, **kwargs)
+
+    @parameterized.expand([
+        ["", {}],  # No host found.
+        ["host-1", {"host-1": DEFAULT_SLOTS}],
+        ["host-1:2", {"host-1": 2}],
+        ["host-1\nhost-5", {"host-1": DEFAULT_SLOTS, "host-5": DEFAULT_SLOTS}],
+        ["host-1:2\nhost-4:3", {"host-1": 2, "host-4": 3}],
+    ])
+    def test_find_available_hosts_and_slots(
+            self, script_result, expected_hosts_and_slots):
+        """Tests that HostDiscoveryScript finds available hosts and slots."""
+        mock_result = mock.Mock(return_value=script_result)
+        host_discovery_script = HostDiscoveryScript(
+            discovery_script=mock.Mock(),
+            slots=DEFAULT_SLOTS
+        )
+        host_discovery_script._execute_discovery_script = mock_result
+
+        hosts_and_slots = host_discovery_script.find_available_hosts_and_slots()
+        assert hosts_and_slots == expected_hosts_and_slots

--- a/test/single/test_elastic_driver.py
+++ b/test/single/test_elastic_driver.py
@@ -167,7 +167,8 @@ class ElasticDriverTests(unittest.TestCase):
     @mock.patch('horovod.runner.elastic.driver.ElasticDriver.get_worker_client')
     def test_wait_for_available_slots(self, mock_get_worker_client, mock_get_coordinator_info):
         """Tests that driver blocks until the min number of slots are available."""
-        slots = [{'host-1': 4},
+        slots = [{},  # Simulate the situation that host-1, host-2, and host-3 are not ready yet.
+                 {'host-1': 4},
                  {'host-1': 4, 'host-2': 8},
                  {'host-1': 4, 'host-2': 8, 'host-3': 4}]
         mock_discovery = mock.Mock()


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes empty hostname returned from HostDiscoveryScript and make sure hostname is not empty.

Context:
When discovery script return nothing, HostDiscoveryScript will treat the empty result i.e. "" string as the available host.
It will fail training job as launcher cannot ssh on the host with empty address. Discovery script can return nothing when no workers are available or new workers are not ready yet.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
