### PR TITLE
Add an option to pin to gpu for all estimators

### DIFF
--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -29,6 +29,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Extract ubuntu distribution version and download the corresponding key.
+# This is to fix CI failures caused by the new rotating key mechanism rolled out by Nvidia.
+# Refer to https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771 for more details.
+RUN DIST=$(echo ${CUDA_DOCKER_VERSION#*ubuntu} | sed 's/\.//'); \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${DIST}/x86_64/3bf863cc.pub && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu${DIST}/x86_64/7fa2af80.pub
+
 # Prepare to install specific g++ versions
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/docker/horovod-ray/Dockerfile
+++ b/docker/horovod-ray/Dockerfile
@@ -16,6 +16,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Download the corresponding key for ubuntu1804.
+# This is to fix CI failures caused by the new rotating key mechanism rolled out by Nvidia.
+# Refer to https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771 for more details.
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+RUN sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
         build-essential \
         cmake \

--- a/docker/horovod/Dockerfile
+++ b/docker/horovod/Dockerfile
@@ -24,6 +24,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+# Extract ubuntu distribution version and download the corresponding key.
+# This is to fix CI failures caused by the new rotating key mechanism rolled out by Nvidia.
+# Refer to https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771 for more details.
+RUN DIST=$(echo ${CUDA_DOCKER_VERSION#*ubuntu} | sed 's/\.//'); \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${DIST}/x86_64/3bf863cc.pub && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu${DIST}/x86_64/7fa2af80.pub
+
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \
         cmake \

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -96,6 +96,14 @@ class EstimatorParams(Params):
 
     label_shapes = Param(Params._dummy(), 'label_shapes', 'specifies the shape (or shapes) of the label column (or columns)')
 
+    inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
+                               'Cache the data in memory for training and validation.',
+                               typeConverter=TypeConverters.toBoolean)
+
+    pin_gpu = Param(Params._dummy(), 'pin_gpu',
+                               'Whether to pin the traininig process to the GPU. Defaults to True.',
+                               typeConverter=TypeConverters.toBoolean)
+
     def __init__(self):
         super(EstimatorParams, self).__init__()
 
@@ -129,7 +137,9 @@ class EstimatorParams(Params):
             train_reader_num_workers=2,
             val_reader_num_workers=2,
             reader_pool_type='process',
-            label_shapes=None)
+            label_shapes=None,
+            inmemory_cache_all=False,
+            pin_gpu=True)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -334,6 +344,17 @@ class EstimatorParams(Params):
     def getLabelShapes(self):
         return self.getOrDefault(self.label_shapes)
 
+    def setInMemoryCacheAll(self, value):
+        return self._set(inmemory_cache_all=value)
+
+    def getInMemoryCacheAll(self):
+        return self.getOrDefault(self.inmemory_cache_all)
+
+    def setPinGpu(self, value):
+        self._set(pin_gpu=value)
+
+    def getPinGpu(self):
+        return self.getOrDefault(self.pin_gpu)
 
 class ModelParams(HasOutputCols):
     history = Param(Params._dummy(), 'history', 'history')

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -100,9 +100,9 @@ class EstimatorParams(Params):
                                'Cache the data in memory for training and validation.',
                                typeConverter=TypeConverters.toBoolean)
 
-    pin_gpu = Param(Params._dummy(), 'pin_gpu',
-                    'Whether to pin the traininig process to the GPU. '
-                    'Setting this to False will skipping binding to GPU even when GPU is available.'
+    use_gpu = Param(Params._dummy(), 'use_gpu',
+                    'Whether to use the GPU for training. '
+                    'Setting this to False will skipping binding to GPU even when GPU is available. '
                     'Defaults to True.',
                     typeConverter=TypeConverters.toBoolean)
 
@@ -141,7 +141,7 @@ class EstimatorParams(Params):
             reader_pool_type='process',
             label_shapes=None,
             inmemory_cache_all=False,
-            pin_gpu=True)
+            use_gpu=True)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -352,11 +352,11 @@ class EstimatorParams(Params):
     def getInMemoryCacheAll(self):
         return self.getOrDefault(self.inmemory_cache_all)
 
-    def setPinGpu(self, value):
-        self._set(pin_gpu=value)
+    def setUseGpu(self, value):
+        self._set(use_gpu=value)
 
