### PR TITLE
fix local_rank typo in TF 2 example

### DIFF
--- a/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
+++ b/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
@@ -84,7 +84,7 @@ def main():
             state.batch = start_batch + batch_idx
             loss_value = training_step(images, labels)
 
-            if state.batch % 10 == 0 and hvd.local_rank() == 0:
+            if state.batch % 10 == 0 and hvd.rank() == 0:
                 print('Step #%d\tLoss: %.6f' % (state.batch, loss_value))
 
             # Horovod: commit state at the end of each batch

--- a/examples/tensorflow/tensorflow_mnist_eager.py
+++ b/examples/tensorflow/tensorflow_mnist_eager.py
@@ -71,7 +71,7 @@ def main(_):
             hvd.broadcast_variables(mnist_model.variables, root_rank=0)
             hvd.broadcast_variables(opt.variables(), root_rank=0)
 
-        if batch % 10 == 0 and hvd.local_rank() == 0:
+        if batch % 10 == 0 and hvd.rank() == 0:
             print('Step #%d\tLoss: %.6f' % (batch, loss_value))
 
     # Horovod: save checkpoints only on worker 0 to prevent other workers from

--- a/examples/tensorflow2/tensorflow2_mnist.py
+++ b/examples/tensorflow2/tensorflow2_mnist.py
@@ -86,7 +86,7 @@ def main():
     for batch, (images, labels) in enumerate(dataset.take(10000 // hvd.size())):
         loss_value = training_step(images, labels, batch == 0)
 
-        if batch % 10 == 0 and hvd.local_rank() == 0:
+        if batch % 10 == 0 and hvd.rank() == 0:
             print('Step #%d\tLoss: %.6f' % (batch, loss_value))
 
     # Horovod: save checkpoints only on worker 0 to prevent other workers from


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

In `tensorflow_mnist.py` loss value was printed on every node (`local_rank == 0`) not only on global master process. I do not see any benefit from doing that. Moreover, it may confuse people why the printed loss values differ across nodes (I know loss values are not synchronized). 

I think it was simply a typo to use `local_rank == 0` instead of `rank() == 0`. If not, feel free to reject and close this PR.