### PR TITLE
Split Buildkite job for better re-run

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -65,14 +65,16 @@ jobs:
           exit 1
         fi
 
-  buildkite:
-    name: "Build and Test GPU (on Builtkite)"
+  buildkite-trigger:
+    name: "Build and Test GPU (trigger Builtkite)"
     needs: [ci-workflow]
     runs-on: ubuntu-latest
     # only run if CI workflow's build-and-test job succeeded and CI workflow ran on a fork
     if: >
       needs.ci-workflow.outputs.build-and-test == 'success' &&
       github.event.workflow_run.head_repository.fork
+    outputs:
+      url: ${{ steps.build.outputs.url }}
     permissions:
       # steps "Create check status" and "Update check status"
       statuses: write
@@ -102,13 +104,19 @@ jobs:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU NON HEADS\"}"
 
+  buildkite:
+    name: "Build and Test GPU (download Builtkite)"
+    needs: [buildkite-trigger]
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Download Buildkite Artifacts
         id: download
         uses: EnricoMi/download-buildkite-artifact-action@v1
         with:
           github_token: ${{ github.token }}
           buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
-          buildkite_build_url: ${{ steps.buildkite.outputs.url }}
+          buildkite_build_url: ${{ needs.buildkite-trigger.outputs.url }}
           ignore_build_states: blocked,canceled,skipped,not_run
           ignore_job_states: timed_out
           output_path: artifacts/Unit Test Results - GPU NON HEADS on Builtkite
@@ -126,7 +134,7 @@ jobs:
           steps.download.conclusion == 'success' &&
           steps.download.outputs.build-state != 'passed'
         run: |
-          echo "::warning::Buildkite pipeline did not pass: ${{ steps.buildkite.outputs.url }}"
+          echo "::warning::Buildkite pipeline did not pass: ${{ needs.buildkite-trigger.outputs.url }}"
           exit 1
 
       - name: Update check status
@@ -144,14 +152,16 @@ jobs:
             \"target_url\": \"https://github.com/horovod/horovod/actions/runs/${GITHUB_RUN_ID}\"
           }"
 
-  buildkite-heads:
-    name: "Build and Test GPU heads (on Builtkite)"
+  buildkite-heads-trigger:
+    name: "Build and Test GPU heads (trigger Builtkite)"
     needs: [ci-workflow]
     runs-on: ubuntu-latest
     # only run if CI workflow's build-and-test job succeeded and CI workflow ran on a fork
     if: >
       needs.ci-workflow.outputs.build-and-test == 'success' &&
       github.event.workflow_run.head_repository.fork
+    outputs:
+      url: ${{ steps.build.outputs.url }}
     permissions:
       # steps "Create check status" and "Update check status"
       statuses: write
@@ -181,13 +191,19 @@ jobs:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU HEADS\"}"
 
+  buildkite-heads:
+    name: "Build and Test GPU heads (download Builtkite)"
+    needs: [buildkite-heads-trigger]
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Download Buildkite Artifacts
         id: download
         uses: EnricoMi/download-buildkite-artifact-action@v1
         with:
           github_token: ${{ github.token }}
           buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
-          buildkite_build_url: ${{ steps.buildkite.outputs.url }}
+          buildkite_build_url: ${{ needs.buildkite-heads-trigger.outputs.url }}
           ignore_build_states: blocked,canceled,skipped,not_run
           ignore_job_states: timed_out
           output_path: artifacts/Unit Test Results - GPU HEADS on Builtkite
@@ -205,7 +221,7 @@ jobs:
           steps.download.conclusion == 'success' &&
           steps.download.outputs.build-state != 'passed'
         run: |
-          echo "::warning::Buildkite pipeline did not pass: ${{ steps.buildkite.outputs.url }}"
+          echo "::warning::Buildkite pipeline did not pass: ${{ needs.buildkite-heads-trigger.outputs.url }}"
           exit 1
 
       - name: Update check status

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4363,8 +4363,8 @@ jobs:
             ${{ steps.test-1.outputs.artifacts-path }}
             ${{ steps.test-2.outputs.artifacts-path }}
             ${{ steps.test-3.outputs.artifacts-path }}
