### PR TITLE
Fallback to NCCL shared lib if static one is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fallback to NCCL shared lib if static one is not found. ([#3500]((https://github.com/horovod/horovod/pull/3500))
+
 ## [v0.24.2] - 2022-03-10
 
 ### Fixed

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -29,14 +29,23 @@ find_path(NCCL_INCLUDE_DIR
 set(HOROVOD_NCCL_LINK $ENV{HOROVOD_NCCL_LINK})
 if (HOROVOD_NCCL_LINK STREQUAL "SHARED")
     set(NCCL_LIBNAME "nccl")
+    message(STATUS "Linking against shared NCCL library")
 else()
-    message(STATUS "Linking against static NCCL library")
     set(NCCL_LIBNAME "libnccl_static.a")
+    message(STATUS "Linking against static NCCL library")
 endif()
 
 find_library(NCCL_LIBRARY
         NAMES ${NCCL_LIBNAME}
         HINTS ${HOROVOD_NCCL_LIB} ${CUDAToolkit_LIBRARY_DIR})
+
+if (NCCL_LIBRARY STREQUAL "NCCL_LIBRARY-NOTFOUND" AND NCCL_LIBNAME MATCHES "static" AND
+    NOT HOROVOD_NCCL_LINK STREQUAL "STATIC")
+    message(STATUS "Could not find static NCCL library. Trying to find shared lib instead.")
+    find_library(NCCL_LIBRARY
+            NAMES "nccl"
+            HINTS ${HOROVOD_NCCL_LIB} ${CUDAToolkit_LIBRARY_DIR})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(NCCL DEFAULT_MSG NCCL_INCLUDE_DIR NCCL_LIBRARY)


### PR DESCRIPTION
Signed-off-by: Nicolas Castet <26874160+nvcastet@users.noreply.github.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Our build default is to link against NCCL static lib. Unfortunately, if this one is unfound (e.g. in NGC containers), the build will fail.
Adding a fallback to trying to link against NCCL shared lib if static is not found and `HOROVOD_NCCL_LINK` is not set to `STATIC`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
