### PR TITLE
Fix resource not found error in TF AggregationHelper

### DIFF
--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -41,7 +41,6 @@ class LocalGradientAggregationHelperEager:
         # is equal to 0.
         self.counter = tf.Variable(initial_value=0)
 
-    @tf.function
     def compute_gradients(self, grads, vars):
         # On steps where allreduce happens, resulting_grads returns the allreduced
         # gradients, on other steps it returns the locally aggregated


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes resource not found error in TensorFlow LocalGradientAggregationHelperEager.

### Context
When gradient aggregation is enabled with sparse gradient input, the following resource not found error will be thrown in LocalGradientAggregationHelperEager. Please check the newly added test case to reproduce the error. 
```
tensorflow.python.framework.errors_impl.NotFoundError:  Resource localhost/_AnonymousVar8/N10tensorflow3VarE does not exist.
[[{{node StatefulPartitionedCall/AssignAddVariableOp}}]] [Op:__inference_train_function_600]
```

### Root cause:
The error message means the anonymous tf.Variable created for local gradient aggregation in LocalGradientAggregationHelperEager hasn't been initialized yet. Here is why.

LocalGradientAggregationHelperEager defines its `compute_gradients` as a tf.function. When a tf.Variable is created in a tf.function, it will be lifted to the default graph context for initialization. However, if the variable has external dependency such as a placeholder input, the variable will fail to be lifted to the default graph context. When one defines a sparse operation in their model, the gradient aggregation variable will fail to be initialized. This is because the shape of the aggregation variable is based on sparse gradient placeholder inputs i.e. shape, indices, and values. For example, the following error was thrown in variable lifting.

```
Unable to lift tensor <tf.Tensor 'zeros_like:0' shape=(None, 64) dtype=float32> because it depends transitively on placeholder <tf.Operation 'grads_2' type=Placeholder> via at least one path, e.g.: zeros_like (ZerosLike) <- UnsortedSegmentSum (UnsortedSegmentSum) <- strided_slice (StridedSlice) <- grads_2 (Placeholder)
``` 

If a variable fails to be lifted to the default graph context, it must be tracked in the current tf.function so that TensorFlow can validate if the variable is properly initialized before executing the tf.funtion. However, we have a hierarchical tf.function structure in this case. Keras model in TensorFlow will wrap everything into a tf.function by default through `model.fit`. In this way, the tf.function created in LocalGradientAggregationHelperEager will be created under another tf.function created by keras. However, the variable created in the `compute_gradients` tf.function will not be tracked under the tf.function created by keras. Hence, the variable will not be initialized properly before execution. 

### How to fix the issue?
We removed the tf.function annotation from the `compute_gradients` function in LocalGradientAggregationHelperEager class so that the variables created in it can be tracked under the tf.function created by keras. It should not have performance impact as everything is still under a tf.function with graph execution. If users are not using keras and use the class directly, users can wrap the compute_gradients function into a tf.function. For example, 
```
aggregation_helper = LocalGradientAggregationHelperEager(...)

@tf.function
def compute_gradients(grads, vars):
    return aggregation_helper.compute_gradients(grads, vars)
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
