### PR TITLE
TF: Make most tests use statically initialized process sets

### DIFF
--- a/test/parallel/test_process_sets_multi_comm.py
+++ b/test/parallel/test_process_sets_multi_comm.py
@@ -1,10 +1,7 @@
 import os
-import sys
 import unittest
 
 import horovod.tensorflow as hvd
-
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 class ProcessSetsMultiCommTests(unittest.TestCase):
     """ Since this test case initializes Horovod and shuts it down, it must be run in a separate process. """

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -15,10 +15,8 @@
 
 """Tests for horovod.tensorflow.keras in TensorFlow 2."""
 
-import math
 import tensorflow as tf
 import numpy as np
-import os
 import warnings
 
 from distutils.version import LooseVersion

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -17,11 +17,6 @@ from horovod.runner.common.util.env import get_env_rank_and_size
 
 _PRE_TF_2_2_0 = LooseVersion(tf.__version__) < LooseVersion("2.2.0")
 
-# Set environment variable to enable adding/removing process sets after
-# initializing Horovod.
-os.environ["HOROVOD_DYNAMIC_PROCESS_SETS"] = "1"
-
-
 @pytest.mark.skipif(LooseVersion(tf.__version__) <
                     LooseVersion('2.0.0'), reason='TensorFlow v2 tests')
 class Tf2KerasProcessSetsTests(tf.test.TestCase):

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -6,14 +6,10 @@ tests for multiple process sets in this script that initializes Horovod with sta
 """
 
 import tensorflow as tf
-import os
-import sys
 import warnings
 from distutils.version import LooseVersion
 import pytest
 from tensorflow import keras
-
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 import horovod.tensorflow.keras as hvd
 from horovod.runner.common.util.env import get_env_rank_and_size

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -16,8 +16,7 @@ from tensorflow import keras
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 import horovod.tensorflow.keras as hvd
-
-from common import mpi_env_rank_and_size
+from horovod.runner.common.util.env import get_env_rank_and_size
 
 
 _PRE_TF_2_2_0 = LooseVersion(tf.__version__) < LooseVersion("2.2.0")
@@ -41,9 +40,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
     @classmethod
     def setUpClass(cls):
         """Initializes Horovod with two process sets"""
-        _, mpi_size = mpi_env_rank_and_size()
-        gloo_size = int(os.getenv('HOROVOD_SIZE', -1))
-        size = max(mpi_size, gloo_size)
+        _, size = get_env_rank_and_size()
 
         cls.even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
         cls.odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -59,6 +59,12 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
             tf.config.experimental.set_visible_devices(
                 gpus[hvd.local_rank()], 'GPU')
 
+    def tearDown(self):
+        """Prevent that one process shuts down Horovod too early"""
+        with tf.device("/cpu:0"):
+            b = hvd.allreduce(tf.constant([0.]), name="global_barrier_after_test")
+            _ = self.evaluate(b)
+
     def test_process_set_optimizer(self):
         """ Note that this test makes the most sense when running with > 2 processes. """
         size = hvd.size()

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -1,21 +1,23 @@
-"""Tests for horovod.tensorflow.keras in TensorFlow 2 that add/remove process sets after initialization.
+"""Tests for horovod.tensorflow.keras in TensorFlow 2 using multiple process sets.
 
 With TensorFlow 2.9 and MPI the option HOROVOD_DYNAMIC_PROCESS_SETS has been observed to cause significant
-slowdowns in all Horovod operations, especially on GPU-equipped AWS instances. For that reason we separate
-out tests that depend on that setting to this script.
+slowdowns in all Horovod operations, especially on GPU-equipped AWS instances. For that reason we collect
+tests for multiple process sets in this script that initializes Horovod with static process sets.
 """
 
 import tensorflow as tf
 import os
+import sys
 import warnings
-
 from distutils.version import LooseVersion
-
 import pytest
-
 from tensorflow import keras
 
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
+
 import horovod.tensorflow.keras as hvd
+
+from common import mpi_env_rank_and_size
 
 
 _PRE_TF_2_2_0 = LooseVersion(tf.__version__) < LooseVersion("2.2.0")
