### PR TITLE
Fixes gradient update timing in TF AggregationHelperEager

### DIFF
--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -141,11 +141,6 @@ class LocalGradientAggregationHelperEager:
             return increment_optimizer_iteration()
 
         def is_aggregation_step():
-            if _POST_TF_2_4_0:
-                # In TF 2.4+ we evaluate whether it's time to aggregated gradients before
-                # calling `_aggregate_gradients()`.
-                return tf.equal(tf.add(self.counter, 1), self.backward_passes_per_step)
-
             return tf.equal(self.counter, 0)
 
         return tf.cond(

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -22,12 +22,13 @@ import os
 import warnings
 
 from distutils.version import LooseVersion
+from parameterized import parameterized
 
 import pytest
 
 from tensorflow import keras
 
-from horovod.common.util  import is_version_greater_equal_than
+from horovod.common.util import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     if LooseVersion(keras.__version__) < LooseVersion("2.9.0"):
@@ -70,6 +71,7 @@ class Tf2KerasTests(tf.test.TestCase):
         initial_lr = 0.1 * hvd.size()
         opt = tf.keras.optimizers.Adam()
         opt = hvd.DistributedOptimizer(opt)
+
         def linear_multiplier(epoch):
             return epoch
 
@@ -229,7 +231,11 @@ class Tf2KerasTests(tf.test.TestCase):
         assert state.batch == 21
         assert state.epoch == 11
 
-    def test_gradient_aggregation(self):
+    @parameterized.expand([
+        [True],
+        [False]
+    ])
+    def test_gradient_aggregation(self, average_aggregated_gradients):
         class TestingOptimizer(optimizer_v2.OptimizerV2):
             """
             Custom optimizer we use for testing gradient aggregation.
@@ -250,55 +256,83 @@ class Tf2KerasTests(tf.test.TestCase):
         hvd_optimizer = hvd.DistributedOptimizer(
             optimizer=TestingOptimizer("test"),
             backward_passes_per_step=backward_passes_per_step,
-            average_aggregated_gradients=True,
+            average_aggregated_gradients=average_aggregated_gradients,
+            sparse_as_dense=True,
         )
         _ = hvd_optimizer.iterations
 
+        x_0 = 0.0
+        y_0, y_1 = 1.0, 2.0
+        x = tf.Variable([x_0])
+        y = tf.Variable([y_0, y_1])
+        variables = [x, y]
+
+        def loss():
+            """
+            loss = x - y * e1 where e1 = [1.0, 0.0]
+            """
+            # Gather the first row of y. It is equivalent to y * e1.
+            # Use tf.gather to produce tf.IndexedSlices gradient to improve test coverage.
+            gathered_y_1 = tf.gather(y, [0])
+            return x - gathered_y_1
+
         def compute_expected_value(batch_id):
-            sum_per_aggregation = 0.0
-            for _ in range(backward_passes_per_step):
-                grads_for_batch = 0.0
+            """
+            Given the loss function above, the gradient of x and y can be derived.
+              dloss/dx = 1.0
+              dloss/dy = [-1.0, 0.0]
+            Therefore, for each step, the value of x increases by 1 and
+            the value of y increases by [-1.0, 0.0].
+            """
+            num_of_steps = (batch_id + 1) // backward_passes_per_step
 
-                # Apply `average_aggregated_gradients`.
-                grads_for_batch /= float(backward_passes_per_step)
+            gradient_of_x = num_of_steps * 1.0
+            gradient_of_y_0 = num_of_steps * -1.0
 
-                # Averages across workers.
-                sum_per_aggregation += grads_for_batch / float(hvd.size())
+            if not average_aggregated_gradients:
+                gradient_of_x *= backward_passes_per_step
+                gradient_of_y_0 *= backward_passes_per_step
 
-            aggregations_completed = math.floor(
-                (batch_id + 1) / backward_passes_per_step)
-            return aggregations_completed * sum_per_aggregation
+            # Add gradient with its initial values because the TestingOptimizer optimize
+            # variable by assign_add.
+            expected_x = x_0 + gradient_of_x
+            expected_y_0 = y_0 + gradient_of_y_0
+            # It should remain constant as gradient is always 0.
+            expected_y_1 = y_1
+
+            return np.array(expected_x), np.array([expected_y_0, expected_y_1])
 
         @tf.function
-        def apply_gradients_in_tf_function(grads_and_vars, **kwargs):
-            # Apply gradient updates in tf.function to reproduce how it is
-            # done inside `model.fit()`.
+        def compute_and_apply_gradients_in_tf_function(var_list, **kwargs):
+            # Compute and apply gradient updates in tf.function to reproduce
+            # how it is done inside `model.fit()`.
+            grads_and_vars = hvd_optimizer._compute_gradients(
+                loss, var_list=var_list)
             hvd_optimizer.apply_gradients(grads_and_vars, **kwargs)
 
-        var = tf.Variable([0.0])
-        variables = [var]
-        def loss():
-            return (var - var)
-        for idx in range(10):
+        total_num_of_steps = 10
+        for idx in range(total_num_of_steps):
             if _PRE_TF_2_2_0:
-                grads_and_vars = hvd_optimizer._compute_gradients(
-                    loss, var_list=variables)
-                apply_gradients_in_tf_function(grads_and_vars, variables)
+                compute_and_apply_gradients_in_tf_function(var_list=variables)
             else:
                 # In 2.2 and 2.3 the horovod optimizer sets `_HAS_AGGREGATE_GRAD = True`.
                 # This configures tf.keras to call `_aggregate_gradients()` outside of
                 # `apply_gradients()` and to set `experimental_aggregate_gradients` to
                 # False when calling `apply_gradients()` to prevent it from calling
                 # `_aggregate_gradients()` again.
+                compute_and_apply_gradients_in_tf_function(
+                    var_list=variables,
+                    experimental_aggregate_gradients=False)
 
-                grads_and_vars = hvd_optimizer._compute_gradients(
-                    loss, var_list=variables)
-                apply_gradients_in_tf_function(
-                    grads_and_vars, experimental_aggregate_gradients=False)
-
-            updated_variable_value = variables[0][0].numpy()
-            assert updated_variable_value == compute_expected_value(idx)
+            expected_x, expected_y = compute_expected_value(idx)
+            updated_x = variables[0].numpy()
+            updated_y = variables[1].numpy()
+            assert np.isclose(updated_x, expected_x)
+            assert np.isclose(updated_y, expected_y).all()
             assert idx + 1 == hvd_optimizer.iterations.numpy()
+
+        aggregation_counter = hvd_optimizer._agg_helper.counter.numpy()
+        assert aggregation_counter == total_num_of_steps % backward_passes_per_step
 
     def test_process_set_optimizer(self):
         """ Note that this test makes the most sense when running with > 2 processes. """


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes gradient update timing in TF LocalGradientAggregationHelperEager.

Why?
The gradient updating timing in LocalGradientAggregationHelperEager was set one step before the locally aggregated gradients are allreduced. Therefore, the applied gradient are the locally aggregated gradient instead of the allreduced gradient. This PR fixes the issue.

The PR also improves the gradient aggregation test case to cover tf.IndexedSlices gradient and validates the updated values. Before the change, the grad and values are always zero which does not test anything. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
