### PR TITLE
Add NVTX op tracing for Reducescatter, make base class destructors virtual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `hvd.reducescatter()` operation with implementations in NCCL, MPI, and Gloo. ([#3299](https://github.com/horovod/horovod/pull/3299))
+- Added `hvd.reducescatter()` operation with implementations in NCCL, MPI, and Gloo. ([#3299](https://github.com/horovod/horovod/pull/3299), [#3574](https://github.com/horovod/horovod/pull/3574))
 
 - Spark: expose random seed as an optional parameter. ([#3517](https://github.com/horovod/horovod/pull/3517))
 

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -42,6 +42,8 @@ public:
 
   Controller(const Controller&) = delete;
 
+  virtual ~Controller() = default;
+
   void Initialize();
 
   virtual int GetTypeSize(DataType dtype) = 0;

--- a/horovod/common/mpi/mpi_controller.h
+++ b/horovod/common/mpi/mpi_controller.h
@@ -36,8 +36,6 @@ public:
     LOG(DEBUG) << "MPI Controller constructed.";
   }
 
-  virtual ~MPIController()=default;
-
   int GetTypeSize(DataType dtype) override;
 
   void CrossRankBitwiseAnd(std::vector<long long>& bitvector,

--- a/horovod/common/nvtx_op_range.cc
+++ b/horovod/common/nvtx_op_range.cc
@@ -14,6 +14,7 @@ NvtxOpsHandle::NvtxOpsHandle() noexcept
   REGISTER_STRING(HorovodAllgather);
   REGISTER_STRING(HorovodBroadcast);
   REGISTER_STRING(HorovodAlltoall);
+  REGISTER_STRING(HorovodReducescatter);
 #undef REGISTER_STRING
 }
 

--- a/horovod/common/nvtx_op_range.h
+++ b/horovod/common/nvtx_op_range.h
@@ -16,7 +16,8 @@ enum class RegisteredNvtxOp {
   HorovodBroadcast,
   HorovodAlltoall,
   HorovodReducescatter,
-  // Insert new enum values above this line
+  // Insert values for new ops above this line. Also add corresponding
+  // REGISTER_STRING lines in the constructor NvtxOpsHandle::NvtxOpsHandle().
   END,
 };
 

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -629,7 +629,7 @@ void BackgroundThreadLoop(HorovodGlobalState& state) {
       int id;
       GetProcessSetOrAddUnitialized(process_set_ranks, id);
     }
-    int32_t initialized_count;
+    int32_t initialized_count = 0;
 #if HAVE_MPI
     if (state.control_operation == LibType::MPI) {
       initialized_count =

--- a/horovod/common/ops/gloo_operations.h
+++ b/horovod/common/ops/gloo_operations.h
@@ -43,13 +43,13 @@ public:
                              std::vector<int>& recvcounts) = 0;
 
   virtual int ElementSize() const = 0;
+
+  virtual ~IGlooAlgorithms() = default;
 };
 
 template <typename T> class GlooAlgorithms : public IGlooAlgorithms {
 public:
   explicit GlooAlgorithms(GlooContext* gloo_context);
-
-  ~GlooAlgorithms() = default;
 
   void Allreduce(void* buffer_data, int num_elements) override;
 
@@ -73,8 +73,6 @@ private:
 class GlooAllreduce : public AllreduceOp {
 public:
   explicit GlooAllreduce(HorovodGlobalState* global_state);
-
-  virtual ~GlooAllreduce() = default;
 
   Status Execute(std::vector<TensorTableEntry>& entries,
                  const Response& response) override;


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

In #3299 I forgot to register the `"HorovodReducescatter"` string with NVTX to use it in named op ranges. This means that `Reducescatter` ops would appear as "[Unknown]" in Nsight Systems profiles.

Besides that change I've defined virtual destructors for two abstract polymorphic base classes. This should fix a warning that has been mentioned in https://github.com/horovod/horovod/pull/3541. Generally I think having them virtual is a safer practice, but currently there probably is no actual problem because smart pointers (`std::shared_ptr` or `std::unique_ptr`) are used rather than raw base class pointers.