### PR TITLE
[Spark/Lightning]: Fix PTL Spark example with checkpoint usage

### DIFF
--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -66,6 +66,9 @@ from spark_common import CallbackBackend, create_noisy_xor_data, create_noisy_xo
 class XOR(pl.LightningModule):
     def __init__(self, input_dim=2, output_dim=1):
         super(XOR, self).__init__()
+        # The Lightning checkpoint also saves the arguments passed into the LightningModule init
+        # under the "hyper_parameters" key in the checkpoint.
+        self.save_hyperparameters()
         self.lin1 = nn.Linear(input_dim, 8)
         self.lin2 = nn.Linear(8, output_dim)
 


### PR DESCRIPTION
save_hyperparameters() should be called to save arguments passed into
the LightningModule init() function.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
