### PR TITLE
Update Eigen submodule to fix build on macOS with aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Updated Eigen submodule to fix build on macOS with aarch64.
+
 
 ## [v0.25.0] - 2022-06-20
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

On my computer (macOS 12.4, M1 Pro) this fixes building Horovod with PyTorch. Note that the problem does not occur if one builds with TensorFlow, too.

We need to make sure to build with a version of Eigen that's recent enough to include the commit https://gitlab.com/libeigen/eigen/-/commit/fd1dcb6b45a2c797ad4c4d6cc7678ee70763b4ed; else we get duplicate symbol errors. The latest release 3.4.0 includes the fix, which is why I opted for that version: https://gitlab.com/libeigen/eigen/-/tags/3.4.0 (commit hash 3147391d).

When we build with TensorFlow, we don't use Eigen from the submodule, but we use the version of the library that ships with the TF package. For that reason I believe that this change will not affect anything running in the CI: As far as I know, there, we always build with all three frameworks TensorFlow, PyTorch, and MXNet.

Fixes #3605 and #3587.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