-    def getPinGpu(self):
-        return self.getOrDefault(self.pin_gpu)
+    def getUseGpu(self):
+        return self.getOrDefault(self.use_gpu)
 
 class ModelParams(HasOutputCols):
     history = Param(Params._dummy(), 'history', 'history')

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -101,8 +101,10 @@ class EstimatorParams(Params):
                                typeConverter=TypeConverters.toBoolean)
 
     pin_gpu = Param(Params._dummy(), 'pin_gpu',
-                               'Whether to pin the traininig process to the GPU. Defaults to True.',
-                               typeConverter=TypeConverters.toBoolean)
+                    'Whether to pin the traininig process to the GPU. '
+                    'Setting this to False will skipping binding to GPU even when GPU is available.'
+                    'Defaults to True.',
+                    typeConverter=TypeConverters.toBoolean)
 
     def __init__(self):
         super(EstimatorParams, self).__init__()

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -147,7 +147,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         inmemory_cache_all: boolean value. Cache the data in memory for training and validation. Default: False.
         backend_env: dict to add to the environment of the backend.  Defaults to setting the java heap size to
                      2G min and max for libhdfs through petastorm
-        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
+        use_gpu: Whether to use the GPU for training. Defaults to True.
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -191,7 +191,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  checkpoint_callback=None,
                  inmemory_cache_all=False,
                  backend_env=None,
-                 pin_gpu=True):
+                 use_gpu=True):
 
         super(KerasEstimator, self).__init__()
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -147,6 +147,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         inmemory_cache_all: boolean value. Cache the data in memory for training and validation. Default: False.
         backend_env: dict to add to the environment of the backend.  Defaults to setting the java heap size to
                      2G min and max for libhdfs through petastorm
+        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -157,6 +158,9 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                                typeConverter=TypeConverters.toBoolean)
     backend_env = Param(Params._dummy(), "backend_env",
                         "dict to add to the environment of the command run on the environment")
+    pin_gpu = Param(Params._dummy(), 'pin_gpu',
+                               'Whether to pin the traininig process to the GPU.',
+                               typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self,
@@ -192,7 +196,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  label_shapes=None,
                  checkpoint_callback=None,
                  inmemory_cache_all=False,
-                 backend_env=None):
+                 backend_env=None,
+                 pin_gpu=True):
 
         super(KerasEstimator, self).__init__()
 
@@ -200,7 +205,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                          custom_objects={},
                          checkpoint_callback=None,
                          inmemory_cache_all=False,
-                         backend_env={'LIBHDFS_OPTS': '-Xms2048m -Xmx2048m'})
+                         backend_env={'LIBHDFS_OPTS': '-Xms2048m -Xmx2048m'},
+                         pin_gpu=True)
 
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
@@ -246,6 +252,12 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
 
     def getBackendEnv(self):
         return self.getOrDefault(self.backend_env)
+
+    def setPinGpu(self, value):
+        self._set(pin_gpu=value)
+
+    def getPinGpu(self):
+        return self.getOrDefault(self.pin_gpu)
 
     def _check_metadata_compatibility(self, metadata):
         input_shapes, output_shapes = self.get_model_shapes()

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -153,14 +153,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
     checkpoint_callback = Param(Params._dummy(), 'checkpoint_callback',
                                 'model checkpointing callback')
-    inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
-                               'Cache the data in memory for training and validation.',
-                               typeConverter=TypeConverters.toBoolean)
     backend_env = Param(Params._dummy(), "backend_env",
                         "dict to add to the environment of the command run on the environment")
-    pin_gpu = Param(Params._dummy(), 'pin_gpu',
-                               'Whether to pin the traininig process to the GPU.',
-                               typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self,
@@ -204,9 +198,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         self._setDefault(optimizer=None,
                          custom_objects={},
                          checkpoint_callback=None,
-                         inmemory_cache_all=False,
-                         backend_env={'LIBHDFS_OPTS': '-Xms2048m -Xmx2048m'},
-                         pin_gpu=True)
+                         backend_env={'LIBHDFS_OPTS': '-Xms2048m -Xmx2048m'})
 
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
@@ -241,23 +233,11 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
     def getCheckpointCallback(self):
         return self.getOrDefault(self.checkpoint_callback)
 
-    def setInMemoryCacheAll(self, value):
-        return self._set(inmemory_cache_all=value)
-
-    def getInMemoryCacheAll(self):
-        return self.getOrDefault(self.inmemory_cache_all)
-
     def setBackendEnv(self, value):
         self._set(backend_env=value)
 
     def getBackendEnv(self):
         return self.getOrDefault(self.backend_env)
