### PR TITLE
Expose an parameter through all spark estimators to set start method for multiprocessing

### DIFF
--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -110,8 +110,9 @@ class EstimatorParams(Params):
                     'The start method of multiprocessing. '
                     'This controls the start up method of python multiprocessing. On unix-based systems, acceptable values are '
                     '["fork", "spawn", "forkserver"]. Only "Spawn" is accepted on Windows. '
-                    'If not set, multiprocessing will by default use "fork" on unix or "spawn" on Windows.'
-                    'Defaults to None.',
+                    'If not set, default values will be internally set by python, please refer to: '
+                    'https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_start_method.'
+                    'This param defaults to None.',
                     typeConverter=TypeConverters.toString)
 
     def __init__(self):

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -102,9 +102,17 @@ class EstimatorParams(Params):
 
     use_gpu = Param(Params._dummy(), 'use_gpu',
                     'Whether to use the GPU for training. '
-                    'Setting this to False will skipping binding to GPU even when GPU is available. '
+                    'Setting this to False will skip binding to GPU even when GPU is available. '
                     'Defaults to True.',
                     typeConverter=TypeConverters.toBoolean)
+
+    mp_start_method = Param(Params._dummy(), 'mp_start_method',
+                    'The start method of multiprocessing. '
+                    'This controls the start up method of python multiprocessing. On unix-based systems, acceptable values are '
+                    '["fork", "spawn", "forkserver"]. Only "Spawn" is accepted on Windows. '
+                    'If not set, multiprocessing will by default use "fork" on unix or "spawn" on Windows.'
+                    'Defaults to None.',
+                    typeConverter=TypeConverters.toString)
 
     def __init__(self):
         super(EstimatorParams, self).__init__()
@@ -141,7 +149,8 @@ class EstimatorParams(Params):
             reader_pool_type='process',
             label_shapes=None,
             inmemory_cache_all=False,
-            use_gpu=True)
+            use_gpu=True,
+            mp_start_method=None)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -357,6 +366,12 @@ class EstimatorParams(Params):
 
     def getUseGpu(self):
         return self.getOrDefault(self.use_gpu)
+
+    def setMpStartMethod(self, value):
+        self._set(mp_start_method=value)
+
+    def getMpStartMethod(self):
+        return self.getOrDefault(self.mp_start_method)
 
 class ModelParams(HasOutputCols):
     history = Param(Params._dummy(), 'history', 'history')

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -812,10 +812,12 @@ def get_spark_df_output_schema(input_df_schema, label_cols, output_cols, metadat
 
     return output_schema
 
-def _set_mp_start_method(method):
+def _set_mp_start_method(method, verbose):
     import multiprocessing as mp
     supported_values = mp.get_all_start_methods()
     if method not in supported_values:
         raise ValueError(f"Multiprocessing start method {method} is not supported on this system. "
                          f"Supported values are : {supported_values}")
     mp.set_start_method(method)
+    if verbose:
+        print(f'Multiprocessing start method has been set to {mp.get_start_method()}')

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -811,3 +811,11 @@ def get_spark_df_output_schema(input_df_schema, label_cols, output_cols, metadat
     output_schema = StructType(output_fields)
 
     return output_schema
+
+def _set_mp_start_method(method):
+    import multiprocessing as mp
+    supported_values = mp.get_all_start_methods()
+    if method not in supported_values:
+        raise ValueError(f"Multiprocessing start method {method} is not supported on this system. "
+                         f"Supported values are : {supported_values}")
+    mp.set_start_method(method)

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -148,6 +148,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         backend_env: dict to add to the environment of the backend.  Defaults to setting the java heap size to
                      2G min and max for libhdfs through petastorm
         use_gpu: Whether to use the GPU for training. Defaults to True.
+        mp_start_method: The method to use to start multiprocessing. Defaults to None.
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -191,7 +192,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  checkpoint_callback=None,
                  inmemory_cache_all=False,
                  backend_env=None,
-                 use_gpu=True):
+                 use_gpu=True,
+                 mp_start_method=None):
 
         super(KerasEstimator, self).__init__()
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -107,7 +107,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     def train(serialized_model, train_rows, val_rows, avg_row_size):
         # If not empty, set it before everything else.
         if mp_start_method:
-            _set_mp_start_method(mp_start_method)
+            _set_mp_start_method(mp_start_method, user_verbose)
 
         from petastorm import TransformSpec, make_reader, make_batch_reader
         import horovod as _horovod

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -25,7 +25,7 @@ from distutils.version import LooseVersion
 
 from horovod.spark.common import constants
 from horovod.spark.common.store import DBFSLocalStore
