### PR TITLE
Fix race condition in PyTorch allocation handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix FuseResponses() on BATCHED_D2D_PADDING edge cases for Reducescatter and/or ROCm. ([#3621](https://github.com/horovod/horovod/pull/3621))
 - PyTorch: Fixed Reducescatter functions to raise `HorovodInternalError` rather than `RuntimeError`. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - PyTorch on GPUs without GPU operations: Fixed grouped allreduce to set CPU device in tensor table. ([#3594](https://github.com/horovod/horovod/pull/3594))
+- Fixed race condition in PyTorch allocation handling. ([#3639](https://github.com/horovod/horovod/pull/3639))
 
 
 ## [v0.25.0] - 2022-06-20


### PR DESCRIPTION


## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR fixes what appears to be a quite serious bug in the handling of buffer allocations in the PyTorch backend that was discovered and reported by @eordentlich at NVIDIA. The issue is that the current implementation does not enforce any type of synchronization after PyTorch buffers are allocated. This is a problem because the PyTorch allocations can be completed asynchronously and not enforcing a sync or recording a dependency using an event results in a race condition when writing to these buffers. This was handled appropriately in the TensorFlow implementation (see: https://github.com/horovod/horovod/blob/ed15ddc8f269664d4a89671b33960d0fab9f2dd9/horovod/tensorflow/mpi_ops.cc#L404-L411), but similar code was never introduced for the PyTorch backend. I've added equivalent synchronization code to the PyTorch backend in this PR.

The cases that are most impacted by this bug are collectives that need to allocate output buffers, since the size is not known at enqueue time (e.g. `allgather`, `reduce_scatter`, and `alltoall`). In these cases, the output data from Horovod can be written to the buffers prior to them being available. This issue can also impact the allocation of the persistent buffer used for tensor fusion; however, I think that allocation occurs very early during job startup, so maybe is somehow less likely to occur. Since `allreduce` and `broadcast` do not allocate output buffers within the Horovod backend, those collectives should be unimpacted (outside of the possible issue with the fusion buffer).

I've taken this as an opportunity to also extend the performance improvement from #3464 to the PyTorch backend where appropriate.