-
-    def setPinGpu(self, value):
-        self._set(pin_gpu=value)
-
-    def getPinGpu(self):
-        return self.getOrDefault(self.pin_gpu)
 
     def _check_metadata_compatibility(self, metadata):
         input_shapes, output_shapes = self.get_model_shapes()

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -52,6 +52,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     user_verbose = estimator.getVerbose()
     checkpoint_callback = estimator.getCheckpointCallback()
     inmemory_cache_all = estimator.getInMemoryCacheAll()
+    should_pin_gpu = estimator.getPinGpu()
 
     # Data reader parameters
     train_reader_worker_count = estimator.getTrainReaderNumWorker()
@@ -111,7 +112,16 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
         hvd = get_horovod()
         hvd.init()
 
-        pin_gpu(hvd, tf, k)
+        # Verbose mode 1 will print a progress bar
+        verbose = user_verbose if hvd.rank() == 0 else 0
+
+        if should_pin_gpu:
+            if verbose:
+                print(f"Pinning current process to the GPU.")
+            pin_gpu(hvd, tf, k)
+        else:
+            if verbose:
+                print(f"Skip pinning current process to the GPU.")
 
         if random_seed is not None:
             if LooseVersion(tf.__version__) < LooseVersion('2.0.0'):
@@ -137,8 +147,6 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
         scaled_lr = k.backend.get_value(model.optimizer.lr) * hvd.size()
         k.backend.set_value(model.optimizer.lr, scaled_lr)
 
-        # Verbose mode 1 will print a progress bar
-        verbose = user_verbose if hvd.rank() == 0 else 0
 
         if verbose:
             print(f"Shared lib path is pointing to: {_horovod.common.process_sets._basics.MPI_LIB_CTYPES}")

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -52,7 +52,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     user_verbose = estimator.getVerbose()
     checkpoint_callback = estimator.getCheckpointCallback()
     inmemory_cache_all = estimator.getInMemoryCacheAll()
-    should_pin_gpu = estimator.getPinGpu()
+    should_use_gpu = estimator.getUseGpu()
 
     # Data reader parameters
     train_reader_worker_count = estimator.getTrainReaderNumWorker()
@@ -115,7 +115,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
         # Verbose mode 1 will print a progress bar
         verbose = user_verbose if hvd.rank() == 0 else 0
 
-        if should_pin_gpu:
+        if should_use_gpu:
             if verbose:
                 print("Pinning current process to the GPU.")
             pin_gpu(hvd, tf, k)

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -117,11 +117,11 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
 
         if should_pin_gpu:
             if verbose:
-                print(f"Pinning current process to the GPU.")
+                print("Pinning current process to the GPU.")
             pin_gpu(hvd, tf, k)
         else:
             if verbose:
-                print(f"Skip pinning current process to the GPU.")
+                print("Skip pinning current process to the GPU.")
 
         if random_seed is not None:
             if LooseVersion(tf.__version__) < LooseVersion('2.0.0'):

--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -181,6 +181,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         debug_data_loader: (Optional)Debugging flag for data loader.
         train_async_data_loader_queue_size: (Optional) Size of train async data loader queue.
         val_async_data_loader_queue_size: (Optional) Size of val async data loader queue.
+        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -220,6 +221,10 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
     train_async_data_loader_queue_size = Param(Params._dummy(), 'train_async_data_loader_queue_size', 'Size of train async data loader queue.')
 
     val_async_data_loader_queue_size = Param(Params._dummy(), 'val_async_data_loader_queue_size', 'Size of val async data loader queue.')
+
+    pin_gpu = Param(Params._dummy(), 'pin_gpu',
+                               'Whether to pin the traininig process to the GPU.',
+                               typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self,
@@ -266,7 +271,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  profiler=None,
                  debug_data_loader=False,
                  train_async_data_loader_queue_size=None,
-                 val_async_data_loader_queue_size=None):
+                 val_async_data_loader_queue_size=None,
+                 pin_gpu=True):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,
@@ -284,7 +290,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                          trainer_args=None,
                          debug_data_loader=False,
                          train_async_data_loader_queue_size=None,
-                         val_async_data_loader_queue_size=None)
+                         val_async_data_loader_queue_size=None,
+                         pin_gpu=True)
 
         kwargs = self._input_kwargs
 
