### PR TITLE
Update docs and changelog for PR #3558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Spark/Lightning: add missing tranform_spec for Petastorm datamodule. ([#3543](https://github.com/horovod/horovod/pull/3543))
 
+- TensorFlow 2.9: Fix build for API change related to `tensorflow_accelerator_device_info`. ([#3513](https://github.com/horovod/horovod/pull/3513))
+
+- TensorFlow 2.10: Bump build partially to C++17. ([#3558](https://github.com/horovod/horovod/pull/3558))
+
 ## [v0.24.3] - 2022-04-21
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ To install Horovod on Linux or macOS:
     <p/>
 
 2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-5`` or above is installed.
+   Starting with TensorFlow 2.10 a C++17-compliant compiler like ``g++8`` or above will be required.
 
    If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-5`` or above is installed.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ Requirements
 
 - GNU Linux or macOS
 - Python >= 3.6
-- `g++-5` or above, or another compiler supporting C++14
+- ``g++-5`` or above, or another compiler supporting C++14
 - CMake 3.13 or newer
 - TensorFlow (>=1.15.0), PyTorch (>=1.5.0), or MXNet (>=1.4.1)
 - (Optional) MPI
@@ -17,7 +17,7 @@ For best performance on GPU:
 
 - `NCCL 2 <https://developer.nvidia.com/nccl>`__
 
-To install Horovod with TensorFlow 2.10 or later you will need a compiler that supports C++17 like `g++8` or newer.
+To install Horovod with TensorFlow 2.10 or later you will need a compiler that supports C++17 like ``g++8`` or newer.
 
 If Horovod cannot find CMake 3.13 or newer, the build script will attempt to pull in a recent CMake binary and run it
 from a temporary location.  To select a specific binary you can also set ``HOROVOD_CMAKE`` in your environment before

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,6 +17,8 @@ For best performance on GPU:
 
 - `NCCL 2 <https://developer.nvidia.com/nccl>`__
 
+To install Horovod with TensorFlow 2.10 or later you will need a compiler that supports C++17 like `g++8` or newer.
+
 If Horovod cannot find CMake 3.13 or newer, the build script will attempt to pull in a recent CMake binary and run it
 from a temporary location.  To select a specific binary you can also set ``HOROVOD_CMAKE`` in your environment before
 installing Horovod.

--- a/docs/summary.rst
+++ b/docs/summary.rst
@@ -116,6 +116,7 @@ To install Horovod on Linux or macOS:
     <p/>
 
 2. If you've installed TensorFlow from `PyPI <https://pypi.org/project/tensorflow>`__, make sure that ``g++-5`` or above is installed.
+   Starting with TensorFlow 2.10 a C++17-compliant compiler like ``g++8`` or above will be required.
 
    If you've installed PyTorch from `PyPI <https://pypi.org/project/torch>`__, make sure that ``g++-5`` or above is installed.
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Follow up for #3558 with new compiler requirements; also updating the changelog for #3513.

> 
> > Do we need to amend the documentation (where it mentions CMake dependency) and CHANGELOG.md?
> > 
> > We can do that in a follow up PR to avoid full CI cycles for these changes.
> 
> Good point! And I agree that it would be wise to do this in a separate PR.
> 
> CMake supports C++17 from version 3.8, so hopefully we should be good there with 3.13+. https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
> 
> `gcc` seems to support all features of C++17 starting with version 8. https://gcc.gnu.org/projects/cxx-status.html#cxx17
> 
> We could add a phrase then like: "To install Horovod with TensorFlow 2.10 or later you will need a compiler that supports C++17 like `g++8` or newer."
> 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
