### PR TITLE
Rework network interfaces args in horovod.run and horovodrun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - MXNet: Deprecated `average` argument of allreduce functions. ([#3299](https://github.com/horovod/horovod/pull/3299))
 
+- Horovodrun: Providing multiple NICS as comma-separated string via `--network-interface` is deprecated,
+  use `--network-interface` multiple times or `--network-interfaces` instead. ([#3506](https://github.com/horovod/horovod/pull/3506))
+
+- horovod.run: Argument `network_interface` with comma-separated string is deprecated,
+  use `network_interfaces` with `Iterable[str]` instead. ([#3506](https://github.com/horovod/horovod/pull/3506))
+
 ### Removed
 
 ### Fixed

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -112,7 +112,9 @@ def run(
         use_gloo=None,
         use_mpi=None,
         mpi_args=None,
+        # network_interface is deprecated, use network_interfaces instead
         network_interface=None,
+        network_interfaces=None,
         executable=None,
         # np is deprecated, use num_proc instead
         np=None,
@@ -174,13 +176,16 @@ def run(
     :param use_mpi: Run Horovod using the MPI controller. This will
                     be the default if Horovod was built with MPI support.
     :param mpi_args: Extra arguments for the MPI controller. This is only used when use_mpi is True.
-    :param network_interface: Network interfaces to use for communication separated by comma. If
-                             not specified, Horovod will find the common NICs among all the
-                             workers and use those; example, eth0,eth1.
+    :param network_interfaces: List of network interfaces to use for communication. If not specified,
+                               Horovod will find the common NICs among all the workers and use those.
+                               Example: ["eth0", "eth1"].
     :param executable: Optional executable to run when launching the workers. Defaults to `sys.executable`.
     :return: Return a list which contains values return by all Horovod processes.
              The index of the list corresponds to the rank of each Horovod process.
     """
+    if network_interface:
+        network_interfaces = network_interface.split(',')
+        warnings.warn('network_interface is deprecated, use network_interfaces instead', DeprecationWarning)
     if np is not None:
         num_proc = np
         warnings.warn('np is deprecated, use num_proc instead', DeprecationWarning)
@@ -224,7 +229,7 @@ def run(
     hargs.verbose = verbose
     hargs.use_gloo = use_gloo
     hargs.use_mpi = use_mpi
-    hargs.nics = network_interface
+    hargs.nics = set(network_interfaces) if network_interfaces else None
     hargs.run_func = wrapped_func
     hargs.executable = executable
 

--- a/horovod/runner/__init__.py
+++ b/horovod/runner/__init__.py
@@ -177,7 +177,7 @@ def run(
                     be the default if Horovod was built with MPI support.
     :param mpi_args: Extra arguments for the MPI controller. This is only used when use_mpi is True.
     :param network_interfaces: List of network interfaces to use for communication. If not specified,
-                               Horovod will find the common NICs among all the workers and use those.
+                               Horovod will find the common NICs among all the workers.
                                Example: ["eth0", "eth1"].
     :param executable: Optional executable to run when launching the workers. Defaults to `sys.executable`.
     :return: Return a list which contains values return by all Horovod processes.

--- a/horovod/runner/common/util/settings.py
+++ b/horovod/runner/common/util/settings.py
@@ -42,7 +42,7 @@ class BaseSettings(object):
         :param run_func_mode: whether it is run function mode
         :type run_func_mode: boolean
         :param nics: specify the NICs to be used for tcp network communication.
-        :type nics: string
+        :type nics: Iterable[str]
         :param elastic: enable elastic auto-scaling and fault tolerance mode
         :type elastic: boolean
         :param prefix_output_with_timestamp: shows timestamp in stdout/stderr forwarding on the driver

--- a/horovod/runner/launch.py
+++ b/horovod/runner/launch.py
@@ -319,14 +319,14 @@ def parse_args():
     parser.add_argument('--network-interfaces', action=make_nic_action(deprecated=False), dest='nics',
                         help='Network interfaces that can be used for communication separated by '
                              'comma. If not specified, Horovod will find the common NICs among all '
-                             'the workers and use it. Also see --network-interface. '
+                             'the workers. Also see --network-interface. '
                              'Example: --network-interfaces "eth0,eth1".')
 
     # once deprecated use of --network-interface is removed, replace action=NicAction with action='append'
     parser.add_argument('--network-interface', action=make_nic_action(deprecated=True), dest='nics',
                         help='Network interface that can be used for communication. Use multiple times '
                              'to configure multiple interfaces. If not specified, Horovod will find the'
-                             'common NICs among all the workers and use it. Also see --network-interfaces. '
+                             'common NICs among all the workers. Also see --network-interfaces. '
                              'Example: --network-interface eth0 --network-interface eth1')
 
     parser.add_argument('--output-filename', action='store',


### PR DESCRIPTION
Reworks network interfaces arguments in two places: the `horovod.run` API and the `horovodrun` CLI:

The `horovod.run` API deprecates `network_interface` argument in favour of `network_interfaces`, which becomes a list of strings, rather than a comma separated string that is to be split.

The `horovodrun` CLI replaces `--network-interface` with semantically more accurate `--network-interfaces`, which still takes a comma separated string of network interfaces, but also provides the new `--network-interface` argument, that semantically correctly expects a single network interface. That argument can be used multiple times to set multiple NICs.

Arguably, `--network-interfaces` could be removed completely, as `--network-interface` allows to specify multiple NICs. Unless, there is any use of comma separated strings.