@@ -29,13 +31,26 @@ os.environ["HOROVOD_DYNAMIC_PROCESS_SETS"] = "1"
                     LooseVersion('2.0.0'), reason='TensorFlow v2 tests')
 class Tf2KerasProcessSetsTests(tf.test.TestCase):
     """
-    Tests for ops in horovod.tensorflow.keras that add/remove process sets after initialization.
+    Tests for ops in horovod.tensorflow.keras using multiple process sets.
     """
 
     def __init__(self, *args, **kwargs):
         super(Tf2KerasProcessSetsTests, self).__init__(*args, **kwargs)
         warnings.simplefilter('module')
-        hvd.init()
+
+    @classmethod
+    def setUpClass(cls):
+        """Initializes Horovod with two process sets"""
+        _, mpi_size = mpi_env_rank_and_size()
+        gloo_size = int(os.getenv('HOROVOD_SIZE', -1))
+        size = max(mpi_size, gloo_size)
+
+        cls.even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        cls.odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        cls.even_set = hvd.ProcessSet(cls.even_ranks)
+        cls.odd_set = hvd.ProcessSet(cls.odd_ranks)
+
+        hvd.init(process_sets=[cls.even_set, cls.odd_set])
 
         gpus = tf.config.experimental.list_physical_devices('GPU')
         for gpu in gpus:
@@ -50,8 +65,6 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
 
         if size == 1:
             self.skipTest("Only one worker available")
-
-        subset = hvd.add_process_set(range(0, size, 2))
 
         class TestOptimizer(keras.optimizers.Optimizer):
             def __init__(self, name, **kwargs):
@@ -72,19 +85,15 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 return config
 
         opt = TestOptimizer(name="TestOpti")
-        opt = hvd.DistributedOptimizer(opt, process_set=subset)
+        opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)
 
         variable = tf.Variable([0.0])
         gradient, = opt.get_gradients(None, [variable])
         opt.apply_gradients([(gradient, variable)])
         computed_value = variable.numpy()
 
-        if subset.included():
-            self.assertAlmostEqual(
-                computed_value, sum(
-                    range(
-                        0, size, 2)) / subset.size())
+        if self.even_set.included():
+            self.assertAlmostEqual(computed_value,
+                                   sum(range(0, size, 2)) / self.even_set.size())
         else:
             self.assertAlmostEqual(computed_value, float(hvd.rank()))
-
-        hvd.remove_process_set(subset)

--- a/test/parallel/test_tensorflow_process_sets.py
+++ b/test/parallel/test_tensorflow_process_sets.py
@@ -23,7 +23,7 @@ import horovod.tensorflow as hvd
 
 from base_test_tensorflow import *
 
-from common import mpi_env_rank_and_size
+from horovod.runner.common.util.env import get_env_rank_and_size
 
 _IS_TF2 = LooseVersion(tf.__version__) >= LooseVersion('2.0.0')
 _is_mac = platform.system() == 'Darwin'
@@ -39,9 +39,7 @@ class TensorFlowProcessSetsTests(BaseTensorFlowTests):
     @classmethod
     def setUpClass(cls):
         """Initializes Horovod with two process sets"""
-        _, mpi_size = mpi_env_rank_and_size()
-        gloo_size = int(os.getenv('HOROVOD_SIZE', -1))
-        size = max(mpi_size, gloo_size)
+        _, size = get_env_rank_and_size()
 
         cls.even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
         cls.odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]

--- a/test/parallel/test_tensorflow_process_sets.py
+++ b/test/parallel/test_tensorflow_process_sets.py
@@ -9,15 +9,9 @@ from distutils.version import LooseVersion
 
 import itertools
 import numpy as np
-import os
 import platform
-import math
-import pytest
-import sys
 import tensorflow as tf
 from horovod.tensorflow.util import _executing_eagerly
-
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 import horovod.tensorflow as hvd
 