@@ -386,6 +393,12 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getValAsyncDataLoaderQueueSize(self):
         return self.getOrDefault(self.val_async_data_loader_queue_size)
+
+    def setPinGpu(self, value):
+        return self._set(pin_gpu=value)
+
+    def getPinGpu(self):
+        return self.getOrDefault(self.pin_gpu)
 
     # Overwrites Model's getOptimizer method
     def getOptimizer(self):

--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -190,10 +190,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
     train_minibatch_fn = Param(Params._dummy(), 'train_minibatch_fn',
                                'functions that construct the minibatch train function for torch')
 
-    inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
-                               'Cache the data in memory for training and validation.',
-                               typeConverter=TypeConverters.toBoolean)
-
     num_gpus = Param(Params._dummy(), 'num_gpus',
                      'Number of gpus per process, default to 1 when CUDA is available in the backend, otherwise 0.')
 
@@ -221,10 +217,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
     train_async_data_loader_queue_size = Param(Params._dummy(), 'train_async_data_loader_queue_size', 'Size of train async data loader queue.')
 
     val_async_data_loader_queue_size = Param(Params._dummy(), 'val_async_data_loader_queue_size', 'Size of val async data loader queue.')
-
-    pin_gpu = Param(Params._dummy(), 'pin_gpu',
-                               'Whether to pin the traininig process to the GPU.',
-                               typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self,
@@ -279,7 +271,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                          input_shapes=None,
                          train_minibatch_fn=None,
                          transformation_fn=None,
-                         inmemory_cache_all=False,
                          num_gpus=None,
                          logger=None,
                          log_every_n_steps=50,
@@ -290,8 +281,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                          trainer_args=None,
                          debug_data_loader=False,
                          train_async_data_loader_queue_size=None,
-                         val_async_data_loader_queue_size=None,
-                         pin_gpu=True)
+                         val_async_data_loader_queue_size=None)
 
         kwargs = self._input_kwargs
 
@@ -321,12 +311,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getLossConstructors(self):
         return self.getOrDefault(self.loss_constructors)
-
-    def setInMemoryCacheAll(self, value):
-        return self._set(inmemory_cache_all=value)
-
-    def getInMemoryCacheAll(self):
-        return self.getOrDefault(self.inmemory_cache_all)
 
     def setNumGPUs(self, value):
         return self._set(num_gpus=value)
@@ -393,12 +377,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getValAsyncDataLoaderQueueSize(self):
         return self.getOrDefault(self.val_async_data_loader_queue_size)
-
-    def setPinGpu(self, value):
-        return self._set(pin_gpu=value)
-
-    def getPinGpu(self):
-        return self.getOrDefault(self.pin_gpu)
 
     # Overwrites Model's getOptimizer method
     def getOptimizer(self):

--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -181,7 +181,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         debug_data_loader: (Optional)Debugging flag for data loader.
         train_async_data_loader_queue_size: (Optional) Size of train async data loader queue.
         val_async_data_loader_queue_size: (Optional) Size of val async data loader queue.
-        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
+        use_gpu: Whether to use the GPU for training. Defaults to True.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -264,7 +264,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  debug_data_loader=False,
                  train_async_data_loader_queue_size=None,
                  val_async_data_loader_queue_size=None,
-                 pin_gpu=True):
+                 use_gpu=True):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -64,7 +64,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
     debug_data_loader = estimator.getDebugDataLoader()
     train_async_data_loader_queue_size = estimator.getTrainAsyncDataLoaderQueueSize()
     val_async_data_loader_queue_size = estimator.getValAsyncDataLoaderQueueSize()
-    should_pin_gpu = estimator.getPinGpu()
+    should_use_gpu = estimator.getUseGpu()
 
     # get logger
     logger = estimator.getLogger()
@@ -195,13 +195,13 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                       f"Val rows: {val_rows}, Val batch size: {val_batch_size}, Val_steps_per_epoch: {_val_steps_per_epoch}\n"
                       f"Checkpoint file: {remote_store.checkpoint_path}, Logs dir: {remote_store.logs_path}\n")
 
-            if not should_pin_gpu and verbose:
+            if not should_use_gpu and verbose:
                 print("Skip pinning current process to the GPU.")
 
             cuda_available = torch.cuda.is_available()
 
