### PR TITLE
Add hvd.grouped_allgather and hvd.grouped_reducescatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added support for batched memory copies in GPUAllgather. ([#3590](https://github.com/horovod/horovod/pull/3590))
-- Added support for batched memory copies in GPUReducescatter.
+- Added support for batched memory copies in GPUReducescatter. ([#3621](https://github.com/horovod/horovod/pull/3621))
+- Added `hvd.grouped_allgather()` and `hvd.grouped_reducescatter()` operations. ([#3594](https://github.com/horovod/horovod/pull/3594))
+- TensorFlow: Added doc string for `hvd.grouped_allreduce()`. ([#3594](https://github.com/horovod/horovod/pull/3594))
+- Added warning messages if output tensor memory allocations fail. ([#3594](https://github.com/horovod/horovod/pull/3594))
 
 ### Changed
 
@@ -19,8 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Updated Eigen submodule to fix build on macOS with aarch64.
-- Fix FuseResponses() on BATCHED_D2D_PADDING edge cases for Reducescatter and/or ROCm.
+- Updated Eigen submodule to fix build on macOS with aarch64. ([#3619](https://github.com/horovod/horovod/pull/3619))
+- Fix FuseResponses() on BATCHED_D2D_PADDING edge cases for Reducescatter and/or ROCm. ([#3621](https://github.com/horovod/horovod/pull/3621))
+- PyTorch: Fixed Reducescatter functions to raise `HorovodInternalError` rather than `RuntimeError`. ([#3594](https://github.com/horovod/horovod/pull/3594))
+- PyTorch on GPUs without GPU operations: Fixed grouped allreduce to set CPU device in tensor table. ([#3594](https://github.com/horovod/horovod/pull/3594))
 
 
 ## [v0.25.0] - 2022-06-20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=3,<4
 sphinxcontrib-napoleon
 alabaster
+jinja2<3.1
 nbsphinx
 pyyaml

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -364,6 +364,9 @@ struct TensorTableEntry {
   std::shared_ptr<Tensor> tensor;
   // Pre-allocated output tensor.
   std::shared_ptr<Tensor> output;
+  // Grouped Reducescatter or Allgather ops will need to allocate memory for
+  // a specific output_index >= 0.
+  int32_t output_index = 0;
   // Identifier for the subset of Horovod processes partaking in this operation.
   int32_t process_set_id = 0;
   // Root rank for broadcast operation (relative to process set).

--- a/horovod/common/nvtx_op_range.cc
+++ b/horovod/common/nvtx_op_range.cc
@@ -12,9 +12,11 @@ NvtxOpsHandle::NvtxOpsHandle() noexcept
   REGISTER_STRING(HorovodAllreduce);
   REGISTER_STRING(HorovodGroupedAllreduce);
   REGISTER_STRING(HorovodAllgather);
+  REGISTER_STRING(HorovodGroupedAllgather);
   REGISTER_STRING(HorovodBroadcast);
   REGISTER_STRING(HorovodAlltoall);
   REGISTER_STRING(HorovodReducescatter);
+  REGISTER_STRING(HorovodGroupedReducescatter);
 #undef REGISTER_STRING
 }
 

--- a/horovod/common/nvtx_op_range.h
+++ b/horovod/common/nvtx_op_range.h
@@ -13,9 +13,11 @@ enum class RegisteredNvtxOp {
   HorovodAllreduce = 0,
   HorovodGroupedAllreduce,
   HorovodAllgather,
+  HorovodGroupedAllgather,
   HorovodBroadcast,
   HorovodAlltoall,
   HorovodReducescatter,
+  HorovodGroupedReducescatter,
   // Insert values for new ops above this line. Also add corresponding
   // REGISTER_STRING lines in the constructor NvtxOpsHandle::NvtxOpsHandle().
   END,

--- a/horovod/common/operations.cc
+++ b/horovod/common/operations.cc
@@ -1534,6 +1534,32 @@ Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               ReadyEventList ready_event_list,
                               const std::string& name, const int device,
                               StatusCallback callback, int32_t process_set_id) {
+  // Wrap inputs in std::vector and pass onto multi tensor implementation
+  std::vector<std::shared_ptr<OpContext>> contexts;
+  std::vector<std::shared_ptr<Tensor>> tensors;
+  std::vector<ReadyEventList> ready_event_lists;
+  std::vector<std::string> names;
+  std::vector<StatusCallback> callbacks;
+
+  contexts.emplace_back(std::move(context));
+  tensors.emplace_back(std::move(tensor));
+  ready_event_lists.emplace_back(std::move(ready_event_list));
+  names.emplace_back(std::move(name));
+  callbacks.emplace_back(std::move(callback));
+
+  return EnqueueTensorAllgathers(contexts, tensors, ready_event_lists, names,
+                                 device, callbacks, process_set_id);
+}
+
+// Contexts and controller must be initialized and the background thread
+// must be running before this function is called.
+Status
+EnqueueTensorAllgathers(std::vector<std::shared_ptr<OpContext>>& contexts,
+                        std::vector<std::shared_ptr<Tensor>>& tensors,
+                        std::vector<ReadyEventList>& ready_event_lists,
+                        std::vector<std::string>& names, int device,
+                        std::vector<StatusCallback>& callbacks,
+                        int32_t process_set_id) {
   if (horovod_global.cpu_operation == LibType::CCL && process_set_id > 0 &&
       device == CPU_DEVICE_ID) {
     return Status::InvalidArgument(
@@ -1555,31 +1581,72 @@ Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
         " is not a member of the provided process set.");
   }
 
-  Request message;
-  message.set_request_rank(process_set.controller->GetRank());
-  message.set_tensor_name(name);
-  message.set_tensor_type(tensor->dtype());
-  message.set_device(device);
-  message.set_request_type(Request::ALLGATHER);
-  for (int i = 0; i < tensor->shape().dims(); ++i) {
-    message.add_tensor_shape((int64_t)tensor->shape().dim_size(i));
+  std::vector<Request> messages;
+  std::vector<TensorTableEntry> entries;
+  messages.reserve(tensors.size());
+  entries.reserve(tensors.size());
+
+  for (int n = 0; n < (int)tensors.size(); ++n) {
+    Request message;
+    message.set_request_rank(process_set.controller->GetRank());
+    message.set_tensor_name(names[n]);
+    message.set_tensor_type(tensors[n]->dtype());
+    message.set_device(device);
+    message.set_request_type(Request::ALLGATHER);
+    message.set_tensor_shape(tensors[n]->shape().to_vector());
+
+    messages.push_back(std::move(message));
+
+    TensorTableEntry e;
+    e.tensor_name = names[n];
+    e.context = contexts[n];
+    e.tensor = tensors[n];
+    e.output_index = n;
+    e.process_set_id = process_set_id;
+    e.ready_event_list = std::move(ready_event_lists[n]);
+    e.device = device;
+    e.callback = std::move(callbacks[n]);
+
+    entries.push_back(std::move(e));
   }
 
-  TensorTableEntry e;
-  e.tensor_name = name;
-  e.context = context;
-  e.tensor = tensor;
-  e.process_set_id = process_set_id;
-  e.ready_event_list = ready_event_list;
-  e.device = device;
-  e.callback = callback;
-  e.nvtx_op_range.Start(RegisteredNvtxOp::HorovodAllgather, e.tensor->size());
-
-  Status status = process_set.tensor_queue.AddToTensorQueue(e, message);
-  if (status.ok()) {
-    LOG(TRACE, horovod_global.global_controller->GetRank())
-        << "Enqueued " << name;
+  // Start appropriate NVTX range
+  if (tensors.size() == 1) {
+    auto& e = entries[0];
+    e.nvtx_op_range.Start(RegisteredNvtxOp::HorovodAllgather, e.tensor->size());
+  } else {
+    auto total_size =
+        std::accumulate(entries.begin(), entries.end(), 0ll,
+                        [](int64_t size_sum, const TensorTableEntry& e) {
+                          return size_sum + e.tensor->size();
+                        });
+    SharedNvtxOpRange range;
+    range.Start(RegisteredNvtxOp::HorovodGroupedAllgather, total_size);
+    for (auto& e : entries) {
+      e.nvtx_op_range = range;
+    }
   }
+
+  std::string tensors_enqueued;
+  for (const auto& n : names) {
+    tensors_enqueued += n + "; ";
+  }
+  LOG(TRACE, horovod_global.global_controller->GetRank())
+      << "Enqueued tensors for Allgather: " << tensors_enqueued;
+
+  // Only create groups larger than 1 tensor, unless disable_group_fusion is
+  // requested. In that case, even single tensor groups are created to enforce
+  // disabling fusion.
+  if (tensors.size() > 1 || horovod_global.disable_group_fusion) {
+    auto group_id = process_set.group_table.RegisterGroup(std::move(names));
+    for (auto& message : messages) {
+      message.set_group_id(group_id);
+    }
+  }
+
+  Status status =
+      process_set.tensor_queue.AddToTensorQueueMulti(entries, messages);
+
   return status;
 }
 
@@ -1661,6 +1728,33 @@ Status EnqueueTensorReducescatter(std::shared_ptr<OpContext> context,
                                   const std::string& name, const int device,
                                   StatusCallback callback, ReduceOp reduce_op,
                                   int32_t process_set_id) {
+  // Wrap inputs in std::vector and pass onto multi tensor implementation
+  std::vector<std::shared_ptr<OpContext>> contexts;
+  std::vector<std::shared_ptr<Tensor>> tensors;
+  std::vector<ReadyEventList> ready_event_lists;
+  std::vector<std::string> names;
+  std::vector<StatusCallback> callbacks;
+
+  contexts.emplace_back(std::move(context));
+  tensors.emplace_back(std::move(tensor));
+  ready_event_lists.emplace_back(std::move(ready_event_list));
+  names.emplace_back(std::move(name));
+  callbacks.emplace_back(std::move(callback));
+
+  return EnqueueTensorReducescatters(contexts, tensors, ready_event_lists,
+                                     names, device, callbacks, reduce_op,
+                                     process_set_id);
+}
+
+// Contexts and controller must be initialized and the background thread
+// must be running before this function is called.
+Status
+EnqueueTensorReducescatters(std::vector<std::shared_ptr<OpContext>>& contexts,
+                            std::vector<std::shared_ptr<Tensor>>& tensors,
+                            std::vector<ReadyEventList>& ready_event_lists,
+                            std::vector<std::string>& names, int device,
+                            std::vector<StatusCallback>& callbacks,
+                            ReduceOp reduce_op, int32_t process_set_id) {
   if (horovod_global.cpu_operation == LibType::CCL && device == CPU_DEVICE_ID) {
     return Status::InvalidArgument(
         "Reducescatter is not supported yet with oneCCL operations.");
@@ -1670,6 +1764,7 @@ Status EnqueueTensorReducescatter(std::shared_ptr<OpContext> context,
         "Reducescatter: Process set provided does not "
         "exist, or has not been registered.");
   }
+
   if (reduce_op != ReduceOp::SUM) {
     // Note: AVERAGE is supported by enqueuing SUM and performing divide at the
     // framework level.
@@ -1689,32 +1784,72 @@ Status EnqueueTensorReducescatter(std::shared_ptr<OpContext> context,
         " is not a member of the provided process set.");
   }
 
-  Request message;
-  message.set_request_rank(process_set.controller->GetRank());
-  message.set_tensor_name(name);
-  message.set_tensor_type(tensor->dtype());
-  message.set_device(device);
-  message.set_request_type(Request::REDUCESCATTER);
-  for (int i = 0; i < tensor->shape().dims(); ++i) {
-    message.add_tensor_shape((int64_t)tensor->shape().dim_size(i));
+  std::vector<Request> messages;
+  std::vector<TensorTableEntry> entries;
+  messages.reserve(tensors.size());
+  entries.reserve(tensors.size());
+
+  for (int n = 0; n < (int)tensors.size(); ++n) {
+    Request message;
+    message.set_request_rank(process_set.controller->GetRank());
+    message.set_tensor_name(names[n]);
+    message.set_tensor_type(tensors[n]->dtype());
+    message.set_device(device);
+    message.set_request_type(Request::REDUCESCATTER);
+    message.set_tensor_shape(tensors[n]->shape().to_vector());
+    messages.push_back(std::move(message));
+
+    TensorTableEntry e;
+    e.tensor_name = names[n];
+    e.context = std::move(contexts[n]);
+    e.tensor = tensors[n];
+    e.output_index = n;
+    e.process_set_id = process_set_id;
+    e.ready_event_list = std::move(ready_event_lists[n]);
+    e.device = device;
+    e.callback = std::move(callbacks[n]);
+
+    entries.push_back(std::move(e));
   }
 
-  TensorTableEntry e;
-  e.tensor_name = name;
-  e.context = context;
-  e.tensor = tensor;
-  e.process_set_id = process_set_id;
-  e.ready_event_list = ready_event_list;
-  e.device = device;
-  e.callback = callback;
-  e.nvtx_op_range.Start(RegisteredNvtxOp::HorovodReducescatter,
-                        e.tensor->size());
-
-  Status status = process_set.tensor_queue.AddToTensorQueue(e, message);
-  if (status.ok()) {
-    LOG(TRACE, horovod_global.global_controller->GetRank())
-        << "Enqueued " << name;
+  // Start appropriate NVTX range
+  if (tensors.size() == 1) {
+    auto& e = entries[0];
+    e.nvtx_op_range.Start(RegisteredNvtxOp::HorovodReducescatter,
+                          e.tensor->size());
+  } else {
+    auto total_size =
+        std::accumulate(entries.begin(), entries.end(), 0ll,
+                        [](int64_t size_sum, const TensorTableEntry& e) {
+                          return size_sum + e.tensor->size();
+                        });
+    SharedNvtxOpRange range;
+    range.Start(RegisteredNvtxOp::HorovodGroupedReducescatter, total_size);
+    for (auto& e : entries) {
+      e.nvtx_op_range = range;
+    }
   }
+
+  std::string tensors_enqueued;
+  for (const auto& n : names) {
+    tensors_enqueued += n + "; ";
+  }
+  LOG(TRACE, horovod_global.global_controller->GetRank())
+      << "Enqueued tensors for Reducescatter: " << tensors_enqueued;
+
+  // Only create groups larger than 1 tensor, unless disable_group_fusion is
+  // requested. In that case, even single tensor groups are created to enforce
+  // disabling fusion.
+  if (tensors.size() > 1 || horovod_global.disable_group_fusion) {
+    auto group_id = process_set.group_table.RegisterGroup(std::move(names));
+    for (auto& message : messages) {
+      message.set_group_id(group_id);
+    }
+  }
+
+  Status status =
+      process_set.tensor_queue.AddToTensorQueueMulti(entries, messages);
+
   return status;
 }
 

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -210,6 +210,14 @@ Status EnqueueTensorAllgather(std::shared_ptr<OpContext> context,
                               StatusCallback callback,
                               int32_t process_set_id = 0);
 
+Status
+EnqueueTensorAllgathers(std::vector<std::shared_ptr<OpContext>>& contexts,
+                        std::vector<std::shared_ptr<Tensor>>& tensors,
+                        std::vector<ReadyEventList>& ready_event_lists,
+                        std::vector<std::string>& names, int device,
+                        std::vector<StatusCallback>& callbacks,
+                        int32_t process_set_id = 0);
+
 Status EnqueueTensorBroadcast(std::shared_ptr<OpContext> context,
                               std::shared_ptr<Tensor> tensor,
                               std::shared_ptr<Tensor> output, int root_rank,
@@ -233,6 +241,15 @@ Status EnqueueTensorReducescatter(std::shared_ptr<OpContext> context,
                                   StatusCallback callback,
                                   ReduceOp reduce_op = ReduceOp::SUM,
                                   int32_t process_set_id = 0);
+
+Status
+EnqueueTensorReducescatters(std::vector<std::shared_ptr<OpContext>>& contexts,
+                            std::vector<std::shared_ptr<Tensor>>& tensors,
+                            std::vector<ReadyEventList>& ready_event_lists,
+                            std::vector<std::string>& names, int device,
+                            std::vector<StatusCallback>& callbacks,
+                            ReduceOp reduce_op = ReduceOp::SUM,
+                            int32_t process_set_id = 0);
 
 Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    std::shared_ptr<Tensor> output_last_joined_rank,

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -179,7 +179,7 @@ Status AllgatherOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
 
       if (entry_component_sizes) {
         entry_component_sizes[ec][rc] =
-                          component_size * single_slice_shape.num_elements();
+            component_size * single_slice_shape.num_elements();
       }
     }
 
@@ -189,10 +189,10 @@ Status AllgatherOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
     output_shape.AddDim((int64_t)total_entry_dimension_size);
     output_shape.AppendShape(single_slice_shape);
 
-    Status status = e.context->AllocateOutput(output_shape, &e.output);
+    Status status =
+        e.context->AllocateOutput(e.output_index, output_shape, &e.output);
     if (!status.ok()) {
-      LOG(WARNING) << "AllgatherOp::AllocateOutput failed: "
-                   << status.reason();
+      LOG(WARNING) << "AllgatherOp::AllocateOutput failed: " << status.reason();
       return status;
     }
   }
@@ -350,7 +350,8 @@ ReducescatterOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
   for (size_t ec = 0; ec < entries.size(); ++ec) {
     auto& e = entries[ec];
     const auto& output_shape = output_shapes[ec];
-    Status status = e.context->AllocateOutput(output_shape, &e.output);
+    Status status =
+        e.context->AllocateOutput(e.output_index, output_shape, &e.output);
     if (!status.ok()) {
       LOG(WARNING) << "ReducescatterOp::AllocateOutput failed: "
                    << status.reason();

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -191,6 +191,8 @@ Status AllgatherOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
 
     Status status = e.context->AllocateOutput(output_shape, &e.output);
     if (!status.ok()) {
+      LOG(WARNING) << "AllgatherOp::AllocateOutput failed: "
+                   << status.reason();
       return status;
     }
   }
@@ -342,13 +344,16 @@ std::vector<int> ReducescatterOp::ComputeReceiveCounts(
   return recvcounts;
 }
 
-Status ReducescatterOp::AllocateOutput(
-    std::vector<TensorTableEntry>& entries, const std::vector<TensorShape>& output_shapes) {
+Status
+ReducescatterOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
+                                const std::vector<TensorShape>& output_shapes) {
   for (size_t ec = 0; ec < entries.size(); ++ec) {
     auto& e = entries[ec];
     const auto& output_shape = output_shapes[ec];
     Status status = e.context->AllocateOutput(output_shape, &e.output);
     if (!status.ok()) {
+      LOG(WARNING) << "ReducescatterOp::AllocateOutput failed: "
+                   << status.reason();
       return status;
     }
   }

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -253,6 +253,9 @@ protected:
     output_shape.AppendShape(slice_shape);
     Status status = e.context->AllocateOutput(output_shape, &e.output);
     if (!status.ok()) {
+      LOG(WARNING)
+          << "AlltoallOp::PrepareOutputAndParams failed to allocate output: "
+          << status.reason();
       return status;
     }
 
@@ -262,6 +265,9 @@ protected:
     Status rstatus = e.context->AllocateOutput(1, received_splits_shape,
                                                &e.received_splits);
     if (!rstatus.ok()) {
+      LOG(WARNING) << "AlltoallOp::PrepareOutputAndParams failed to allocate "
+                      "received_splits: "
+                   << status.reason();
       return rstatus;
     }
     auto* target_pointer = reinterpret_cast<int32_t*>(

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -623,7 +623,8 @@ Status NCCLAllgather::AllocateOutput(std::vector<TensorTableEntry>& entries,
     output_shape.AppendShape(single_slice_shape);
 
     std::shared_ptr<ReadyEvent> event;
-    Status status = e.context->AllocateOutput(output_shape, &e.output, &event);
+    Status status = e.context->AllocateOutput(e.output_index, output_shape,
+                                              &e.output, &event);
     if (!status.ok()) {
       LOG(WARNING) << "NCCLAllgather::AllocateOutput failed: "
                    << status.reason();
@@ -1011,7 +1012,8 @@ Status NCCLReducescatter::AllocateOutput(
     const auto& output_shape = output_shapes[ec];
 
     std::shared_ptr<ReadyEvent> event;
-    Status status = e.context->AllocateOutput(output_shape, &e.output, &event);
+    Status status = e.context->AllocateOutput(e.output_index, output_shape,
+                                              &e.output, &event);
     if (!status.ok()) {
       LOG(WARNING) << "NCCLReducescatter::AllocateOutput failed: "
                    << status.reason();

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -625,6 +625,8 @@ Status NCCLAllgather::AllocateOutput(std::vector<TensorTableEntry>& entries,
     std::shared_ptr<ReadyEvent> event;
     Status status = e.context->AllocateOutput(output_shape, &e.output, &event);
     if (!status.ok()) {
+      LOG(WARNING) << "NCCLAllgather::AllocateOutput failed: "
+                   << status.reason();
       return status;
     }
 
@@ -1011,6 +1013,8 @@ Status NCCLReducescatter::AllocateOutput(
     std::shared_ptr<ReadyEvent> event;
     Status status = e.context->AllocateOutput(output_shape, &e.output, &event);
     if (!status.ok()) {
+      LOG(WARNING) << "NCCLReducescatter::AllocateOutput failed: "
+                   << status.reason();
       return status;
     }
 

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -180,6 +180,9 @@ protected:
     std::shared_ptr<ReadyEvent> event;
     Status status = e.context->AllocateOutput(output_shape, &e.output, &event);
     if (!status.ok()) {
+      LOG(WARNING)
+          << "NCCLAlltoall::PrepareOutputAndParams failed to allocate output: "
+          << status.reason();
       return status;
     }
 
@@ -197,6 +200,9 @@ protected:
                                                &e.received_splits,
                                                &revent);
     if (!rstatus.ok()) {
+      LOG(WARNING) << "NCCLAlltoall::PrepareOutputAndParams failed to allocate "
+                      "received_splits: "
+                   << status.reason();
       return rstatus;
     }
 

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -292,7 +292,7 @@ public:
 
 protected:
   Status AllocateOutput(std::vector<TensorTableEntry>& entries,
-                                const std::vector<TensorShape>& output_shapes) override;
+                        const std::vector<TensorShape>& output_shapes) override;
 
   void WaitForData(std::vector<TensorTableEntry>& entries) override;
 

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -24,7 +24,7 @@ from horovod.mxnet.mpi_ops import allgather, grouped_allgather
 from horovod.mxnet.mpi_ops import allreduce, allreduce_, grouped_allreduce, grouped_allreduce_
 from horovod.mxnet.mpi_ops import alltoall
 from horovod.mxnet.mpi_ops import broadcast, broadcast_
-from horovod.mxnet.mpi_ops import reducescatter
+from horovod.mxnet.mpi_ops import reducescatter, grouped_reducescatter
 from horovod.mxnet.mpi_ops import init, shutdown
 from horovod.mxnet.mpi_ops import is_initialized, start_timeline, stop_timeline
 from horovod.mxnet.mpi_ops import size, local_size, cross_size, rank, local_rank, cross_rank

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -20,7 +20,7 @@ check_extension('horovod.mxnet', 'HOROVOD_WITH_MXNET',
 
 from horovod.mxnet.compression import Compression
 from horovod.mxnet.functions import allgather_object, broadcast_object
-from horovod.mxnet.mpi_ops import allgather
+from horovod.mxnet.mpi_ops import allgather, grouped_allgather
 from horovod.mxnet.mpi_ops import allreduce, allreduce_, grouped_allreduce, grouped_allreduce_
 from horovod.mxnet.mpi_ops import alltoall
 from horovod.mxnet.mpi_ops import broadcast, broadcast_

--- a/horovod/mxnet/adapter.cc
+++ b/horovod/mxnet/adapter.cc
@@ -82,6 +82,9 @@ int64_t MXTensor::size() const {
 MXOpContext::MXOpContext(int device, NDArray* principal_output)
     : device_(device), outputs_{principal_output} {}
 
+MXOpContext::MXOpContext(int device, const std::vector<NDArray*>& outputs)
+    : device_(device), outputs_(outputs) {}
+
 void MXOpContext::AddOutput(NDArray* output) {
   outputs_.push_back(output);
 }
@@ -97,7 +100,7 @@ MXOpContext::AllocatePersistent(int64_t size,
 Status MXOpContext::AllocateOutput(TensorShape shape,
                                    std::shared_ptr<Tensor>* tensor,
                                    std::shared_ptr<ReadyEvent>* event) {
-  return MXOpContext::AllocateOutput(0, shape, tensor);
+  return MXOpContext::AllocateOutput(0, shape, tensor, event);
 }
 
 Status MXOpContext::AllocateOutput(int output_index, TensorShape shape,

--- a/horovod/mxnet/adapter.h
+++ b/horovod/mxnet/adapter.h
@@ -52,19 +52,19 @@ protected:
 class MXOpContext : public OpContext {
 public:
   MXOpContext(int device, NDArray* principal_output);
+  MXOpContext(int device, const std::vector<NDArray*>& outputs);
   void AddOutput(NDArray* output);
   virtual Status
   AllocatePersistent(int64_t size,
                      std::shared_ptr<PersistentBuffer>* tensor) override;
-  virtual Status AllocateOutput(TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
-  virtual Status AllocateOutput(int output_index, TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
-  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
-                               std::shared_ptr<Tensor>* tensor) override;
-  virtual Framework framework() const override;
+  Status AllocateOutput(TensorShape shape, std::shared_ptr<Tensor>* tensor,
+                        std::shared_ptr<ReadyEvent>* event = nullptr) override;
+  Status AllocateOutput(int output_index, TensorShape shape,
+                        std::shared_ptr<Tensor>* tensor,
+                        std::shared_ptr<ReadyEvent>* event = nullptr) override;
+  Status AllocateZeros(int64_t num_elements, DataType dtype,
+                       std::shared_ptr<Tensor>* tensor) override;
+  Framework framework() const override;
 
 private:
   int device_;

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -764,7 +764,7 @@ extern "C" int horovod_mxnet_reducescatter_async(NDArray* const* inputs,
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_REDUCESCATTER
-  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
+  if (IsTensorOnCPU(inputs[0]) && IsTensorOnCPU(outputs[0])) {
     PushHorovodOperation(OperationType::REDUCESCATTER, inputs, outputs, name,
                          priority, num_tensors, process_set_id, -1, false);
   } else {

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -172,7 +172,16 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
     if (TensorUtil::GetDevice(input_tensor) != device) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
-    auto ctx = std::make_shared<MXOpContext>(device, output);
+    std::shared_ptr<MXOpContext> ctx;
+    if (ops_param->op_type == OperationType::ALLGATHER ||
+        ops_param->op_type == OperationType::REDUCESCATTER) {
+      // Grouped allgather and reducescatter operations will need to allocate
+      // the correct output tensor later on, therefore referring to all output
+      // tensors in context.
+      ctx = std::make_shared<MXOpContext>(device, ops_param->outputs);
+    } else {
+      ctx = std::make_shared<MXOpContext>(device, output);
+    }
     if (ops_param->received_splits_tensor) {
       ctx->AddOutput(ops_param->received_splits_tensor.get());
     }
@@ -260,9 +269,9 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
           postscale_factor, process_set_id);
       break;
     case OperationType::ALLGATHER:
-      enqueue_result = EnqueueTensorAllgather(
-          hvd_contexts[0], hvd_tensors[0], ready_event_lists[0],
-          ops_param->op_names[0], device, callbacks[0], process_set_id);
+      enqueue_result = EnqueueTensorAllgathers(
+          hvd_contexts, hvd_tensors, ready_event_lists,
+          ops_param->op_names, device, callbacks, process_set_id);
       break;
     case OperationType::BROADCAST:
       if (horovod_rank() != ops_param->root_rank) {
@@ -426,15 +435,20 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
   std::vector<std::shared_ptr<OpContext>> hvd_contexts;
   std::vector<StatusCallback> callbacks;
   std::vector<ReadyEventList> ready_event_lists;
+  std::vector<NDArray *> outputs;
   hvd_cpu_buffers.reserve(num_tensors);
   hvd_contexts.reserve(num_tensors);
   ready_event_lists.reserve(num_tensors);
   callbacks.reserve(num_tensors);
+  outputs.reserve(num_tensors);
+  for (std::size_t i = 0; i < num_tensors; ++i) {
+    outputs.push_back(ops_param->cpu_output_tensors[i].get());
+  }
 
   auto callback_mutex = std::make_shared<std::mutex>();
   for (std::size_t i = 0; i < num_tensors; ++i) {
     auto input = ops_param->cpu_input_tensors[i].get();
-    auto output = ops_param->cpu_output_tensors[i].get();
+    auto output = outputs[i];
 
     ready_event_lists.emplace_back(FormReadyEventList(input, output));
 
@@ -442,7 +456,16 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
     if (TensorUtil::GetDevice(input) != device) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
-    auto ctx = std::make_shared<MXOpContext>(device, output);
+    std::shared_ptr<MXOpContext> ctx;
+    if (ops_param->op_type == OperationType::ALLGATHER ||
+        ops_param->op_type == OperationType::REDUCESCATTER) {
+      // Grouped allgather and reducescatter operations will need to allocate
+      // the correct output tensor later on, therefore referring to all output
+      // tensors in context.
+      ctx = std::make_shared<MXOpContext>(device, outputs);
+    } else {
+      ctx = std::make_shared<MXOpContext>(device, output);
+    }
     if (ops_param->received_splits_tensor) {
       ctx->AddOutput(ops_param->received_splits_tensor.get());
     }
@@ -471,9 +494,9 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
         postscale_factor, process_set_id);
     break;
   case OperationType::ALLGATHER:
-    enqueue_result = EnqueueTensorAllgather(
-        hvd_contexts[0], hvd_cpu_buffers[0], ready_event_lists[0],
-        ops_param->op_names[0], device, callbacks[0], process_set_id);
+    enqueue_result = EnqueueTensorAllgathers(
+        hvd_contexts, hvd_cpu_buffers, ready_event_lists,
+        ops_param->op_names, device, callbacks, process_set_id);
     break;
   case OperationType::BROADCAST:
     enqueue_result = EnqueueTensorBroadcast(
@@ -657,23 +680,24 @@ extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
   MX_API_END();
 }
 
-extern "C" int horovod_mxnet_allgather_async(NDArray* input,
-                                             NDArray* output,
+extern "C" int horovod_mxnet_allgather_async(NDArray* const* inputs,
+                                             NDArray* const* outputs,
                                              const char* name, int priority,
-                                             int process_set_id) {
+                                             int process_set_id,
+                                             int num_tensors) {
   MX_API_BEGIN();
 
 #if HAVE_CUDA && !HOROVOD_GPU_ALLGATHER
-  if (IsTensorOnCPU(input) && IsTensorOnCPU(output)) {
-    PushHorovodOperation(OperationType::ALLGATHER, &input, &output,
-                         name, priority, 1, process_set_id);
+  if (IsTensorOnCPU(inputs[0]) && IsTensorOnCPU(outputs[0])) {
+    PushHorovodOperation(OperationType::ALLGATHER, inputs, outputs,
+                         name, priority, num_tensors, process_set_id);
   } else {
-    PushHorovodOperationCudaOnCPU(OperationType::ALLGATHER, &input, &output,
-                                  name, priority, 1, process_set_id);
+    PushHorovodOperationCudaOnCPU(OperationType::ALLGATHER, inputs, outputs,
+                                  name, priority, num_tensors, process_set_id);
   }
 #else
-  PushHorovodOperation(OperationType::ALLGATHER, &input, &output,
-                       name, priority, 1, process_set_id);
+  PushHorovodOperation(OperationType::ALLGATHER, inputs, outputs,
+                       name, priority, num_tensors, process_set_id);
 #endif
 
   MX_API_END();

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -134,10 +134,11 @@ extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
                                             NDArray* output_received_splits,
                                             int priority,
                                             int process_set_id);
-extern "C" int
-horovod_mxnet_reducescatter_async(NDArray* input, NDArray* output,
-                                  const char* name, int priority,
-                                  int process_set_id);
+extern "C" int horovod_mxnet_reducescatter_async(NDArray* const* inputs,
+                                                 NDArray* const* outputs,
+                                                 const char* name, int priority,
+                                                 int process_set_id,
+                                                 int num_tensors);
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -112,18 +112,16 @@ void DeleteMpiOpsParam(void* param) {
   delete ops_param;
 }
 
-extern "C" int horovod_mxnet_allreduce_async(NDArray* const * inputs,
-                                             NDArray* const * outputs,
-                                             const char* name, bool average,
-                                             int priority,
-                                             double prescale_factor,
-                                             double postscale_factor,
-                                             int num_tensors,
-                                             int process_set_id);
-extern "C" int horovod_mxnet_allgather_async(NDArray* input,
-                                             NDArray* output,
+extern "C" int
+horovod_mxnet_allreduce_async(NDArray* const* inputs, NDArray* const* outputs,
+                              const char* name, bool average, int priority,
+                              double prescale_factor, double postscale_factor,
+                              int num_tensors, int process_set_id);
+extern "C" int horovod_mxnet_allgather_async(NDArray* const* inputs,
+                                             NDArray* const* outputs,
                                              const char* name, int priority,
-                                             int process_set_id);
+                                             int process_set_id,
+                                             int num_tensors);
 extern "C" int horovod_mxnet_broadcast_async(NDArray* input,
                                              NDArray* output,
                                              const char* name, int root_rank,

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -570,14 +570,11 @@ def reducescatter(tensor, op=Average, name=None, priority=0,
                          dtype=tensor.dtype)
     c_in = tensor.handle
     c_out = output.handle
-    if isinstance(name, string_types):
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_reducescatter_async(
-            c_in, c_out, c_str(name), ctypes.c_int(priority),
-            ctypes.c_int(process_set.process_set_id)))
-    else:
-        check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_reducescatter_async(
-            c_in, c_out, name, ctypes.c_int(priority),
-            ctypes.c_int(process_set.process_set_id)))
+    c_name = c_str(name) if isinstance(name, string_types) else ctypes.c_char_p(None)
+
+    check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_reducescatter_async(
+        ctypes.byref(c_in), ctypes.byref(c_out), c_name, ctypes.c_int(priority),
+        ctypes.c_int(process_set.process_set_id), ctypes.c_int(1)))
 
     # Need to block here so changes to output tensor are visible
     output.wait_to_read()
@@ -586,3 +583,59 @@ def reducescatter(tensor, op=Average, name=None, priority=0,
         output /= process_set.size()
 
     return output
+
+
+def grouped_reducescatter(tensors, op=Average, name=None, priority=0,
+                          process_set=global_process_set):
+    """
+    A function that performs reduction of a list of input tensors over all the
+    Horovod processes, then scatters the results across all Horovod processes. The
+    input tensors are not modified.
+
+    The reduction operation is keyed by the name. If name is not provided, an incremented
+    auto-generated name is used. The tensor type and shape must be the same on all
+    Horovod processes for a given name. The reduction will not start until all processes
+    are ready to send and receive the tensor.
+
+    This acts as a thin wrapper around an autograd function.  If your input
+    tensor requires gradients, then callings this function will allow gradients
+    to be computed and backpropagated.
+
+    Arguments:
+        tensors: A list of tensors to average and sum.
+        op: The reduction operation to combine tensors across different ranks.
+            Can be Average (default) or Sum.
+        name: A base name to use for the group reduction operation.
+        priority: The priority of this operation. Higher priority operations
+                  are likely to be executed before other operations.
+        process_set: Process set object to limit this operation to a subset of
+                     Horovod processes. Default is the global process set.
+
+    Returns:
+        A list containing tensors of the same rank and type as in `tensors`. For each
+        tensor the shape is identical to the input shape, except for the first dimension,
+        which will be divided across the different Horovod processes.
+    """
+    assert(all(isinstance(t, mx.nd.NDArray) for t in tensors))
+    assert(op in [Average, Sum])
+    # Sizes of outputs are unknown, create output arrays that
+    # will be resized during Horovod operation
+    outputs = [mx.nd.empty(shape=(1,), ctx=t.context, dtype=t.dtype)
+               for t in tensors]
+    c_in = c_handle_array(tensors)
+    c_out = c_handle_array(outputs)
+    c_name = c_str(name) if isinstance(name, string_types) else ctypes.c_char_p(None)
+
+    check_call(MPI_MXNET_LIB_CTYPES.horovod_mxnet_reducescatter_async(
+        c_in, c_out, c_name, ctypes.c_int(priority),
+        ctypes.c_int(process_set.process_set_id), ctypes.c_int(len(tensors))))
+
+    # Need to block here so changes to output tensors are visible
+    for o in outputs:
+        o.wait_to_read()
+
+    if op == Average:
+        for i in range(len(outputs)):
+            outputs[i] /= process_set.size()
+
+    return outputs

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -206,6 +206,35 @@ def grouped_allreduce(tensors, average=None, device_dense='', device_sparse='',
                       compression=Compression.none, op=None,
                       prescale_factor=1.0, postscale_factor=1.0,
                       process_set=global_process_set):
+    """Perform grouped allreduces on a sequence of tf.Tensor or tf.IndexedSlices.
+
+    Arguments:
+        tensors: Sequence of tf.Tensor, tf.Variable, or tf.IndexedSlices to reduce.
+                 The tensor type and shape must be the same on all Horovod processes
+                 for tensors sharing positions in `tensors`.
+        average:
+            .. warning:: .. deprecated:: 0.19.0
+
+                Use `op` instead. Will be removed in v1.0.
+
+        device_dense: Device to be used for dense tensors. Uses GPU by default
+                      if Horovod was built with HOROVOD_GPU_OPERATIONS.
+        device_sparse: Device to be used for sparse tensors. Uses GPU by default
+                       if Horovod was built with HOROVOD_GPU_OPERATIONS.
+        compression: Compression algorithm used to reduce the amount of data
+                     sent and received by each worker node.  Defaults to not
+                     using compression.
+        op: The reduction operation to combine tensors across different ranks.
+            Defaults to Average if None is given.
+        prescale_factor: Multiplicative factor to scale tensors before allreduce.
+        postscale_factor: Multiplicative factor to scale tensors after allreduce.
+        process_set: Process set object to limit this operation to a subset of
+            Horovod processes. Default is the global process set.
+
+    Returns:
+        A list of tensors of the same shape and type as those in `tensors`,
+        reduced across all processes.
+    """
     if not tensors:
         return tensors
 
@@ -318,6 +347,30 @@ def _grouped_allreduce_cond(tensors, *args, process_set=global_process_set, **kw
 
 def grouped_reducescatter(tensors, device_dense='', compression=Compression.none, op=Average,
                           process_set=global_process_set):
+    """Perform grouped reducescatters on a sequence of tf.Tensor.
+
+    Arguments:
+        tensors: Sequence of tf.Tensor or tf.Variable to reduce.
+                 The shape must be the same on all Horovod processes
+                 for inputs sharing positions in `tensors`.
+        device_dense: Device to be used for dense tensors. Uses GPU by default
+                      if Horovod was built with HOROVOD_GPU_OPERATIONS.
+        device_sparse: Device to be used for sparse tensors. Uses GPU by default
+                       if Horovod was built with HOROVOD_GPU_OPERATIONS.
+        compression: Compression algorithm used to reduce the amount of data
+                     sent and received by each worker node.  Defaults to not
+                     using compression.
+        op: The reduction operation to combine tensors across different ranks.
+            Defaults to Average if None is given.
+        process_set: Process set object to limit this operation to a subset of
+            Horovod processes. Default is the global process set.
+
+    Returns:
+        A list of tensors of the same rank and type as those in `tensors`,
+        reduced across all processes. For each returned tensor the shape is
+        identical to the corresponding input shape, except for the first
+        dimension, which will be divided across the different Horovod processes.
+    """
     if not tensors:
         return tensors
     # Averaging happens in framework code, so translate that to Sum for the actual call

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -39,6 +39,7 @@ if _MPI_LIB_AVAILABLE:
     from horovod.torch.mpi_ops import grouped_allreduce, grouped_allreduce_async, grouped_allreduce_, grouped_allreduce_async_
     from horovod.torch.mpi_ops import sparse_allreduce_async
     from horovod.torch.mpi_ops import allgather, allgather_async
+    from horovod.torch.mpi_ops import grouped_allgather, grouped_allgather_async
     from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
     from horovod.torch.mpi_ops import alltoall, alltoall_async
     from horovod.torch.mpi_ops import reducescatter, reducescatter_async

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -43,6 +43,7 @@ if _MPI_LIB_AVAILABLE:
     from horovod.torch.mpi_ops import broadcast, broadcast_async, broadcast_, broadcast_async_
     from horovod.torch.mpi_ops import alltoall, alltoall_async
     from horovod.torch.mpi_ops import reducescatter, reducescatter_async
+    from horovod.torch.mpi_ops import grouped_reducescatter, grouped_reducescatter_async
     from horovod.torch.mpi_ops import join
     from horovod.torch.mpi_ops import barrier
     from horovod.torch.mpi_ops import poll, synchronize

--- a/horovod/torch/adapter_v2.cc
+++ b/horovod/torch/adapter_v2.cc
@@ -99,6 +99,11 @@ int64_t TorchTensor::size() const {
 TorchOpContext::TorchOpContext(int device, ::torch::Tensor principal_output)
     : device_(device), output_devices_{device}, outputs_{principal_output} {}
 
+TorchOpContext::TorchOpContext(int device,
+                               const std::vector<::torch::Tensor>& outputs)
+    : device_(device), output_devices_(outputs.size(), device),
+      outputs_(outputs) {}
+
 void TorchOpContext::AddOutput(int device, ::torch::Tensor output) {
   output_devices_.push_back(device);
   outputs_.push_back(output);

--- a/horovod/torch/adapter_v2.h
+++ b/horovod/torch/adapter_v2.h
@@ -54,19 +54,18 @@ protected:
 class TorchOpContext : public OpContext {
 public:
   TorchOpContext(int device, ::torch::Tensor principal_output);
+  TorchOpContext(int device, const std::vector<::torch::Tensor>& outputs);
   void AddOutput(int device, ::torch::Tensor output);
-  virtual Status
-  AllocatePersistent(int64_t size,
-                     std::shared_ptr<PersistentBuffer>* tensor) override;
-  virtual Status AllocateOutput(TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
-  virtual Status AllocateOutput(int output_index, TensorShape shape,
-                                std::shared_ptr<Tensor>* tensor,
-                                std::shared_ptr<ReadyEvent>* event = nullptr) override;
-  virtual Status AllocateZeros(int64_t num_elements, DataType dtype,
-                               std::shared_ptr<Tensor>* tensor) override;
-  virtual Framework framework() const override;
+  Status AllocatePersistent(int64_t size,
+                            std::shared_ptr<PersistentBuffer>* tensor) override;
+  Status AllocateOutput(TensorShape shape, std::shared_ptr<Tensor>* tensor,
+                        std::shared_ptr<ReadyEvent>* event = nullptr) override;
+  Status AllocateOutput(int output_index, TensorShape shape,
+                        std::shared_ptr<Tensor>* tensor,
+                        std::shared_ptr<ReadyEvent>* event = nullptr) override;
+  Status AllocateZeros(int64_t num_elements, DataType dtype,
+                       std::shared_ptr<Tensor>* tensor) override;
+  Framework framework() const override;
 
 private:
   int device_ = CPU_DEVICE_ID;

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -1009,9 +1009,12 @@ def _reducescatter_function_factory(tensor):
 
 def _reducescatter_async(tensor, output, name, op, process_set: ProcessSet):
     function = _check_function(_reducescatter_function_factory, tensor)
-    handle = getattr(mpi_lib, function)(tensor, output,
-                                        name.encode() if name is not None else _NULL,
-                                        op, process_set.process_set_id)
+    try:
+        handle = getattr(mpi_lib, function)(tensor, output,
+                                            name.encode() if name is not None else _NULL,
+                                            op, process_set.process_set_id)
+    except RuntimeError as e:
+        raise HorovodInternalError(e)
     _handle_map[handle] = (tensor, output)
     return handle
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -729,7 +729,7 @@ class HorovodGroupedAllgather(torch.autograd.Function):
                    for dim in dims]
         result = [gr.narrow(0, offset, dim)
                   for gr, offset, dim in zip(grad_reduced, offsets, ctx.dims)]
-        return None, None, *result
+        return (None, None, *result)
 
 
 def grouped_allgather(tensors, name=None, process_set=global_process_set):

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -293,8 +293,9 @@ int DoGroupedAllreduceCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
   ReduceOp reduce_op = static_cast<ReduceOp>(reduce_op_int);
 
   auto enqueue_result = EnqueueTensorAllreduces(
-      hvd_contexts, cpu_buffers, cpu_buffers, ready_event_lists, names, device,
-      callbacks, reduce_op, prescale_factor, postscale_factor, process_set_id);
+      hvd_contexts, cpu_buffers, cpu_buffers, ready_event_lists, names,
+      CPU_DEVICE_ID, callbacks, reduce_op, prescale_factor, postscale_factor,
+      process_set_id);
   ThrowIfError(enqueue_result);
 
   return handle;
@@ -517,7 +518,7 @@ int DoGroupedAllgatherCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
 
   auto enqueue_result =
       EnqueueTensorAllgathers(hvd_contexts, hvd_cpu_tensors, ready_event_lists,
-                              names, device, callbacks, process_set_id);
+                              names, CPU_DEVICE_ID, callbacks, process_set_id);
   ThrowIfError(enqueue_result);
 
   return handle;

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -368,6 +368,161 @@ int DoAllgatherCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output,
   return handle;
 }
 
+int DoGroupedAllgather(const std::vector<::torch::Tensor>& tensors,
+                       const std::vector<::torch::Tensor>& outputs,
+                       const std::string& name, int process_set_id) {
+  ThrowIfError(common::CheckInitialized());
+
+  if (tensors.size() != outputs.size()) {
+    throw std::logic_error("Number of tensors and outputs must be equal");
+  }
+
+  auto handle = handle_manager.AllocateHandle();
+  auto device = GetDeviceID(tensors[0]);
+  common::ReadyEventList ready_event_list;
+#if HAVE_GPU
+  ready_event_list.AddReadyEvent(RecordReadyEvent(device));
+#endif
+
+  std::vector<std::shared_ptr<Tensor>> hvd_tensors;
+  std::vector<std::shared_ptr<OpContext>> hvd_contexts;
+  std::vector<common::ReadyEventList> ready_event_lists;
+  std::vector<StatusCallback> callbacks;
+  std::vector<std::string> names;
+
+  auto num_tensors = tensors.size();
+  hvd_tensors.reserve(num_tensors);
+  hvd_contexts.reserve(num_tensors);
+  ready_event_lists.reserve(num_tensors);
+  names.reserve(num_tensors);
+  callbacks.reserve(num_tensors);
+
+  auto base_name = GetOpName("grouped_allgather", name, handle);
+
+  auto callback_mutex = std::make_shared<std::mutex>();
+  auto callback_count = std::make_shared<std::size_t>(0);
+  for (std::size_t i = 0; i < num_tensors; ++i) {
+    if (GetDeviceID(tensors[i]) != device) {
+      throw std::logic_error("Tensors in list must be on same device.");
+    }
+    hvd_tensors.emplace_back(std::make_shared<TorchTensor>(tensors[i]));
+    hvd_contexts.emplace_back(
+        std::make_shared<TorchOpContext>(device, outputs));
+    ready_event_lists.emplace_back(
+        ready_event_list); // Same for all tensors in group
+    names.emplace_back(base_name + "_" + std::to_string(i + 1) + "of" +
+                       std::to_string(num_tensors));
+    auto output = outputs[i];
+    callbacks.emplace_back([handle, output, callback_mutex,
+                            callback_count, num_tensors,
+                            device](const Status& status) mutable {
+#if HAVE_GPU
+      auto hvd_event = status.event;
+      if (hvd_event.event) {
+        auto stream = GetGPUStream(device);
+        HVD_GPU_CHECK(gpuStreamWaitEvent(stream, *(hvd_event.event), 0));
+      }
+#endif
+      // Must only call MarkDone on last tensor.
+      std::lock_guard<std::mutex> guard(*callback_mutex);
+      (*callback_count)++;
+      if (*callback_count == num_tensors) {
+        handle_manager.MarkDone(handle, status);
+      }
+    });
+  }
+
+  auto enqueue_result = EnqueueTensorAllgathers(
+      hvd_contexts, hvd_tensors, ready_event_lists, names, device,
+      callbacks, process_set_id);
+  ThrowIfError(enqueue_result);
+
+  return handle;
+}
+
+int DoGroupedAllgatherCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
+                                const std::vector<::torch::Tensor>& outputs,
+                                const std::string& name, int process_set_id) {
+  ThrowIfError(common::CheckInitialized());
+
+  if (tensors.size() != outputs.size()) {
+    throw std::logic_error("Number of tensors and outputs must be equal");
+  }
+
+  auto handle = handle_manager.AllocateHandle();
+  auto device = GetDeviceID(tensors[0]);
+
+  std::vector<std::shared_ptr<Tensor>> hvd_cpu_tensors;
+  std::vector<::torch::Tensor> cpu_outputs;
+  std::vector<std::shared_ptr<OpContext>> hvd_contexts;
+  std::vector<common::ReadyEventList> ready_event_lists;
+  std::vector<StatusCallback> callbacks;
+  std::vector<std::string> names;
+
+  auto num_tensors = tensors.size();
+  hvd_cpu_tensors.reserve(num_tensors);
+  cpu_outputs.reserve(outputs.size());
+  hvd_contexts.reserve(num_tensors);
+  ready_event_lists.reserve(num_tensors);
+  names.reserve(num_tensors);
+  callbacks.reserve(num_tensors);
+
+  auto base_name = GetOpName("grouped_allgather", name, handle);
+
+  for (std::size_t i = 0; i < num_tensors; ++i) {
+    if (GetDeviceID(tensors[i]) != device) {
+      throw std::logic_error("Tensors in list must be on same device.");
+    }
+    // Make async copy of input tensor to CPU tensor and record completion
+    // event.
+    auto cpu_tensor =
+        tensors[i].to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
+    hvd_cpu_tensors.emplace_back(std::make_shared<TorchTensor>(cpu_tensor));
+    common::ReadyEventList ready_event_list;
+#if HAVE_GPU
+    ready_event_list.AddReadyEvent(RecordReadyEvent(device));
+#endif
+    ready_event_lists.emplace_back(ready_event_list);
+    cpu_outputs.emplace_back(
+        ::torch::empty_like(cpu_tensor, LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+    names.emplace_back(base_name + "_" + std::to_string(i + 1) + "of" +
+                       std::to_string(num_tensors));
+  }
+
+  auto callback_mutex = std::make_shared<std::mutex>();
+  auto callback_count = std::make_shared<std::size_t>(0);
+  for (std::size_t i = 0; i < num_tensors; ++i) {
+    hvd_contexts.emplace_back(
+        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs));
+    auto output = outputs[i];
+    auto cpu_output = cpu_outputs[i];
+    callbacks.emplace_back([handle, cpu_output, output, device, callback_mutex,
+                            callback_count,
+                            num_tensors](const Status& status) mutable {
+      // Since the operation was on CPU, need to perform copy with the GPU
+      // device guard.
+      with_device device_guard(device);
+      // output needs to be resized before copying in the CPU tensor.
+      output.resize_(cpu_output.sizes());
+      output.copy_(cpu_output);
+
+      // Must only call MarkDone on last tensor.
+      std::lock_guard<std::mutex> guard(*callback_mutex);
+      (*callback_count)++;
+      if (*callback_count == num_tensors) {
+        handle_manager.MarkDone(handle, status);
+      }
+    });
+  }
+
+  auto enqueue_result =
+      EnqueueTensorAllgathers(hvd_contexts, hvd_cpu_tensors, ready_event_lists,
+                              names, device, callbacks, process_set_id);
+  ThrowIfError(enqueue_result);
+
+  return handle;
+}
+
 int DoBroadcast(::torch::Tensor tensor, ::torch::Tensor output, int root_rank,
                 const std::string& name, int process_set_id) {
   ThrowIfError(common::CheckInitialized());
@@ -793,6 +948,59 @@ PYBIND11_MODULE(mpi_lib_v2, m) {
         &DoAllgatherCudaOnCPU);
   m.def("horovod_torch_allgather_async_torch_cuda_DoubleTensor",
         &DoAllgatherCudaOnCPU);
+#endif
+
+  // grouped allgather
+  m.def("horovod_torch_grouped_allgather_async_torch_ByteTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_CharTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_ShortTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_IntTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_LongTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_HalfTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_FloatTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_DoubleTensor",
+        &DoGroupedAllgather);
+#if HOROVOD_GPU_ALLGATHER
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_ByteTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_CharTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_ShortTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_IntTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_LongTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_HalfTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_FloatTensor",
+        &DoGroupedAllgather);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_DoubleTensor",
+        &DoGroupedAllgather);
+#else
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_ByteTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_CharTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_ShortTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_IntTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_LongTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_HalfTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_FloatTensor",
+        &DoGroupedAllgatherCudaOnCPU);
+  m.def("horovod_torch_grouped_allgather_async_torch_cuda_DoubleTensor",
+        &DoGroupedAllgatherCudaOnCPU);
 #endif
 
   // broadcast

--- a/test/parallel/test_mxnet1.py
+++ b/test/parallel/test_mxnet1.py
@@ -49,6 +49,14 @@ class MX1Tests(MXTests, unittest.TestCase):
            list contains a mix of tensors on CPU and GPU."""
         super(MX1Tests, self).test_horovod_grouped_allreduce_cpu_gpu_error()
 
+    @unittest.skipUnless(has_gpu, "no gpu detected")
+    @pytest.mark.skipif(_skip_enqueue_errors,
+                        reason="Skip enqueue errors for MXNet version < 1.5.0")
+    def test_horovod_grouped_allgather_cpu_gpu_error(self):
+        """Test that the grouped allgather raises an error if the input tensor
+           list contains a mix of tensors on CPU and GPU."""
+        super(MX1Tests, self).test_horovod_grouped_allgather_cpu_gpu_error()
+
     @pytest.mark.skipif(_skip_enqueue_errors,
                         reason="Skip enqueue errors for MXNet version < 1.5.0")
     def test_horovod_alltoall_equal_split_length_error(self):

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -3579,6 +3579,394 @@ class TensorFlowTests(BaseTensorFlowTests):
                             "gradient %s differs from expected %s, "
                             "error: %s" % (grad_out, expected, str(err)))
 
+    def test_horovod_grouped_reducescatter_cpu(self):
+        """Test on CPU that the grouped reducescatter correctly sums or averages and scatters 1D, 2D, 3D tensors."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for red_op, dtype, dim in itertools.product([hvd.Sum, hvd.Average], dtypes, dims):
+            with tf.device("/cpu:0"):
+                tensors = [self.random_uniform([size * 4] * dim, -100, 100, dtype=dtype) for _ in range(5)]
+                reduced = hvd.grouped_reducescatter(tensors, op=red_op)
+            if red_op == hvd.Sum:
+                expected = [tf.cast(tensor[rank * 4:(rank + 1) * 4] * size, reduced[0].dtype) for tensor in tensors]
+            elif red_op == hvd.Average:
+                expected = [tf.cast(tensor[rank * 4:(rank + 1) * 4], reduced[0].dtype) for tensor in tensors]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(t1 - t2)) for t1, t2 in zip(reduced, expected)])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if dtype == tf.float16:
+                threshold = .5
+            elif dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_reducescatter produces incorrect results")
+
+    def test_horovod_grouped_reducescatter_cpu_process_sets(self):
+        """Test on CPU that the grouped reducescatter correctly sums if restricted to non-global process sets"""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+        if rank in even_ranks:
+            this_set = even_set
+        else:
+            this_set = odd_set
+        process_set_size = this_set.size()
+        process_set_rank = this_set.rank()
+
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for red_op, dtype, dim in itertools.product([hvd.Sum, hvd.Average], dtypes, dims):
+            with tf.device("/cpu:0"):
+                even_rank_tensors = [self.random_uniform([process_set_size * 4] * dim, -100, 100, dtype=dtype)
+                                     for _ in range(5)]
+                odd_rank_tensors = [self.random_uniform([process_set_size * 4] * dim, -100, 100, dtype=dtype)
+                                    for _ in range(5)]
+                if rank in even_ranks:
+                    tensors = even_rank_tensors
+                else:
+                    tensors = odd_rank_tensors
+                reduced = hvd.grouped_reducescatter(tensors, op=red_op, process_set=this_set)
+            if red_op == hvd.Sum:
+                expected = [tf.cast(tensor[process_set_rank * 4:(process_set_rank + 1) * 4] * process_set_size,
+                                    reduced[0].dtype) for tensor in tensors]
+            elif red_op == hvd.Average:
+                expected = [tf.cast(tensor[process_set_rank * 4:(process_set_rank + 1) * 4], reduced[0].dtype)
+                            for tensor in tensors]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(t1 - t2)) for t1, t2 in zip(reduced, expected)])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if dtype == tf.float16:
+                threshold = .5
+            elif dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif process_set_size < 10:
+                threshold = 1e-4
+            elif process_set_size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold,
+                            "hvd.reducescatter produces incorrect results")
+
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
+    def test_horovod_grouped_reducescatter_grad_cpu(self):
+        """Test the correctness of the grouped reducescatter gradient on CPU."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                if _executing_eagerly():
+                    tensors = [self.tfe.Variable(self.random_uniform([size * 4] * dim, -100, 100, dtype=dtype))
+                               for _ in range(5)]
+                    with tf.GradientTape(persistent=True) as tape:
+                        summed = hvd.grouped_reducescatter(tensors, op=hvd.Sum)
+                else:
+                    tensors = [self.random_uniform([size * 4] * dim, -100, 100, dtype=dtype)
+                               for _ in range(5)]
+                    summed = hvd.grouped_reducescatter(tensors, op=hvd.Sum)
+
+                grads_ys = [tf.ones([4] + [size * 4] * (dim - 1)) for _ in range(5)]
+                if _executing_eagerly():
+                    grads_out = [tape.gradient(s, t, g) for s, t, g in zip(summed, tensors, grads_ys)]
+                else:
+                    grads = [tf.gradients(s, t, g)[0] for s, t, g in zip(summed, tensors, grads_ys)]
+                    grads_out = self.evaluate(grads)
+
+            expected = np.ones([size * 4] * dim) * size
+            for grad_out in grads_out:
+                err = np.linalg.norm(expected - grad_out)
+                self.assertLess(err, 0.00000001,
+                                "gradient %s differs from expected %s, "
+                                "error: %s" % (grad_out, expected, str(err)))
+
+    def test_horovod_grouped_reducescatter_gpu(self):
+        """Test that the grouped reducescatter works on GPUs."""
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest("No GPUs available")
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        local_rank = hvd.local_rank()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        dtypes = [tf.int32, tf.int64, tf.float16, tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for red_op, dtype, dim in itertools.product([hvd.Sum, hvd.Average], dtypes, dims):
+            with tf.device("/gpu:%d" % local_rank):
+                tensors = [self.random_uniform([size * 4] * dim, -100, 100, dtype=dtype)
+                           for _ in range(5)]
+                reduced = hvd.grouped_reducescatter(tensors, op=red_op)
+            if red_op == hvd.Sum:
+                expected = [tf.cast(tensor[rank * 4:(rank + 1) * 4] * size, reduced[0].dtype)
+                            for tensor in tensors]
+            elif red_op == hvd.Average:
+                expected = [tf.cast(tensor[rank * 4:(rank + 1) * 4], reduced[0].dtype)
+                            for tensor in tensors]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(t1 - t2)) for t1, t2 in zip(reduced, expected)])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if dtype == tf.float16:
+                threshold = .5
+            elif dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                return
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold,
+                            "hvd.grouped_reducescatter on GPU produces incorrect results")
+
+    def test_horovod_grouped_allgather_cpu(self):
+        """Test that the grouped allgather correctly gathers 1D, 2D, 3D tensors."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64, tf.bool]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensors = [tf.ones([17] * dim) * rank for _ in range(5)]
+            if dtype == tf.bool:
+                tensors = [tensor % 2 for tensor in tensors]
+            tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+            with tf.device("/cpu:0"):
+                gathered = hvd.grouped_allgather(tensors)
+
+            gathered_tensors = self.evaluate(gathered)
+            for gathered_tensor in gathered_tensors:
+                self.assertEqual(list(gathered_tensor.shape),
+                                 [17 * size] + [17] * (dim - 1))
+
+            for i in range(size):
+                rank_tensors = [tf.slice(gathered_tensor,
+                                         [i * 17] + [0] * (dim - 1),
+                                         [17] + [-1] * (dim - 1))
+                                for gathered_tensor in gathered_tensors]
+                self.assertEqual([rank_tensor.shape for rank_tensor in rank_tensors], len(tensors) * [[17] * dim])
+                # tf.equal() does not support tf.uint16 as of TensorFlow 1.2,
+                # so need to cast rank_tensor to tf.int32.
+                if dtype != tf.bool:
+                    value = i
+                else:
+                    value = i % 2
+                self.assertTrue(all(self.evaluate(tf.reduce_all(
+                    tf.equal(tf.cast(rank_tensor, tf.int32), value))) for rank_tensor in rank_tensors),
+                    "hvd.grouped_allgather produces incorrect gathered tensor")
+
+    def test_horovod_grouped_allgather_cpu_process_sets(self):
+        """Test that the grouped allgather correctly gathers 1D, 2D, 3D tensors
+        if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+
+        if rank in even_ranks:
+            set_size = len(even_ranks)
+            set_ranks = even_ranks
+            this_set = even_set
+        elif rank in odd_ranks:
+            set_size = len(odd_ranks)
+            set_ranks = odd_ranks
+            this_set = odd_set
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64, tf.bool]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensors = [tf.ones([17] * dim) * rank for _ in range(5)]
+            if dtype == tf.bool:
+                tensors = [tensor % 2 for tensor in tensors]
+            tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+            with tf.device("/cpu:0"):
+                gathered = hvd.grouped_allgather(tensors, process_set=this_set)
+
+            gathered_tensors = self.evaluate(gathered)
+            for gathered_tensor in gathered_tensors:
+                self.assertEqual(list(gathered_tensor.shape),
+                                 [17 * set_size] + [17] * (dim - 1))
+
+            for i in range(set_size):
+                rank_tensors = [tf.slice(gathered_tensor,
+                                         [i * 17] + [0] * (dim - 1),
+                                         [17] + [-1] * (dim - 1))
+                                for gathered_tensor in gathered_tensors]
+                self.assertEqual([rank_tensor.shape for rank_tensor in rank_tensors], len(tensors) * [[17] * dim])
+                # tf.equal() does not support tf.uint16 as of TensorFlow 1.2,
+                # so need to cast rank_tensor to tf.int32.
+                if dtype != tf.bool:
+                    value = set_ranks[i]
+                else:
+                    value = set_ranks[i] % 2
+                self.assertTrue(all(self.evaluate(tf.reduce_all(
+                    tf.equal(tf.cast(rank_tensor, tf.int32), value))) for rank_tensor in rank_tensors),
+                    "hvd.grouped_allgather produces incorrect gathered tensor")
+
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
+    def test_horovod_grouped_allgather_grad_cpu(self):
+        """Test the correctness of the grouped allgather gradient on CPU."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        # As of TensorFlow v1.9, gradients are not supported on
+        # integer tensors
+        dtypes = [tf.float32, tf.float64]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            print(dtype)
+            tensor_sizes = [3, 2, 7, 4, 6, 8, 10] * 5
+            tensor_sizes = tensor_sizes[:size]
+
+            with tf.device("/cpu:0"):
+                if _executing_eagerly():
+                    with tf.GradientTape(persistent=True) as tape:
+                        tensors = [self.tfe.Variable(tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank)
+                                   for _ in range(5)]
+                        tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+                        gathered = hvd.grouped_allgather(tensors)
+                        grad_list = []
+                        for r, tensor_size in enumerate(tensor_sizes):
+                            g = tf.ones([tensor_size] + [17] * (dim - 1)) * r
+                            grad_list.append(g)
+                        grads_ys = [tf.concat(grad_list, axis=0) for _ in range(5)]
+                    grads_out = [tape.gradient(x, t, g) for x, t, g in zip(gathered, tensors, grads_ys)]
+                else:
+                    tensors = [tf.ones([tensor_sizes[rank]] + [17] * (dim - 1)) * rank
+                               for _ in range(5)]
+                    tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+                    gathered = hvd.grouped_allgather(tensors)
+
+                    grad_list = []
+                    for r, tensor_size in enumerate(tensor_sizes):
+                        g = tf.ones([tensor_size] + [17] * (dim - 1)) * r
+                        grad_list.append(g)
+                    grad_ys = tf.concat(grad_list, axis=0)
+                    grads = [tf.gradients(x, t, grad_ys)[0] for x, t in zip(gathered, tensors)]
+
+                    grads_out = self.evaluate(grads)
+
+            expected = np.ones(
+                [tensor_sizes[rank]] + [17] * (dim - 1)
+            ) * rank
+            for grad_out in grads_out:
+                err = np.linalg.norm(expected - grad_out)
+                self.assertLess(err, 0.00000001,
+                                "gradient %s differs from expected %s, "
+                                "error: %s" %
+                                (grad_out, expected, str(err)))
+
+    def test_horovod_grouped_allgather_gpu(self):
+        """Test that the grouped allgather correctly gathers 1D, 2D, 3D tensors."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+        size = hvd.size()
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64, tf.bool]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensors = [tf.ones([17] * dim) * rank for _ in range(5)]
+            if dtype == tf.bool:
+                tensors = [tensor % 2 for tensor in tensors]
+            tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+            with tf.device("/gpu:%d" % local_rank):
+                gathered = hvd.grouped_allgather(tensors)
+
+            gathered_tensors = self.evaluate(gathered)
+            for gathered_tensor in gathered_tensors:
+                self.assertEqual(list(gathered_tensor.shape),
+                                 [17 * size] + [17] * (dim - 1))
+
+            for i in range(size):
+                rank_tensors = [tf.slice(gathered_tensor,
+                                         [i * 17] + [0] * (dim - 1),
+                                         [17] + [-1] * (dim - 1))
+                                for gathered_tensor in gathered_tensors]
+                self.assertEqual([rank_tensor.shape for rank_tensor in rank_tensors], len(tensors) * [[17] * dim])
+                # tf.equal() does not support tf.uint16 as of TensorFlow 1.2,
+                # so need to cast rank_tensor to tf.int32.
+                if dtype != tf.bool:
+                    value = i
+                else:
+                    value = i % 2
+                self.assertTrue(all(self.evaluate(tf.reduce_all(
+                    tf.equal(tf.cast(rank_tensor, tf.int32), value))) for rank_tensor in rank_tensors),
+                    "hvd.grouped_allgather produces incorrect gathered tensor")
+
+
+
 
 from tensorflow.python.framework.test_util import run_all_in_graph_and_eager_modes
 run_all_in_graph_and_eager_modes(TensorFlowTests)

--- a/test/parallel/test_tensorflow_process_sets.py
+++ b/test/parallel/test_tensorflow_process_sets.py
@@ -1523,6 +1523,129 @@ class TensorFlowProcessSetsTests(BaseTensorFlowTests):
         hvd.remove_process_set(odd_set)
         hvd.remove_process_set(even_set)
 
+    def test_horovod_grouped_reducescatter_cpu_process_sets(self):
+        """Test on CPU that the grouped reducescatter correctly sums if restricted to non-global process sets"""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+        if rank in even_ranks:
+            this_set = even_set
+        else:
+            this_set = odd_set
+        process_set_size = this_set.size()
+        process_set_rank = this_set.rank()
+
+        dtypes = self.filter_supported_types([tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for red_op, dtype, dim in itertools.product([hvd.Sum, hvd.Average], dtypes, dims):
+            with tf.device("/cpu:0"):
+                even_rank_tensors = [self.random_uniform([process_set_size * 4] * dim, -100, 100, dtype=dtype)
+                                     for _ in range(5)]
+                odd_rank_tensors = [self.random_uniform([process_set_size * 4] * dim, -100, 100, dtype=dtype)
+                                    for _ in range(5)]
+                if rank in even_ranks:
+                    tensors = even_rank_tensors
+                else:
+                    tensors = odd_rank_tensors
+                reduced = hvd.grouped_reducescatter(tensors, op=red_op, process_set=this_set)
+            if red_op == hvd.Sum:
+                expected = [tf.cast(tensor[process_set_rank * 4:(process_set_rank + 1) * 4] * process_set_size,
+                                    reduced[0].dtype) for tensor in tensors]
+            elif red_op == hvd.Average:
+                expected = [tf.cast(tensor[process_set_rank * 4:(process_set_rank + 1) * 4], reduced[0].dtype)
+                            for tensor in tensors]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(t1 - t2)) for t1, t2 in zip(reduced, expected)])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if dtype == tf.float16:
+                threshold = .5
+            elif dtype in [tf.int32, tf.int64]:
+                threshold = 0
+            elif process_set_size < 10:
+                threshold = 1e-4
+            elif process_set_size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold,
+                            "hvd.reducescatter produces incorrect results")
+
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
+    def test_horovod_grouped_allgather_cpu_process_sets(self):
+        """Test that the grouped allgather correctly gathers 1D, 2D, 3D tensors
+        if restricted to non-global process sets."""
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+
+        if hvd.ccl_built():
+            self.skipTest("Multiple process sets currently do not support CCL.")
+
+        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+
+        even_set = hvd.add_process_set(even_ranks)
+        odd_set = hvd.add_process_set(odd_ranks)
+
+        if rank in even_ranks:
+            set_size = len(even_ranks)
+            set_ranks = even_ranks
+            this_set = even_set
+        elif rank in odd_ranks:
+            set_size = len(odd_ranks)
+            set_ranks = odd_ranks
+            this_set = odd_set
+
+        dtypes = [tf.uint8, tf.int8, tf.uint16, tf.int16,
+                  tf.int32, tf.int64, tf.float16, tf.float32,
+                  tf.float64, tf.bool]
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            tensors = [tf.ones([17] * dim) * rank for _ in range(5)]
+            if dtype == tf.bool:
+                tensors = [tensor % 2 for tensor in tensors]
+            tensors = [tf.cast(tensor, dtype=dtype) for tensor in tensors]
+            with tf.device("/cpu:0"):
+                gathered = hvd.grouped_allgather(tensors, process_set=this_set)
+
+            gathered_tensors = self.evaluate(gathered)
+            for gathered_tensor in gathered_tensors:
+                self.assertEqual(list(gathered_tensor.shape),
+                                 [17 * set_size] + [17] * (dim - 1))
+
+            for i in range(set_size):
+                rank_tensors = [tf.slice(gathered_tensor,
+                                         [i * 17] + [0] * (dim - 1),
+                                         [17] + [-1] * (dim - 1))
+                                for gathered_tensor in gathered_tensors]
+                self.assertEqual([rank_tensor.shape for rank_tensor in rank_tensors], len(tensors) * [[17] * dim])
+                # tf.equal() does not support tf.uint16 as of TensorFlow 1.2,
+                # so need to cast rank_tensor to tf.int32.
+                if dtype != tf.bool:
+                    value = set_ranks[i]
+                else:
+                    value = set_ranks[i] % 2
+                self.assertTrue(all(self.evaluate(tf.reduce_all(
+                    tf.equal(tf.cast(rank_tensor, tf.int32), value))) for rank_tensor in rank_tensors),
+                    "hvd.grouped_allgather produces incorrect gathered tensor")
+
+        hvd.remove_process_set(odd_set)
+        hvd.remove_process_set(even_set)
+
 
 from tensorflow.python.framework.test_util import run_all_in_graph_and_eager_modes
 run_all_in_graph_and_eager_modes(TensorFlowProcessSetsTests)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This adds two new multi-tensor functions to Horovod: `hvd.grouped_allgather()` and `hvd.grouped_reducescatter()`. They are very similar to the existing `hvd.grouped_allreduce()`, introduced with PR #2453, giving users the equivalent extra control over tensor fusion for their `Allgather` and `Reducescatter` ops.

To implement this functionality I've added a new attribute `output_index` to `TensorTableEntry`. This allows an `AllgatherOp` or `ReducescatterOp` that has been enqueued as part of a group to allocate its output tensor properly (in contrast to `Allreduce` this cannot be done beforehand because the resulting output size is only known after cross-process coordination). I've also added warning log messages in case `AllocateOutput` ever fails because TensorFlow would crash with just a default "Unknown error." exception message in such a case.

Supported frameworks:
- [x] TensorFlow
- [x] PyTorch
- [x] MXNet

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
