### PR TITLE
Add elastic run api

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -302,9 +302,11 @@ run_gloo_integration() {
     run_test "${test}" "${queue}" \
       ":tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (${test})" \
       "horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py"
-    run_test "${test}" "${queue}" \
-      ":tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (${test})" \
-      "python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2"
+    if [[ ${queue} != *gpu* ]]; then
+      run_test "${test}" "${queue}" \
+        ":tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (${test})" \
+        "python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2"
+    fi
   else
     run_test "${test}" "${queue}" \
       ":tensorflow: Gloo TensorFlow MNIST (${test})" \

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -298,6 +298,13 @@ run_gloo_integration() {
         ":tensorflow: Gloo TensorFlow 2.0 Keras MNIST api (${test})" \
         "python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py 2 localhost:2 gloo"
     fi
+
+    run_test "${test}" "${queue}" \
+      ":tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (${test})" \
+      "horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py"
+    run_test "${test}" "${queue}" \
+      ":tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (${test})" \
+      "python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2"
   else
     run_test "${test}" "${queue}" \
       ":tensorflow: Gloo TensorFlow MNIST (${test})" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet_MNIST: true
@@ -212,6 +214,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet_MNIST: true
@@ -231,6 +235,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet_MNIST: true
@@ -252,6 +258,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet_MNIST: true
@@ -273,6 +281,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet_MNIST: true
@@ -307,6 +317,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             MPI_Cluster_PyTests: true
@@ -883,6 +895,60 @@ jobs:
         run: |
           mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun_run_3
           docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 1 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && true
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 2 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 3 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3
+        continue-on-error: false
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 1 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && true
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 2 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 3 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3
+        continue-on-error: false
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
         shell: bash
 
       - name: "Gloo TensorFlow 2.0 MNIST api [attempt 1 of 3]"
@@ -2227,6 +2293,8 @@ jobs:
             Gloo_Single_PyTests: true
             Gloo_TensorFlow_2_0_Keras_MNIST_api: true
             Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
             Gloo_TensorFlow_2_0_MNIST_api: true
             Gloo_TensorFlow_2_0_MNIST_horovodrun: true
             Single_MXNet2_MNIST: true
@@ -2761,6 +2829,60 @@ jobs:
         run: |
           mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun_run_3
           docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 1 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && true
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 2 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_1.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic api [attempt 3 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3
+        continue-on-error: false
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_api && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_2.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_api_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 1 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && true
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 2 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2
+        continue-on-error: true
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_1.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+        shell: bash
+
+      - name: "Gloo TensorFlow 2.0 MNIST Elastic horovodrun [attempt 3 of 3]"
+        id: Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3
+        continue-on-error: false
+        if: always() && steps.build.outcome == 'success' && matrix.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun && steps.Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_2.outcome == 'failure'
+        run: |
+          mkdir -p artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3
+          docker-compose -f docker-compose.test.yml run -e GITHUB_ACTIONS --rm --volume "$(pwd)/artifacts/${{ matrix.image }}/Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun_run_3:/artifacts" ${{ matrix.image }} /usr/bin/timeout 10m horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
         shell: bash
 
       - name: "Gloo TensorFlow 2.0 MNIST api [attempt 1 of 3]"

--- a/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+++ b/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
@@ -105,7 +105,6 @@ def main():
     # corrupting it.
     if hvd.rank() == 0:
         checkpoint.save(checkpoint_dir)
-        return mnist_model
 
 
 if __name__ == '__main__':
@@ -116,8 +115,8 @@ if __name__ == '__main__':
         max_num_proc = int(sys.argv[3])
         hosts = sys.argv[4]
         print('Running training through horovod.run')
-        models = horovod.run(main, num_proc=num_proc, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
-                             hosts=hosts, use_gloo=True, verbose=2)
+        horovod.run(main, num_proc=num_proc, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
+                    hosts=hosts, use_gloo=True, verbose=2)
     else:
         # this is running via horovodrun
         main()

--- a/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+++ b/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
@@ -13,94 +13,111 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
+
 import tensorflow as tf
+
+import horovod
 import horovod.tensorflow as hvd
 
-# Horovod: initialize Horovod.
-hvd.init()
 
-# Horovod: pin GPU to be used to process local rank (one GPU per process)
-gpus = tf.config.experimental.list_physical_devices('GPU')
-for gpu in gpus:
-    tf.config.experimental.set_memory_growth(gpu, True)
-if gpus:
-    tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')
+def main():
+    # Horovod: initialize Horovod.
+    hvd.init()
 
-(mnist_images, mnist_labels), _ = \
-    tf.keras.datasets.mnist.load_data(path='mnist-%d.npz' % hvd.rank())
+    # Horovod: pin GPU to be used to process local rank (one GPU per process)
+    gpus = tf.config.experimental.list_physical_devices('GPU')
+    for gpu in gpus:
+        tf.config.experimental.set_memory_growth(gpu, True)
+    if gpus:
+        tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')
 
-dataset = tf.data.Dataset.from_tensor_slices(
-    (tf.cast(mnist_images[..., tf.newaxis] / 255.0, tf.float32),
-     tf.cast(mnist_labels, tf.int64))
-)
-dataset = dataset.repeat().shuffle(10000).batch(128)
+    (mnist_images, mnist_labels), _ = \
+        tf.keras.datasets.mnist.load_data(path='mnist-%d.npz' % hvd.rank())
 
-mnist_model = tf.keras.Sequential([
-    tf.keras.layers.Conv2D(32, [3, 3], activation='relu'),
-    tf.keras.layers.Conv2D(64, [3, 3], activation='relu'),
-    tf.keras.layers.MaxPooling2D(pool_size=(2, 2)),
-    tf.keras.layers.Dropout(0.25),
-    tf.keras.layers.Flatten(),
-    tf.keras.layers.Dense(128, activation='relu'),
-    tf.keras.layers.Dropout(0.5),
-    tf.keras.layers.Dense(10, activation='softmax')
-])
-loss = tf.losses.SparseCategoricalCrossentropy()
+    dataset = tf.data.Dataset.from_tensor_slices(
+        (tf.cast(mnist_images[..., tf.newaxis] / 255.0, tf.float32),
+         tf.cast(mnist_labels, tf.int64))
+    )
+    dataset = dataset.repeat().shuffle(10000).batch(128)
 
-# Horovod: adjust learning rate based on number of GPUs.
-lr = 0.001
-opt = tf.optimizers.Adam(lr * hvd.size())
+    mnist_model = tf.keras.Sequential([
+        tf.keras.layers.Conv2D(32, [3, 3], activation='relu'),
+        tf.keras.layers.Conv2D(64, [3, 3], activation='relu'),
+        tf.keras.layers.MaxPooling2D(pool_size=(2, 2)),
+        tf.keras.layers.Dropout(0.25),
+        tf.keras.layers.Flatten(),
+        tf.keras.layers.Dense(128, activation='relu'),
+        tf.keras.layers.Dropout(0.5),
+        tf.keras.layers.Dense(10, activation='softmax')
+    ])
+    loss = tf.losses.SparseCategoricalCrossentropy()
+
+    # Horovod: adjust learning rate based on number of GPUs.
+    lr = 0.001
+    opt = tf.optimizers.Adam(lr * hvd.size())
+
+    @tf.function
+    def training_step(images, labels, allreduce=True):
+        with tf.GradientTape() as tape:
+            probs = mnist_model(images, training=True)
+            loss_value = loss(labels, probs)
+
+        # Horovod: add Horovod Distributed GradientTape.
+        if allreduce:
+            tape = hvd.DistributedGradientTape(tape)
+
+        grads = tape.gradient(loss_value, mnist_model.trainable_variables)
+        opt.apply_gradients(zip(grads, mnist_model.trainable_variables))
+        return loss_value
+
+    # Horovod: initialize model and optimizer state so we can synchronize across workers
+    for batch_idx, (images, labels) in enumerate(dataset.take(1)):
+        training_step(images, labels, allreduce=False)
+
+    @hvd.elastic.run
+    def train(state):
+        start_batch = state.batch
+
+        # Horovod: adjust number of steps based on number of GPUs.
+        for batch_idx, (images, labels) in enumerate(dataset.skip(state.batch).take(100 // hvd.size())):
+            state.batch = start_batch + batch_idx
+            loss_value = training_step(images, labels)
+
+            if state.batch % 10 == 0 and hvd.local_rank() == 0:
+                print('Step #%d\tLoss: %.6f' % (state.batch, loss_value))
+
+            # Horovod: commit state at the end of each batch
+            state.commit()
+
+    def on_state_reset():
+        opt.lr.assign(lr * hvd.size())
+
+    state = hvd.elastic.TensorFlowKerasState(mnist_model, opt, batch=0)
+    state.register_reset_callbacks([on_state_reset])
+
+    train(state)
+
+    checkpoint_dir = './checkpoints'
+    checkpoint = tf.train.Checkpoint(model=mnist_model, optimizer=opt)
+
+    # Horovod: save checkpoints only on worker 0 to prevent other workers from
+    # corrupting it.
+    if hvd.rank() == 0:
+        checkpoint.save(checkpoint_dir)
+        return mnist_model
 
 
-@tf.function
-def training_step(images, labels, allreduce=True):
-    with tf.GradientTape() as tape:
-        probs = mnist_model(images, training=True)
-        loss_value = loss(labels, probs)
-
-    # Horovod: add Horovod Distributed GradientTape.
-    if allreduce:
-        tape = hvd.DistributedGradientTape(tape)
-
-    grads = tape.gradient(loss_value, mnist_model.trainable_variables)
-    opt.apply_gradients(zip(grads, mnist_model.trainable_variables))
-    return loss_value
-
-
-# Horovod: initialize model and optimizer state so we can synchronize across workers
-for batch_idx, (images, labels) in enumerate(dataset.take(1)):
-    training_step(images, labels, allreduce=False)
-
-
-@hvd.elastic.run
-def train(state):
-    start_batch = state.batch
-
-    # Horovod: adjust number of steps based on number of GPUs.
-    for batch_idx, (images, labels) in enumerate(dataset.skip(state.batch).take(10000 // hvd.size())):
-        state.batch = start_batch + batch_idx
-        loss_value = training_step(images, labels)
-
-        if state.batch % 10 == 0 and hvd.local_rank() == 0:
-            print('Step #%d\tLoss: %.6f' % (state.batch, loss_value))
-
-        # Horovod: commit state at the end of each batch
-        state.commit()
-
-
-def on_state_reset():
-    opt.lr.assign(lr * hvd.size())
-
-
-state = hvd.elastic.TensorFlowKerasState(mnist_model, opt, batch=0)
-state.register_reset_callbacks([on_state_reset])
-
-train(state)
-
-checkpoint_dir = './checkpoints'
-checkpoint = tf.train.Checkpoint(model=mnist_model, optimizer=opt)
-
-# Horovod: save checkpoints only on worker 0 to prevent other workers from
-# corrupting it.
-if hvd.rank() == 0:
-    checkpoint.save(checkpoint_dir)
+if __name__ == '__main__':
+    if len(sys.argv) == 5:
+        # run training through horovod.run
+        num_proc = int(sys.argv[1])
+        min_num_proc = int(sys.argv[2])
+        max_num_proc = int(sys.argv[3])
+        hosts = sys.argv[4]
+        print('Running training through horovod.run')
+        models = horovod.run(main, num_proc=num_proc, min_num_proc=min_num_proc, max_num_proc=max_num_proc,
+                             hosts=hosts, use_gloo=True, verbose=2)
+    else:
+        # this is running via horovodrun
+        main()

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -135,6 +135,7 @@ def run(
     :param min_num_proc: Minimum number of processes running for training to continue. If number of
                    available processes dips below this threshold, then training will wait for
                    more instances to become available. Defaults to num_proc
+                   Consider providing network_interface to speed up elastic tasks startup.
     :param max_num_proc: Maximum number of training processes, beyond which no additional processes
                    will be created. If not specified, then will be unbounded.
     :param slots: Number of slots for processes per host. Normally 1 slot per GPU per host.
@@ -161,6 +162,7 @@ def run(
                                   Providing a discovery script enables elastic training.
                                   The job will fail immediately if execution of the script returns a non-zero exit
                                   code on the first call. Subsequent calls will be retried until timeout.
+                                  Consider providing network_interface to speed up elastic tasks startup.
     :param start_timeout: Horovodrun has to perform all the checks and
                           start the processes before the specified
                           timeout. The default value is 30 seconds.

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -135,7 +135,6 @@ def run(
     :param min_num_proc: Minimum number of processes running for training to continue. If number of
                    available processes dips below this threshold, then training will wait for
                    more instances to become available. Defaults to num_proc
-                   Consider providing network_interface to speed up elastic tasks startup.
     :param max_num_proc: Maximum number of training processes, beyond which no additional processes
                    will be created. If not specified, then will be unbounded.
     :param slots: Number of slots for processes per host. Normally 1 slot per GPU per host.
@@ -162,7 +161,6 @@ def run(
                                   Providing a discovery script enables elastic training.
                                   The job will fail immediately if execution of the script returns a non-zero exit
                                   code on the first call. Subsequent calls will be retried until timeout.
-                                  Consider providing network_interface to speed up elastic tasks startup.
     :param start_timeout: Horovodrun has to perform all the checks and
                           start the processes before the specified
                           timeout. The default value is 30 seconds.

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -192,8 +192,7 @@ def run(
     :param executable: Optional executable to run when launching the workers. Defaults to `sys.executable`.
     :return: Return a list which contains values return by all Horovod processes.
              The index of the list corresponds to the rank of each Horovod process.
-             Returns only the first min_num_proc results when running in elastic mode,
-             i.e. at least one of host_discovery_script and min_num_proc is set.
+             Returns only the first min_num_proc results, if set.
     """
     if network_interface:
         network_interfaces = network_interface.split(',')

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -103,6 +103,7 @@ def run(
         cooldown_range=None,
         hosts=None,
         hostfile=None,
+        host_discovery_script=None,
         start_timeout=None,
         ssh_port=None,
         ssh_identity_file=None,
@@ -153,6 +154,13 @@ def run(
     :param hostfile: Path to a host file containing the list of host names and the number of
                      available slots. Each line of the file must be of the form:
                      <hostname> slots=<slots>
+    :param host_discovery_script: Used for elastic training (autoscaling and fault tolerance).
+                                  An executable script that will print to stdout every available host (one per
+                                  newline character) that can be used to run worker processes. Optionally
+                                  specifies number of slots on the same line as the hostname as: "hostname:slots".
+                                  Providing a discovery script enables elastic training.
+                                  The job will fail immediately if execution of the script returns a non-zero exit
+                                  code on the first call. Subsequent calls will be retried until timeout.
     :param start_timeout: Horovodrun has to perform all the checks and
                           start the processes before the specified
                           timeout. The default value is 30 seconds.
@@ -182,6 +190,8 @@ def run(
     :param executable: Optional executable to run when launching the workers. Defaults to `sys.executable`.
     :return: Return a list which contains values return by all Horovod processes.
              The index of the list corresponds to the rank of each Horovod process.
+             Returns only the first min_num_proc results when running in elastic mode,
+             i.e. at least one of host_discovery_script and min_num_proc is set.
     """
     if network_interface:
         network_interfaces = network_interface.split(',')
@@ -220,6 +230,7 @@ def run(
     hargs.cooldown_range = cooldown_range
     hargs.hosts = hosts
     hargs.hostfile = hostfile
+    hargs.host_discovery_script = host_discovery_script
     hargs.start_timeout = start_timeout
     hargs.ssh_port = ssh_port
     hargs.ssh_identity_file = ssh_identity_file

--- a/horovod/runner/http/http_client.py
+++ b/horovod/runner/http/http_client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-import socket
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
 from urllib.request import urlopen
@@ -20,26 +19,26 @@ from urllib.request import urlopen
 from horovod.runner.common.util import codec
 
 
-def read_data_from_kvstore(addr, port, scope, key, timeout=None):
+def read_data_from_kvstore(addr, port, scope, key):
     try:
         url = "http://{addr}:{port}/{scope}/{key}".format(
             addr=addr, port=str(port), scope=scope, key=key
         )
         req = Request(url)
-        resp = urlopen(req, timeout=timeout if timeout else socket.getdefaulttimeout())
+        resp = urlopen(req)
         # TODO: remove base64 encoding because base64 is not efficient
         return codec.loads_base64(resp.read())
     except (HTTPError, URLError) as e:
         raise RuntimeError("Read data from KVStore server failed.", e)
 
 
-def put_data_into_kvstore(addr, port, scope, key, value, timeout=None):
+def put_data_into_kvstore(addr, port, scope, key, value):
     try:
         url = "http://{addr}:{port}/{scope}/{key}".format(
             addr=addr, port=str(port), scope=scope, key=key
         )
         req = Request(url, data=codec.dumps_base64(value, to_ascii=False))
         req.get_method = lambda: "PUT"  # for urllib2 compatibility
-        urlopen(req, timeout=timeout if timeout else socket.getdefaulttimeout())
+        urlopen(req)
     except (HTTPError, URLError) as e:
         raise RuntimeError("Put data input KVStore server failed.", e)

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -598,12 +598,12 @@ def _get_ips(nics):
         else:
             raise ValueError('No IPv4 IP found found')
 
-    # sort ips, move localhost IP to the front
+    # move localhost IP to the back
     localhost = '127.0.0.1'
-    ips = sorted(list(ips))
+    ips = list(ips)
     if localhost in ips:
         pos = ips.index(localhost)
-        ips = [ips[pos]] + ips[:pos] + ips[pos+1:]
+        ips = ips[:pos] + ips[pos+1:] + [ips[pos]]
 
     return list(ips)
 

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -643,7 +643,8 @@ def _run_static(args):
         if settings.verbose >= 2:
             print('SSH was successful into all the remote hosts.')
 
-    nics = driver_service.get_common_interfaces(settings, all_host_names, remote_host_names, fn_cache)
+    nics = driver_service.get_common_interfaces(settings, all_host_names,
+                                                remote_host_names, fn_cache)
 
     if args.run_func:
         # get the driver IPv4 address

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -766,9 +766,10 @@ def _run_elastic(args):
 
         try:
             gloo_run_elastic(settings, env, command)
-            results = [None] * args.min_num_proc
+            np = (args.min_num_proc or args.num_proc)
+            results = [None] * np
             # TODO: make it parallel to improve performance
-            for i in range(args.min_num_proc):
+            for i in range(np):
                 results[i] = read_data_from_kvstore(driver_ips[0], run_func_server_port,
                                                     'runfunc_result', str(i))
             return results

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -753,9 +753,9 @@ def _run_elastic(args):
     env = os.environ.copy()
     config_parser.set_env_from_args(env, args)
 
+    # get the driver IPv4 address
     driver_ips = _get_ips(settings.nics)
     if args.run_func:
-        # get the driver IPv4 address
         run_func_server = KVStoreServer(verbose=settings.verbose)
         run_func_server_port = run_func_server.start_server()
         put_data_into_kvstore(driver_ips[0], run_func_server_port,

--- a/horovod/runner/run_task.py
+++ b/horovod/runner/run_task.py
@@ -29,15 +29,20 @@ def _get_func(addrs, port, timeout=5):
             func = read_data_from_kvstore(addr, port, 'runfunc', 'func', timeout=timeout)
             return addr, func
         except RuntimeError as e:
+            # when there is only one addr in addrs, raise this error as is
+            # that was the behaviour before introducing multiple addrs
+            if len(addrs) == 1:
+                raise
+
             # when the RuntimeError is caused by an URLError, the addr is probably not reachable for us
             if len(e.args) >= 2 and isinstance(e.args[1], URLError):
                 # provide a warning when multiple addrs are provided on how to improve this situation
-                if len(addrs) > 1:
-                    print(f'Driver is not reachable at {addr} within {timeout} seconds. '
-                          f'Consider restricting the driver to some NICs, '
-                          f'which reduces the number of IPs probed here.')
+                print(f'Driver is not reachable at {addr} within {timeout} seconds. '
+                      f'Consider restricting the driver to some NICs, '
+                      f'which reduces the number of IPs probed here: {e}')
                 continue
-    raise ValueError(f'None of the provided IPs could be used to connect to driver''s KV store: {", ".join(addrs)}')
+
+    raise ValueError(f"None of the provided IPs could be used to connect to driver's KV store: {', '.join(addrs)}")
 
 
 def main(addrs, port):

--- a/horovod/runner/run_task.py
+++ b/horovod/runner/run_task.py
@@ -20,7 +20,7 @@ from horovod.runner.common.util.env import get_env_rank_and_size
 from horovod.runner.http.http_client import read_data_from_kvstore, put_data_into_kvstore
 
 
-def _get_func(addrs, port, timeout=5):
+def _get_func(addrs, port, timeout=None):
     # we try all provided addresses to connect to the kvstore
     # the first addr that works will be returned, together with the run func
     # we give each IP 5 seconds timeout, if that is not enough, the driver is not really well reachable
@@ -46,7 +46,7 @@ def _get_func(addrs, port, timeout=5):
 
 
 def main(addrs, port):
-    addr, func = _get_func(addrs, port)
+    addr, func = _get_func(addrs, port, 10 if len(addrs) > 1 else None)
     try:
         ret_val = func()
     except BaseException as e:

--- a/horovod/spark/gloo_run.py
+++ b/horovod/spark/gloo_run.py
@@ -99,4 +99,4 @@ def gloo_run_elastic(settings, driver, env, stdout=None, stderr=None):
     exec_command = _exec_command_fn(driver, settings.key, settings, env,
                                     stdout, stderr, settings.prefix_output_with_timestamp)
     rendezvous = SparkRendezvousServer(driver, settings.verbose)
-    launch_gloo_elastic(command, exec_command, settings, env, lambda _: nics, rendezvous)
+    launch_gloo_elastic(command, exec_command, settings, env, lambda _: nics, rendezvous, sys.executable)

--- a/horovod/spark/runner.py
+++ b/horovod/spark/runner.py
@@ -413,7 +413,7 @@ def run_elastic(fn, args=(), kwargs={}, num_proc=None, min_num_proc=None, max_nu
                                                     key=key,
                                                     start_timeout=tmout,
                                                     nics=nics,
-                                                    run_func_mode=True,
+                                                    run_func_mode=False,
                                                     prefix_output_with_timestamp=prefix_output_with_timestamp)
 
     result_queue = queue.Queue(1)

--- a/test/integration/elastic_spark_common.py
+++ b/test/integration/elastic_spark_common.py
@@ -354,6 +354,7 @@ class BaseElasticSparkTests(unittest.TestCase):
         super(BaseElasticSparkTests, self).__init__(*args, **kwargs)
         warnings.simplefilter('module')
         logging.getLogger('py4j.java_gateway').setLevel(logging.INFO)
+        logging.getLogger('py4j.clientserver').setLevel(logging.INFO)
 
     @staticmethod
     def _exec(cmd):

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -109,6 +109,42 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1)'
+  command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1)'
+  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -127,24 +127,6 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1)'
-  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.5.0:
-      run: test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -698,6 +698,42 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1)'
+  command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1)'
+  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -824,6 +860,42 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1)'
+  command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1)'
+  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -934,6 +1006,42 @@ steps:
     queue: 2x-gpu-v572
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
+  command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
+  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -1150,6 +1258,42 @@ steps:
     queue: 2x-gpu-v572
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
+  command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+  artifact_paths: "artifacts/**"
+  env:
+    COMPOSE_HTTP_TIMEOUT: 300
+  plugins:
+  - docker-compose#v3.5.0:
+      run: test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
+      volumes: "./artifacts:/artifacts"
+      config: docker-compose.test.yml
+      pull-retries: 3
+  - ecr#v1.2.0:
+      login: true
+  timeout_in_minutes: 10
+  retry:
+    automatic: true
+  agents:
+    queue: 2x-gpu-v572
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
+  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -716,24 +716,6 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1)'
-  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.5.0:
-      run: test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_6_5-keras2_6_0-torch1_9_1-mxnet1_7_0_p1-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -878,24 +860,6 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v572
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1)'
-  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.5.0:
-      run: test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v572
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_8_0_p0-pyspark3_2_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -1024,24 +988,6 @@ steps:
     queue: 2x-gpu-v572
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.5.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v572
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-gpu-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
-  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -1276,24 +1222,6 @@ steps:
     queue: 2x-gpu-v572
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.5.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v572
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic api (test-mixed-openmpi-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_9_1-pyspark3_2_1)'
-  command: python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py 2 2 2 localhost:2,127.0.0.1:2
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300

--- a/test/single/test_elastic_run.py
+++ b/test/single/test_elastic_run.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Uber Technologies, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import unittest
+from tempfile import NamedTemporaryFile
+
+import horovod
+from horovod.common.util import gloo_built
+from horovod.runner.common.util.env import get_env_rank_and_size
+
+
+def train():
+    return get_env_rank_and_size()
+
+
+@unittest.skipIf(not gloo_built(), "Gloo is not available")
+class ElasticRunTests(unittest.TestCase):
+    """
+    Tests for run api with elastic config.
+    """
+
+    def test_run_with_hosts(self):
+        """Tests two usable hosts, two slots each in standard happy path."""
+        hosts = 'localhost:2,127.0.0.1:2'
+        results = horovod.run(train, num_proc=2, min_num_proc=2, max_num_proc=2, hosts=hosts)
+        self.assertEqual([(0, 2), (1, 2)], results)
+
+    def test_run_with_discovery_script(self):
+        """Tests two usable hosts, two slots each via discovery script in standard happy path."""
+        with NamedTemporaryFile(mode='w') as script:
+            script.write('echo "localhost:2"\n')
+            script.write('echo "127.0.0.1:2"\n')
+            script.file.close()
+            os.chmod(script.name, 0o700)
+
+            results = horovod.run(train, num_proc=2, min_num_proc=2, max_num_proc=2, host_discovery_script=script.name)
+
+        self.assertEqual([(0, 2), (1, 2)], results)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently, the elastic training mode can only be used through `horovodrun` and not the existing `horovod.run` API.

This allows to run `horovod.run` with `min_num_proc` or `host_discovery_script` set to run a `func` in elastic  mode.