--- a/test/parallel/test_tensorflow_process_sets_dynamic.py
+++ b/test/parallel/test_tensorflow_process_sets_dynamic.py
@@ -5,12 +5,7 @@ slowdowns in all Horovod operations, especially on GPU-equipped AWS instances. F
 tests that depend on that setting in this script.
 """
 
-import os
-import sys
 import tensorflow as tf
-from horovod.tensorflow.util import _executing_eagerly
-
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 import horovod.tensorflow as hvd
 

--- a/test/parallel/test_tensorflow_process_sets_dynamic.py
+++ b/test/parallel/test_tensorflow_process_sets_dynamic.py
@@ -1,0 +1,110 @@
+"""Tests for horovod.tensorflow.mpi_ops that add/remove process sets after initialization.
+
+With TensorFlow 2.9 and MPI the option HOROVOD_DYNAMIC_PROCESS_SETS has been observed to cause significant
+slowdowns in all Horovod operations, especially on GPU-equipped AWS instances. For that reason we collect
+tests that depend on that setting in this script.
+"""
+
+import os
+import sys
+import tensorflow as tf
+from horovod.tensorflow.util import _executing_eagerly
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
+
+import horovod.tensorflow as hvd
+
+from base_test_tensorflow import *
+
+# Set environment variable to enable adding/removing process sets after initializing Horovod.
+os.environ["HOROVOD_DYNAMIC_PROCESS_SETS"] = "1"
+
+class TensorFlowProcessSetsDynamicTests(BaseTensorFlowTests):
+    """
+    Tests for ops in horovod.tensorflow that add/remove process sets after initialization.
+    """
+    def __init__(self, *args, **kwargs):
+        super(TensorFlowProcessSetsDynamicTests, self).__init__(*args, **kwargs)
+
+    def test_horovod_add_get_remove_process_set(self):
+        hvd.init()
+        size = hvd.size()
+
+        # This test does not apply if there is only one worker.
+        if size == 1:
+            self.skipTest("Only one worker available")
+
+        # Here we test some implementation details (numeric process set id values) using an internal function. We only
+        # test the concrete value 0 because IDs will be reassigned between eager and graph-mode test runs and may
+        # change.
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        self.assertDictEqual(ps, {0: list(range(size))})
+
+        set1 = hvd.add_process_set([0])
+        set2 = hvd.add_process_set(range(1, size))
+
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        self.assertDictEqual(ps, {0: list(range(size)),
+                                  set1.process_set_id: [0],
+                                  set2.process_set_id: list(range(1, size))})
+
+        # Ensure process set ids are equal across processes.
+        with tf.device("/cpu:0"):
+            for a_set in [set1, set2]:
+                ids_on_ranks = list(self.evaluate(hvd.allgather(tf.convert_to_tensor([a_set.process_set_id]))))
+                self.assertTrue(all(an_id == a_set.process_set_id for an_id in ids_on_ranks))
+
+        # Test stringification
+        self.assertListEqual([str(p) for p in [hvd.global_process_set, set1, set2]],
+                             [f"ProcessSet(process_set_id=0, ranks={list(range(size))}, mpi_comm=None)",
+                              f"ProcessSet(process_set_id={set1.process_set_id}, ranks=[0], mpi_comm=None)",
+                              f"ProcessSet(process_set_id={set2.process_set_id}, ranks={list(range(1, size))}, mpi_comm=None)",
+                              ])
+
+        old_id_of_set1 = set1.process_set_id
+        hvd.remove_process_set(set1)
+        self.assertIsNone(set1.process_set_id)  # invalidated
+
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        self.assertDictEqual(ps, {0: list(range(size)),
+                                  set2.process_set_id: list(range(1, size))})
+
+        # test re-adding set1
+        hvd.add_process_set(set1)
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        self.assertDictEqual(ps, {0: list(range(size)),
+                                  set1.process_set_id: [0],
+                                  set2.process_set_id: list(range(1, size))})
+        hvd.remove_process_set(set1)
+
+
+        if size > 2:
+            set3 = hvd.add_process_set([0, size - 1])
+            self.assertEqual(old_id_of_set1, set3.process_set_id) # id reuse
+        else:
+            with self.assertRaises(ValueError):  # duplicate of the global process set
+                set3 = hvd.add_process_set([0, size - 1])
+            set3 = hvd.global_process_set
+
+        with self.assertRaises(ValueError):  # duplicate of set2
+            set4 = hvd.add_process_set(range(size - 1, 0, -1))
+
+        with self.assertRaises(ValueError):  # duplicate of the global process set
+            set5 = hvd.add_process_set(range(0, size))
+
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        if size > 2:
+            self.assertDictEqual(ps, {0: list(range(size)),
+                                      set2.process_set_id: list(range(1, size)),
+                                      set3.process_set_id: [0, size-1]})
+        else:
+            self.assertDictEqual(ps, {0: list(range(size)),
+                                      set2.process_set_id: list(range(1, size))})
+        hvd.remove_process_set(set2)
+        hvd.remove_process_set(set3)
+
+        ps = hvd.mpi_ops._basics._get_process_set_ids_and_ranks()
+        self.assertDictEqual(ps, {0: list(range(size))})
+
+        self.assertFalse(hvd.remove_process_set(hvd.global_process_set),
+                         "Removing the global process set should be impossible.")

--- a/test/parallel/test_tensorflow_process_sets_dynamic.py
+++ b/test/parallel/test_tensorflow_process_sets_dynamic.py
@@ -26,6 +26,12 @@ class TensorFlowProcessSetsDynamicTests(BaseTensorFlowTests):
     def __init__(self, *args, **kwargs):
         super(TensorFlowProcessSetsDynamicTests, self).__init__(*args, **kwargs)
 
+    def tearDown(self):
+        """Prevent that one process shuts down Horovod too early"""
+        with tf.device("/cpu:0"):
+            b = hvd.allreduce(tf.constant([0.]), name="global_barrier_after_test")
+            _ = self.evaluate(b)
+
     def test_horovod_add_get_remove_process_set(self):
         hvd.init()
         size = hvd.size()

--- a/test/parallel/test_xla.py
+++ b/test/parallel/test_xla.py
@@ -26,7 +26,6 @@ import numpy as np
 import itertools
 from distutils.version import LooseVersion
 import warnings
-from common import mpi_env_rank_and_size, skip_or_fail_gpu_test
 
 # Enable HVD XLA ops so that tf.function(jit_compile=True) works. This
 # environment variable needs to be set up before loading Tensorflow, because

--- a/test/parallel/test_xla_process_sets.py
+++ b/test/parallel/test_xla_process_sets.py
@@ -76,6 +76,12 @@ class XLAProcessSetsTests(BaseTensorFlowTests):
 
         hvd.init(process_sets=[cls.even_set, cls.odd_set])
 
+    def tearDown(self):
+        """Prevent that one process shuts down Horovod too early"""
+        with tf.device("/cpu:0"):
+            b = hvd.allreduce(tf.constant([0.]), name="global_barrier_after_test")
+            _ = self.evaluate(b)
+
     def test_horovod_allreduce_gpu_process_sets(self):
         """ Test on XLA/GPU that allreduce correctly sums if restricted to non-global process sets"""
         # Only do this test if there are GPUs available.

--- a/test/parallel/test_xla_process_sets.py
+++ b/test/parallel/test_xla_process_sets.py
@@ -48,7 +48,7 @@ import horovod.tensorflow as hvd
 
 from base_test_tensorflow import *
 
-from common import mpi_env_rank_and_size
+from horovod.runner.common.util.env import get_env_rank_and_size
 
 _IS_TF26 = LooseVersion(tf.__version__) >= LooseVersion('2.6.0')
 
@@ -65,9 +65,7 @@ class XLAProcessSetsTests(BaseTensorFlowTests):
     @classmethod
     def setUpClass(cls):
         """Initializes Horovod with two process sets"""
-        _, mpi_size = mpi_env_rank_and_size()
-        gloo_size = int(os.getenv('HOROVOD_SIZE', -1))
-        size = max(mpi_size, gloo_size)
+        _, size = get_env_rank_and_size()
 
         cls.even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
         cls.odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]

--- a/test/parallel/test_xla_process_sets.py
+++ b/test/parallel/test_xla_process_sets.py
@@ -28,8 +28,6 @@ from distutils.version import LooseVersion
 import itertools
 import numpy as np
 import os
-import platform
-import math
 import pytest
 import sys
 
@@ -40,9 +38,6 @@ import sys
 os.environ["HOROVOD_ENABLE_XLA_OPS"] = "1"
 
 import tensorflow as tf
-from horovod.tensorflow.util import _executing_eagerly
-
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 
 import horovod.tensorflow as hvd
 

--- a/test/parallel/test_xla_process_sets.py
+++ b/test/parallel/test_xla_process_sets.py
@@ -48,58 +48,63 @@ import horovod.tensorflow as hvd
 
 from base_test_tensorflow import *
 
-_IS_TF26 = LooseVersion(tf.__version__) >= LooseVersion('2.6.0')
+from common import mpi_env_rank_and_size
 
-# Set environment variable to enable adding/removing process sets after
-# initializing Horovod.
-os.environ["HOROVOD_DYNAMIC_PROCESS_SETS"] = "1"
+_IS_TF26 = LooseVersion(tf.__version__) >= LooseVersion('2.6.0')
 
 
 @pytest.mark.skipif(not _IS_TF26, reason='TF2.6+ is required')
 class XLAProcessSetsTests(BaseTensorFlowTests):
     """
