### PR TITLE
Fix `CI (Results)` workflow

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -94,7 +94,7 @@ jobs:
           }"
 
       - name: Trigger Buildkite Pipeline
-        id: buildkite
+        id: build
         uses: EnricoMi/trigger-pipeline-action@master
         env:
           PIPELINE: "horovod/horovod"
@@ -181,7 +181,7 @@ jobs:
           }"
 
       - name: Trigger Buildkite Pipeline
-        id: buildkite
+        id: build
         uses: EnricoMi/trigger-pipeline-action@master
         env:
           PIPELINE: "horovod/horovod"


### PR DESCRIPTION
Downloading results from Buildkite broke in #3563 for `CI (Results)` workflow (not the main `CI` workflow). This fixes it.