### PR TITLE
Remove std::regex use for better cxx11 abi compatibility

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -16,9 +16,9 @@
 // limitations under the License.
 // =============================================================================
 
+#include <algorithm>
 #include <memory>
 #include <queue>
-#include <regex>
 #include <thread>
 #include <unordered_map>
 
@@ -864,8 +864,9 @@ Output
 #if TENSORFLOW_VERSION >= 2006000000
 namespace {
 std::string NormalizeNameForTensorFlow(const std::string& name) {
-  static const std::regex normalize_re(R"regex([^a-zA-Z0-9_])regex");
-  return std::regex_replace(name, normalize_re, "_");
+  std::string result(name);
+  std::replace_if(result.begin(), result.end(), [](char c) { return !std::isalnum(c); }, '_');
+  return result;
 }
 
 Status GetInputDataTypeFromVariable(OpKernelContext* ctx, int input,


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Since TensorFlow has moved to `_GLIBCXX_USE_CXX11_ABI=1`, we have ran into some issues with Horovod related to the use of `std::regex` when we build TF/Horovod on manylinux2014. `HorovodBroadcastInplaceOp` was crashing when `std::regex` was used.

To fix the problem, I replaced the regex with something simpler which is probably also faster and more lightweight.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
