### PR TITLE
fix the optimizer iteration count when gradient accumulation is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Tensorflow: Fixed the optimizer iteration increments when `backward_passes_per_step > 1`. ([#3631](https://github.com/horovod/horovod/pull/3631))
 - Updated Eigen submodule to fix build on macOS with aarch64. ([#3619](https://github.com/horovod/horovod/pull/3619))
 - Fix FuseResponses() on BATCHED_D2D_PADDING edge cases for Reducescatter and/or ROCm. ([#3621](https://github.com/horovod/horovod/pull/3621))
 - PyTorch: Fixed Reducescatter functions to raise `HorovodInternalError` rather than `RuntimeError`. ([#3594](https://github.com/horovod/horovod/pull/3594))

--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -241,8 +241,14 @@ class LocalGradientAggregationHelper:
         # If optimizer tracks iterations, we increment it on steps where we
         # are not going to call `apply_gradients()`.
         def increment_optimizer_iteration():
-            if hasattr(optimizer, "_iterations") and optimizer._iterations is not None:
-                return optimizer._iterations.assign_add(1).op
+            # (kvignesh1420): Since all `tf.OptimizerV2` instances have the `iterations`
+            # property for modifying the underlying `optimizer._iterations`, it is safe to use
+            # the property instead of the private variable. For instance, the keras
+            # `LossScaleOptimizer` inherits `tf.Optimizer` and exposes the cleaner `iterations`
+            # property instead of the unsafe `_iterations`.
+
+            if hasattr(optimizer, "iterations") and optimizer.iterations is not None:
+                return optimizer.iterations.assign_add(1).op
             return tf.no_op()
 
         with tf.control_dependencies([tf.group(*get_not_none_from_list(flattended_args0))]):

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -124,8 +124,14 @@ class LocalGradientAggregationHelperEager:
 
     def apply_gradients(self, apply_grads_closure, optimizer, *args, **kwargs):
         def increment_optimizer_iteration():
-            if hasattr(optimizer, "_iterations") and optimizer._iterations is not None:
-                return optimizer._iterations.assign_add(1).op
+            # (kvignesh1420): Since all `tf.OptimizerV2` instances have the `iterations`
+            # property for modifying the underlying `optimizer._iterations`, it is safe to use
+            # the property instead of the private variable. For instance, the keras
+            # `LossScaleOptimizer` inherits `tf.Optimizer` and exposes the cleaner `iterations`
+            # property instead of the unsafe `_iterations`.
+
+            if hasattr(optimizer, "iterations") and optimizer.iterations is not None:
+                return optimizer.iterations.assign_add(1).op
             return tf.no_op()
 
         def non_aggregation_step():


### PR DESCRIPTION

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? NA
- [x] Did you write any tests to validate this change?  Current tests suffice.
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

When gradient accumulation is enabled (`backward_passes_per_step > 1`), the underlying optimizer iteration count update uses the `optimizer._iterations` private variable which might not be exposed for custom optimizers such as the [LossScaleOptimizer](https://github.com/keras-team/keras/blob/059781f3b02ff01d419637c76de833002869ff92/keras/mixed_precision/loss_scale_optimizer.py#L587) in keras. 

The users who have been using such optimizers would not have incremented the underlying iterations property as we just return a `tf.no_op()`, which in turn affects the update calculation. For instance, when we wrap  `Adam` optimizer with `LossScaleOptimizer`, the adam updates would have been miscalculated. This PR fixes this issue by using the safer `iterations` property.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