-    Tests for ops in horovod.tensorflow that add/remove process sets after initialization.
+    Tests for ops in horovod.tensorflow using multiple process sets.
     """
 
     def __init__(self, *args, **kwargs):
         super(XLAProcessSetsTests, self).__init__(*args, **kwargs)
 
+    @classmethod
+    def setUpClass(cls):
+        """Initializes Horovod with two process sets"""
+        _, mpi_size = mpi_env_rank_and_size()
+        gloo_size = int(os.getenv('HOROVOD_SIZE', -1))
+        size = max(mpi_size, gloo_size)
+
+        cls.even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
+        cls.odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
+        cls.even_set = hvd.ProcessSet(cls.even_ranks)
+        cls.odd_set = hvd.ProcessSet(cls.odd_ranks)
+
+        hvd.init(process_sets=[cls.even_set, cls.odd_set])
+
     def test_horovod_allreduce_gpu_process_sets(self):
         """ Test on XLA/GPU that allreduce correctly sums if restricted to non-global process sets"""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
-            self.skipTest(("No GPUs available"))
+            self.skipTest("No GPUs available")
 
         if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
             # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
             self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
 
-        hvd.init()
         local_rank = hvd.local_rank()
         rank = hvd.rank()
         size = hvd.size()
-
-        even_ranks = [rk for rk in range(0, size) if rk % 2 == 0]
-        odd_ranks = [rk for rk in range(0, size) if rk % 2 == 1]
-
-        even_set = hvd.add_process_set(even_ranks)
-        odd_set = hvd.add_process_set(odd_ranks)
 
         def allreduce_gpu_process_set(self, dtype, dim):
             even_rank_tensor = self.random_uniform(
                 [17] * dim, -100, 100, dtype=dtype)
             odd_rank_tensor = self.random_uniform(
                 [17] * dim, -100, 100, dtype=dtype)
-            if rank in even_ranks:
+            if rank in self.even_ranks:
                 summed = hvd.allreduce(
                     even_rank_tensor,
                     average=False,
-                    process_set=even_set)
-                multiplied = even_rank_tensor * len(even_ranks)
-            if rank in odd_ranks:
+                    process_set=self.even_set)
+                multiplied = even_rank_tensor * len(self.even_ranks)
+            if rank in self.odd_ranks:
                 summed = hvd.allreduce(
-                    odd_rank_tensor, average=False, process_set=odd_set)
-                multiplied = odd_rank_tensor * len(odd_ranks)
+                    odd_rank_tensor, average=False, process_set=self.odd_set)
+                multiplied = odd_rank_tensor * len(self.odd_ranks)
             max_difference = tf.reduce_max(tf.abs(summed - multiplied))
             return max_difference
 
@@ -112,7 +117,7 @@ class XLAProcessSetsTests(BaseTensorFlowTests):
 
             # Threshold for floating point equality depends on number of
             # ranks, since we're comparing against precise multiplication.
-            max_process_set_size = max(len(even_ranks), len(odd_ranks))
+            max_process_set_size = max(len(self.even_ranks), len(self.odd_ranks))
             if max_process_set_size <= 3 or dtype in [tf.int32, tf.int64]:
                 threshold = 0
             elif max_process_set_size < 10:
@@ -126,6 +131,3 @@ class XLAProcessSetsTests(BaseTensorFlowTests):
             diff = self.evaluate(max_difference)
             self.assertTrue(diff <= threshold,
                             "hvd.allreduce produces incorrect results")
-
-        hvd.remove_process_set(odd_set)
-        hvd.remove_process_set(even_set)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

As observed in #3557 there can be significant slowdowns with TensorFlow 2.9 when `HOROVOD_DYNAMIC_PROCESS_SETS=1` is set and MPI is used rather than Gloo. This PR refactors most process-set-specific tests for TensorFlow so they work with statically initialized process sets. This should avoid timeouts in CI pipelines on GPU-equipped AWS hosts.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
