### PR TITLE
Replace '+' with '.' to get more consistent package version with the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - MXNet: Updated allreduce functions to newer `op` API. ([#3299](https://github.com/horovod/horovod/pull/3299))
+- Replace '+' with '.' to get more consistent package version when the environment HOROVOD_LOCAL_VERSION is set. ([#3495](https://github.com/horovod/horovod/pull/3495))
 
 ### Deprecated
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ if not os.environ.get('HOROVOD_WITHOUT_PYTORCH'):
 
 
 def get_package_version():
-    return __version__ + "+" + os.environ['HOROVOD_LOCAL_VERSION'] if 'HOROVOD_LOCAL_VERSION' in os.environ else __version__
+    return __version__ + "." + os.environ['HOROVOD_LOCAL_VERSION'] if 'HOROVOD_LOCAL_VERSION' in os.environ else __version__
 
 
 setup(name='horovod',


### PR DESCRIPTION
…environment HOROVOD_LOCAL_VERSION set

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Replace '+' with '.' to get more consistent package version when the environment HOROVOD_LOCAL_VERSION is set.

Issue: Presently,  `get_package_version()` appended the HOROVOD_LOCAL_VERSION using '+'.  For example, with `HOROVOD_LOCAL_VERSION` is set to `1` and the horovod version is `0.24.2`, the package version becomes `0.24.2+1`. 
By replacing `+` with `.`,  we get more consistent package name  (e.g., `0.24.2.1`) for our build process.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