-  buildkite:
-    name: "Build and Test GPU (on Builtkite)"
+  buildkite-trigger:
+    name: "Build and Test GPU (trigger Builtkite)"
     needs: [init-workflow, build-and-test]
     runs-on: ubuntu-latest
     if: >
@@ -4372,6 +4372,8 @@ jobs:
       needs.init-workflow.outputs.run-at-all == 'true' &&
       needs.init-workflow.outputs.run-builds-and-tests == 'true' &&
       ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+    outputs:
+      url: ${{ steps.build.outputs.url }}
 
     steps:
       - name: Trigger Buildkite Pipeline
@@ -4386,12 +4388,18 @@ jobs:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU NON HEADS\"}"
 
+  buildkite:
+    name: "Build and Test GPU (download Builtkite)"
+    needs: [buildkite-trigger]
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Download Buildkite Artifacts
         id: download
         uses: EnricoMi/download-buildkite-artifact-action@v1
         with:
           buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
-          buildkite_build_url: ${{ steps.build.outputs.url }}
+          buildkite_build_url: ${{ needs.buildkite-trigger.outputs.url }}
           ignore_build_states: blocked,canceled,skipped,not_run
           ignore_job_states: timed_out
           output_path: artifacts/Unit Test Results - GPU NON HEADS on Builtkite
@@ -4409,11 +4417,11 @@ jobs:
           steps.download.conclusion == 'success' &&
           steps.download.outputs.build-state != 'passed'
         run: |
-          echo "::warning::Buildkite pipeline did not pass: ${{ steps.build.outputs.url }}"
+          echo "::warning::Buildkite pipeline did not pass: ${{ needs.buildkite-trigger.outputs.url }}"
           exit 1
 
-  buildkite-heads:
-    name: "Build and Test GPU heads (on Builtkite)"
+  buildkite-heads-trigger:
+    name: "Build and Test GPU heads (trigger Builtkite)"
     needs: [init-workflow, build-and-test]
     runs-on: ubuntu-latest
     if: >
@@ -4421,6 +4429,8 @@ jobs:
       needs.init-workflow.outputs.run-at-all == 'true' &&
       needs.init-workflow.outputs.run-builds-and-tests == 'true' &&
       ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
+    outputs:
+      url: ${{ steps.build.outputs.url }}
 
     steps:
       - name: Trigger Buildkite Pipeline
@@ -4435,12 +4445,18 @@ jobs:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILD_ENV_VARS: "{\"PIPELINE_MODE\": \"GPU HEADS\"}"
 
+  buildkite-heads:
+    name: "Build and Test GPU heads (download Builtkite)"
+    needs: [buildkite-heads-trigger]
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Download Buildkite Artifacts
         id: download
         uses: EnricoMi/download-buildkite-artifact-action@v1
         with:
           buildkite_token: ${{ secrets.BUILDKITE_TOKEN }}
-          buildkite_build_url: ${{ steps.build.outputs.url }}
+          buildkite_build_url: ${{ needs.buildkite-heads-trigger.outputs.url }}
           ignore_build_states: blocked,canceled,skipped,not_run
           ignore_job_states: timed_out
           output_path: artifacts/Unit Test Results - GPU HEADS on Builtkite
@@ -4458,7 +4474,7 @@ jobs:
           steps.download.conclusion == 'success' &&
           steps.download.outputs.build-state != 'passed'
         run: |
-          echo "::warning::Buildkite pipeline did not pass: ${{ steps.build.outputs.url }}"
+          echo "::warning::Buildkite pipeline did not pass: ${{ needs.buildkite-heads-trigger.outputs.url }}"
           exit 1
 
   docker-config:


### PR DESCRIPTION
This splits the job that triggers Buildkite CI and downloads results into two jobs:

![grafik](https://user-images.githubusercontent.com/44700269/171738642-47dbc576-eefe-4fa9-ab8b-5e9ba600edbc.png)

is split into trigger and download jobs:

![grafik](https://user-images.githubusercontent.com/44700269/171738511-65f81214-5970-4fa5-8872-d8cba48016c0.png)

In case of a download timeout or any other error while waiting for the results, rerunning the failed job does not rerun the CI but only downloads the results.

Example run (with reduced tests): https://github.com/horovod/horovod/actions/runs/2429186983/attempts/1
Re-run does not trigger a new CI: https://github.com/horovod/horovod/actions/runs/2429186983/attempts/2