### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   debug:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Debug Action

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ concurrency:
 
 jobs:
   debug:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: Debug Action
@@ -47,6 +49,8 @@ jobs:
       run: echo "ci-${{ github.event_name }}-${{ github.ref }}-${{ github.head_ref || github.sha }}"
 
   event_file:
+    permissions:
+      contents: none
     name: "Event File"
     runs-on: ubuntu-latest
     steps:
@@ -3736,6 +3740,8 @@ jobs:
           exit 1
 
   docker-config:
+    permissions:
+      contents: none
     name: Configure docker build
     needs: [init-workflow, build-and-test, buildkite]
     # build-and-test and buildkite might have been skipped (! needs.init-workflow.outputs.run-builds-and-tests)

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
