### PR TITLE
Add support for batched memory copies in GPUReducescatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for batched memory copies in GPUAllgather. ([#3590](https://github.com/horovod/horovod/pull/3590))
+- Added support for batched memory copies in GPUReducescatter.
+
 ### Changed
 
 ### Deprecated
@@ -17,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Updated Eigen submodule to fix build on macOS with aarch64.
+- Fix FuseResponses() on BATCHED_D2D_PADDING edge cases for Reducescatter and/or ROCm.
 
 
 ## [v0.25.0] - 2022-06-20

--- a/horovod/common/ops/cuda/cuda_kernels.cu
+++ b/horovod/common/ops/cuda/cuda_kernels.cu
@@ -59,9 +59,9 @@ __global__ void batched_memcpy_k(BatchedD2DParams params) {
   // Select load/store size based on the misaligned buffer
   size_t align = (align_out == 0) ? align_in : align_out;
   if (align_in && align_out) {
-    // If both are misaligned, use unsigned char (this should not occur
-    // as fusion buffer locations should be aligned by applying BATCH_D2D_PADDING
-    // during construction.)
+    // If both are misaligned, use unsigned char (this should not occur for
+    // Allreduces as fusion buffer locations should be aligned by applying
+    // BATCHED_D2D_PADDING during construction.)
     align = 1;
   }
 

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -692,5 +692,115 @@ void GPUReduceScatter::MemcpyEntryOutFusionBuffer(
       gpu_context_->streams[global_state_->current_nccl_stream][e.device]);
 }
 
+#if HAVE_GPU
+void GPUReduceScatter::MemcpyInFusionBuffer(
+    const std::vector<TensorTableEntry>& entries,
+    const std::vector<std::vector<TensorShape>>& output_shapes,
+    std::size_t element_size, void*& buffer_data) {
+  if (global_state_->batch_d2d_memcopies) {
+    // Access the fusion buffer.
+    const auto& first_entry = entries[0];
+    auto buffer = global_state_->fusion_buffer.GetBuffer(
+        first_entry.device, first_entry.context->framework(),
+        global_state_->current_nccl_stream);
+    buffer_data = const_cast<void*>(buffer->AccessData(first_entry.context));
+
+    size_t buffer_offset = 0;
+    std::vector<size_t> entry_offsets(entries.size(), 0);
+
+    size_t idx = 0;
+    int count = 0;
+    const size_t total_count = output_shapes.size() * entries.size();
+    BatchedD2DParams d2d_params;
+    for (const auto& rank_shapes : output_shapes) {
+      for (size_t ec = 0; ec < entries.size(); ++ec) {
+        auto& e = entries[ec];
+        const auto& entry_shape = rank_shapes[ec];
+        const size_t entry_offset = entry_offsets[ec];
+        const size_t entry_size = entry_shape.num_elements() * element_size;
+        void* buffer_data_at_offset = (uint8_t*)buffer_data + buffer_offset;
+        void* tensor_data_at_offset = (uint8_t*)e.tensor->data() + entry_offset;
+
+        // accumulate the buffered data
+        d2d_params.out[idx % BATCHED_D2D_CAPACITY] = buffer_data_at_offset;
+        d2d_params.in[idx % BATCHED_D2D_CAPACITY] = tensor_data_at_offset;
+        d2d_params.sizes[idx % BATCHED_D2D_CAPACITY] = entry_size;
+
+        entry_offsets[ec] += entry_size;
+        buffer_offset += entry_size;
+        idx++;
+        count++;
+
+        if (idx % BATCHED_D2D_CAPACITY == 0 || idx == total_count) {
+          // do the batched d2d memcopies of all the accumulated entries
+#if HAVE_CUDA
+          BatchedD2DMemcpyCudaImpl(
+              d2d_params, count,
+              gpu_context_->streams[global_state_->current_nccl_stream]
+                                   [first_entry.device]);
+#elif HAVE_ROCM
+          BatchedD2DMemcpyROCmImpl(
+              d2d_params, count,
+              gpu_context_->streams[global_state_->current_nccl_stream]
+                                   [first_entry.device]);
+#endif
+          // TODO: https://github.com/horovod/horovod/issues/2230
+          // gpu_context_->ErrorCheck("BatchedD2DMemcpyCudaImpl",
+          // cudaGetLastError());
+          count = 0;
+        }
+      }
+    }
+  } else {
+    // default implementation using GPUReduceScatter::MemcpyEntryInFusionBuffer
+    ReducescatterOp::MemcpyInFusionBuffer(entries, output_shapes, element_size,
+                                          buffer_data);
+  }
+}
+
+void GPUReduceScatter::MemcpyOutFusionBuffer(
+    const void* buffer_data, std::vector<TensorTableEntry>& entries) {
+  if (global_state_->batch_d2d_memcopies) {
+    int device = entries[0].device;
+    int64_t offset = 0;
+    size_t idx = 0;
+    int count = 0;
+    BatchedD2DParams d2d_params;
+    for (auto& e : entries) {
+      void* buffer_data_at_offset = (uint8_t*)buffer_data + offset;
+
+      // populate the d2d params for blocked mem copies
+      d2d_params.out[idx % BATCHED_D2D_CAPACITY] = (void*)e.output->data();
+      d2d_params.in[idx % BATCHED_D2D_CAPACITY] = buffer_data_at_offset;
+      d2d_params.sizes[idx % BATCHED_D2D_CAPACITY] = (size_t)e.output->size();
+
+      offset += e.output->size();
+      idx++;
+      count++;
+
+      if (idx % BATCHED_D2D_CAPACITY == 0 || idx == entries.size()) {
+        // do the batched d2d memcopies of all the accumulated entries
+#if HAVE_CUDA
+        BatchedD2DMemcpyCudaImpl(
+            d2d_params, count,
+            gpu_context_->streams[global_state_->current_nccl_stream][device]);
+#elif HAVE_ROCM
+        BatchedD2DMemcpyROCmImpl(
+            d2d_params, count,
+            gpu_context_->streams[global_state_->current_nccl_stream][device]);
+#endif
+        // TODO: https://github.com/horovod/horovod/issues/2230
+        // gpu_context_->ErrorCheck("BatchedD2DMemcpyCudaImpl",
+        // cudaGetLastError());
+        count = 0;
+      }
+    }
+  } else {
+    // default implementation using GPUReduceScatter::MemcpyEntryOutFusionBuffer
+    ReducescatterOp::MemcpyOutFusionBuffer(buffer_data, entries);
+  }
+}
+#endif // HAVE_GPU
+
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -188,7 +188,7 @@ protected:
   void ScaleBuffer(double scale_factor,
                    const std::vector<TensorTableEntry>& entries,
                    const void* fused_input_data, void* buffer_data,
-                   int64_t num_elements);
+                   int64_t num_elements) override;
 
   GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;
@@ -235,7 +235,7 @@ public:
                const Response& response) const override;
 
 protected:
-  struct GPUContext* gpu_context_;
+  GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;
 };
 
@@ -266,6 +266,16 @@ protected:
 
   void MemcpyEntryOutFusionBuffer(const void* buffer_data_at_offset,
                                   TensorTableEntry& e) override;
+
+#if HAVE_GPU
+  void MemcpyInFusionBuffer(
+      const std::vector<TensorTableEntry>& entries,
+      const std::vector<std::vector<TensorShape>>& output_shapes,
+      std::size_t element_size, void*& buffer_data) override;
+
+  void MemcpyOutFusionBuffer(const void* buffer_data,
+                             std::vector<TensorTableEntry>& entries) override;
+#endif // HAVE_GPU
 
   GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;

--- a/horovod/common/ops/rocm/hip_kernels.cu
+++ b/horovod/common/ops/rocm/hip_kernels.cu
@@ -59,9 +59,9 @@ __global__ void batched_memcpy_k(BatchedD2DParams params) {
   // Select load/store size based on the misaligned buffer
   size_t align = (align_out == 0) ? align_in : align_out;
   if (align_in && align_out) {
-    // If both are misaligned, use unsigned char (this should not occur
-    // as fusion buffer locations should be aligned by applying BATCH_D2D_PADDING
-    // during construction.)
+    // If both are misaligned, use unsigned char (this should not occur for
+    // Allreduces as fusion buffer locations should be aligned by applying
+    // BATCHED_D2D_PADDING during construction.)
     align = 1;
   }
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

In a similar fashion to the recent PR #3590 for Allgather, this adds support for more efficient, batched memory copies in the GPU implementation of Reducescatter.

I've also fixed a related minor bug in `Controller::FuseResponses()`, where extra padding bytes were counted mistakenly for Reducescatter when aggregating tensors up to fusion buffer size.

To improve memory alignment this padding could be introduced for Reducescatter (and Allgather), too, but it would be a bit trickier to get right than for Allreduce.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