-            if cuda_available and not should_pin_gpu:
-                print("GPU is available but pin_gpu is set to False."
+            if cuda_available and not should_use_gpu:
+                print("GPU is available but use_gpu is set to False."
                       "Training will proceed without GPU support.")
                 cuda_available = False
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -198,7 +198,13 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
             if not should_pin_gpu and verbose:
                 print("Skip pinning current process to the GPU.")
 
-            cuda_available = torch.cuda.is_available() and should_pin_gpu
+            cuda_available = torch.cuda.is_available()
+
+            if cuda_available and not should_pin_gpu:
+                print("GPU is available but pin_gpu is set to False."
+                      "Training will proceed without GPU support.")
+                cuda_available = False
+
             # We need to check all ranks have same device type for traning.
             # Horovod doesn't support heterogeneous allreduce for gradients.
             cuda_avail_list = hvd.allgather_object(cuda_available, name='device type')

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -64,6 +64,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
     debug_data_loader = estimator.getDebugDataLoader()
     train_async_data_loader_queue_size = estimator.getTrainAsyncDataLoaderQueueSize()
     val_async_data_loader_queue_size = estimator.getValAsyncDataLoaderQueueSize()
+    should_pin_gpu = estimator.getPinGpu()
 
     # get logger
     logger = estimator.getLogger()
@@ -194,7 +195,10 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
                       f"Val rows: {val_rows}, Val batch size: {val_batch_size}, Val_steps_per_epoch: {_val_steps_per_epoch}\n"
                       f"Checkpoint file: {remote_store.checkpoint_path}, Logs dir: {remote_store.logs_path}\n")
 
-            cuda_available = torch.cuda.is_available()
+            if not should_pin_gpu and verbose:
+                print("Skip pinning current process to the GPU.")
+
+            cuda_available = torch.cuda.is_available() and should_pin_gpu
             # We need to check all ranks have same device type for traning.
             # Horovod doesn't support heterogeneous allreduce for gradients.
             cuda_avail_list = hvd.allgather_object(cuda_available, name='device type')

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -147,6 +147,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         val_reader_num_workers: Similar to the train_reader_num_workers.
         reader_pool_type: Type of worker pool used to parallelize reading data from the dataset.
                           Should be one of ['thread', 'process']. Defaults to 'process'.
+        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -157,6 +158,9 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
                                'Cache the data in memory for training and validation.',
+                               typeConverter=TypeConverters.toBoolean)
+    pin_gpu = Param(Params._dummy(), 'pin_gpu',
+                               'Whether to pin the traininig process to the GPU.',
                                typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
@@ -193,14 +197,16 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  val_reader_num_workers=None,
                  reader_pool_type=None,
                  label_shapes=None,
-                 inmemory_cache_all=False):
+                 inmemory_cache_all=False,
+                 pin_gpu=True):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,
                          input_shapes=None,
                          train_minibatch_fn=None,
                          transformation_fn=None,
-                         inmemory_cache_all=False)
+                         inmemory_cache_all=False,
+                         pin_gpu=True)
 
         kwargs = self._input_kwargs
 
@@ -232,6 +238,12 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getInMemoryCacheAll(self):
         return self.getOrDefault(self.inmemory_cache_all)
+
+    def setPinGpu(self, value):
+        return self._set(pin_gpu=value)
+
+    def getPinGpu(self):
+        return self.getOrDefault(self.pin_gpu)
 
     def _get_optimizer(self):
         return self.getOrDefault(self.optimizer)

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -148,7 +148,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         reader_pool_type: Type of worker pool used to parallelize reading data from the dataset.
                           Should be one of ['thread', 'process']. Defaults to 'process'.
         inmemory_cache_all: (Optional) Cache the data in memory for training and validation.
-        pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
+        use_gpu: Whether to use the GPU for training. Defaults to True.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -192,7 +192,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  reader_pool_type=None,
                  label_shapes=None,
                  inmemory_cache_all=False,
-                 pin_gpu=True):
+                 use_gpu=True):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -147,6 +147,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         val_reader_num_workers: Similar to the train_reader_num_workers.
         reader_pool_type: Type of worker pool used to parallelize reading data from the dataset.
                           Should be one of ['thread', 'process']. Defaults to 'process'.
