### PR TITLE
clear locally accumulated gradient by assigning with zeros_like to avoid infinite gradient not correctly cleared up

### DIFF
--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -119,8 +119,8 @@ class LocalGradientAggregationHelperEager:
     def _clear_vars(self):
         self.counter.assign(0)
         for idx in self.locally_aggregated_grads.keys():
-            self.locally_aggregated_grads[idx].assign_add(
-                -1 * self.locally_aggregated_grads[idx])
+            self.locally_aggregated_grads[idx].assign(
+                tf.zeros_like(self.locally_aggregated_grads[idx]))
 
     def apply_gradients(self, apply_grads_closure, optimizer, *args, **kwargs):
         def increment_optimizer_iteration():


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3504

When clearing the locally aggregated/added gradient, we should rather assign with `tf.zeros_like`, because substracting by the local aggregated value doesn't work for infinite gradients.

Added a unit test for this. Without the change it'll fail.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
