### PR TITLE
Avoid redundant ptx generation for maximum specififed compute capability

### DIFF
--- a/cmake/build_utils.py
+++ b/cmake/build_utils.py
@@ -109,9 +109,10 @@ def get_nvcc_flags():
 
     # Build native kernels for specified compute capabilities
     cc_list = full_cc_list if cc_list_env is None else [int(x) for x in cc_list_env.split(',')]
-    for cc in cc_list:
-      default_flags += ['-gencode', 'arch=compute_{cc},code=sm_{cc}'.format(cc=cc)]
+    cc_list = sorted(cc_list)
+    for cc in cc_list[:-1]:
+        default_flags += ['-gencode', 'arch=compute_{cc},code=sm_{cc}'.format(cc=cc)]
     # Build PTX for maximum specified compute capability
-    default_flags += ['-gencode', 'arch=compute_{cc},code=compute_{cc}'.format(cc=max(cc_list))]
+    default_flags += ['-gencode', 'arch=compute_{cc},code=\\"sm_{cc},compute_{cc}\\"'.format(cc=cc_list[-1])]
 
     return default_flags


### PR DESCRIPTION
Use 
```
-gencode=arch=compute_xy,code=\"sm_xy,compute_xy\"
```
instead of
```
-gencode=arch=compute_xy,code=compute_xy
-gencode=arch=compute_xy,code=sm_xy
```
for the highest arch, which avoids generating ptx a second time. This slightly improves nvcc compilation time.