+        inmemory_cache_all: (Optional) Cache the data in memory for training and validation.
         pin_gpu: Whether to pin the traininig process to the GPU. Defaults to True.
     """
 
@@ -155,13 +156,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                               'functions that construct the loss')
     train_minibatch_fn = Param(Params._dummy(), 'train_minibatch_fn',
                                'functions that construct the minibatch train function for torch')
-
-    inmemory_cache_all = Param(Params._dummy(), 'inmemory_cache_all',
-                               'Cache the data in memory for training and validation.',
-                               typeConverter=TypeConverters.toBoolean)
-    pin_gpu = Param(Params._dummy(), 'pin_gpu',
-                               'Whether to pin the traininig process to the GPU.',
-                               typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self,
@@ -204,9 +198,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         self._setDefault(loss_constructors=None,
                          input_shapes=None,
                          train_minibatch_fn=None,
-                         transformation_fn=None,
-                         inmemory_cache_all=False,
-                         pin_gpu=True)
+                         transformation_fn=None)
 
         kwargs = self._input_kwargs
 
@@ -232,18 +224,6 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
 
     def getLossConstructors(self):
         return self.getOrDefault(self.loss_constructors)
-
-    def setInMemoryCacheAll(self, value):
-        return self._set(inmemory_cache_all=value)
-
-    def getInMemoryCacheAll(self):
-        return self.getOrDefault(self.inmemory_cache_all)
-
-    def setPinGpu(self, value):
-        return self._set(pin_gpu=value)
-
-    def getPinGpu(self):
-        return self.getOrDefault(self.pin_gpu)
 
     def _get_optimizer(self):
         return self.getOrDefault(self.optimizer)

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -139,6 +139,12 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
             print("Skip pinning current process to the GPU.")
 
         cuda_available = torch.cuda.is_available() and should_pin_gpu
+
+        if cuda_available and not should_pin_gpu:
+            print("GPU is available but pin_gpu is set to False."
+                    "Training will proceed without GPU support.")
+            cuda_available = False
+
         # We need to check all ranks have same device type for traning.
         # Horovod doesn't support heterogeneous allreduce for gradients.
         cuda_avail_list = hvd.allgather_object(cuda_available, name='device type')

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -60,7 +60,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
     transformation_fn = estimator.getTransformationFn()
     transformation = transformation_fn if transformation_fn else None
     inmemory_cache_all = estimator.getInMemoryCacheAll()
-    should_pin_gpu = estimator.getPinGpu()
+    should_use_gpu = estimator.getUseGpu()
 
     # If loss weight is not provided, use equal loss for all the labels
     loss_weights = estimator.getLossWeights()
@@ -135,14 +135,14 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
                 raise ValueError("user_shuffle_buffer_size cannot be negative!")
             shuffle_buffer_size = user_shuffle_buffer_size
 
-        if not should_pin_gpu and user_verbose:
+        if not should_use_gpu and user_verbose:
             print("Skip pinning current process to the GPU.")
 
-        cuda_available = torch.cuda.is_available() and should_pin_gpu
+        cuda_available = torch.cuda.is_available()
 
-        if cuda_available and not should_pin_gpu:
-            print("GPU is available but pin_gpu is set to False."
-                    "Training will proceed without GPU support.")
+        if cuda_available and not should_use_gpu:
+            print("GPU is available but use_gpu is set to False."
+                  "Training will proceed without GPU support.")
             cuda_available = False
 
         # We need to check all ranks have same device type for traning.

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -98,7 +98,10 @@ class SparkKerasTests(tf.test.TestCase):
                     batch_size=1,
                     random_seed=1,
                     epochs=3,
-                    verbose=2)
+                    verbose=2,
+                    pin_gpu=False)
+
+                assert not keras_estimator.getPinGpu()
 
                 keras_model = keras_estimator.fit(df)
 

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -99,9 +99,9 @@ class SparkKerasTests(tf.test.TestCase):
                     random_seed=1,
                     epochs=3,
                     verbose=2,
-                    pin_gpu=False)
+                    use_gpu=False)
 
-                assert not keras_estimator.getPinGpu()
+                assert not keras_estimator.getUseGpu()
 
                 keras_model = keras_estimator.fit(df)
 


### PR DESCRIPTION
Signed-off-by: TJ <tix@uber.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Sometimes the estimator can be created on a GPU host which initializes model weights on one device. Pinning to GPU again in remote trainer can have strange behaviors such as "Variable resource not found" error for Tensorflow since tf thinks the model weights were initialized on a different device.

Fixes # (issue).
https://github.com/horovod/horovod/issues/3524
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