-from horovod.spark.common.util import _get_assigned_gpu_or_default
+from horovod.spark.common.util import _get_assigned_gpu_or_default, _set_mp_start_method
 from horovod.runner.common.util import codec
 
 
@@ -53,6 +53,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     checkpoint_callback = estimator.getCheckpointCallback()
     inmemory_cache_all = estimator.getInMemoryCacheAll()
     should_use_gpu = estimator.getUseGpu()
+    mp_start_method = estimator.getMpStartMethod()
 
     # Data reader parameters
     train_reader_worker_count = estimator.getTrainReaderNumWorker()
@@ -104,6 +105,10 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
         yield None
 
     def train(serialized_model, train_rows, val_rows, avg_row_size):
+        # If not empty, set it before everything else.
+        if mp_start_method:
+            _set_mp_start_method(mp_start_method)
+
         from petastorm import TransformSpec, make_reader, make_batch_reader
         import horovod as _horovod
         k = get_keras()

--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -182,6 +182,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         train_async_data_loader_queue_size: (Optional) Size of train async data loader queue.
         val_async_data_loader_queue_size: (Optional) Size of val async data loader queue.
         use_gpu: Whether to use the GPU for training. Defaults to True.
+        mp_start_method: The method to use to start multiprocessing. Defaults to None.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -264,7 +265,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  debug_data_loader=False,
                  train_async_data_loader_queue_size=None,
                  val_async_data_loader_queue_size=None,
-                 use_gpu=True):
+                 use_gpu=True,
+                 mp_start_method=None):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -104,7 +104,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
     def train(serialized_model):
         # If not empty, set it before everything else.
         if mp_start_method:
-            _set_mp_start_method(mp_start_method)
+            _set_mp_start_method(mp_start_method, verbose)
 
         import horovod.torch as hvd
 

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -149,6 +149,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                           Should be one of ['thread', 'process']. Defaults to 'process'.
         inmemory_cache_all: (Optional) Cache the data in memory for training and validation.
         use_gpu: Whether to use the GPU for training. Defaults to True.
+        mp_start_method: The method to use to start multiprocessing. Defaults to None.
     """
 
     input_shapes = Param(Params._dummy(), 'input_shapes', 'input layer shapes')
@@ -192,7 +193,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  reader_pool_type=None,
                  label_shapes=None,
                  inmemory_cache_all=False,
-                 use_gpu=True):
+                 use_gpu=True,
+                 mp_start_method=None):
 
         super(TorchEstimator, self).__init__()
         self._setDefault(loss_constructors=None,

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -104,7 +104,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
               train_rows, val_rows, avg_row_size):
         # If not empty, set it before everything else.
         if mp_start_method:
-            _set_mp_start_method(mp_start_method)
+            _set_mp_start_method(mp_start_method, user_verbose)
 
         from petastorm import TransformSpec, make_reader, make_batch_reader
         from petastorm.pytorch import BatchedDataLoader, InMemBatchedDataLoader

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -99,9 +99,14 @@ class SparkKerasTests(tf.test.TestCase):
                     random_seed=1,
                     epochs=3,
                     verbose=2,
-                    use_gpu=False)
+                    use_gpu=False,
+                    mp_start_method='spawn')
 
                 assert not keras_estimator.getUseGpu()
+                assert 'spawn' == keras_estimator.getMpStartMethod()
+
+                keras_estimator.setMpStartMethod('forkserver')
+                assert 'forkserver' == keras_estimator.getMpStartMethod()
 
                 keras_model = keras_estimator.fit(df)
 

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -154,7 +154,12 @@ class SparkLightningTests(unittest.TestCase):
                     batch_size=4,
                     epochs=2,
                     random_seed=1,
-                    verbose=2)
+                    verbose=2,
+                    mp_start_method='spawn')
+
+                assert 'spawn' == torch_estimator.getMpStartMethod()
+                torch_estimator.setMpStartMethod('forkserver')
+                assert 'forkserver' == torch_estimator.getMpStartMethod()
 
                 torch_model = torch_estimator.fit(df)
 


### PR DESCRIPTION
Expose an parameter through all spark estimators to set start method for multiprocessing.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This is to avoid resource leaks in situations where CUDA calls are made in multiprocessing environment. According to CUDA [guidelines](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-fork-managed-memory), calling CUDA kernels on pinned memory region in forked processes will lead to undefined behavior such as handles not being cleared. Some leaks persist even when the process terminates.
Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
