### PR TITLE
add PartialDistributedGradientTape API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - TensorFlow: Added doc string for `hvd.grouped_allreduce()`. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - Added warning messages if output tensor memory allocations fail. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - Added `register_local_source` and `use_generic_names` funtionality to DistributedGradientTape. ([#3628](https://github.com/horovod/horovod/pull/3628))
-
+- Added `PartialDistributedGradientTape()` API for model parallel use cases. ([#3643](https://github.com/horovod/horovod/pull/3643))
 ### Changed
 
 ### Deprecated

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1049,12 +1049,10 @@ if hasattr(tf, 'GradientTape'):
         """
         if local_layers is None:
             local_layers = []
-        else:
-            if isinstance(local_layers, tf.keras.layers.Layer):
-                local_layers = [local_layers]
-            else:
-                if not all(isinstance(layer, tf.keras.layers.Layer) for layer in local_layers):
-                    raise ValueError("All local layers must be of tf.keras.layers.Layer type.")
+        elif isinstance(local_layers, tf.keras.layers.Layer):
+            local_layers = [local_layers]
+        elif not all(isinstance(layer, tf.keras.layers.Layer) for layer in local_layers):
+            raise ValueError("All local layers must be of tf.keras.layers.Layer type.")
 
         local_vars = [var for layer in local_layers for var in layer.trainable_weights]
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1053,7 +1053,7 @@ if hasattr(tf, 'GradientTape'):
                 local_layers = [local_layers]
             else:
                 if not all(isinstance(layer, tf.keras.layers.Layer) for layer in local_layers):
-                    raise ValueError("All local layers must be of tf.keras.Layer type.")
+                    raise ValueError("All local layers must be of tf.keras.layers.Layer type.")
 
         local_vars = [var for layer in local_layers for var in layer.trainable_weights]
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1028,10 +1028,9 @@ if hasattr(tf, 'GradientTape'):
 
 
     def PartialDistributedGradientTape(gradtape, device_dense='', device_sparse='',
-                                compression=Compression.none, sparse_as_dense=False,
-                                op=Average, gradient_predivide_factor=1.0,
-                                num_groups=0, groups=None, process_set=global_process_set,
-                                local_layers=None):
+                                       compression=Compression.none, sparse_as_dense=False,
+                                       op=Average, gradient_predivide_factor=1.0,
+                                       num_groups=0, groups=None, process_set=global_process_set, local_layers=None):
         """A tape that wraps another tf.GradientTape, using an allreduce to
         combine gradient values before applying gradients to model weights similar to
         DistributedGradientTape execpt it skips allreducing gradients of the local layers
@@ -1048,7 +1047,9 @@ if hasattr(tf, 'GradientTape'):
 
         The rest of the arguments are similar to those of DistributedGradientTape.
         """
-        if local_layers:
+        if local_layers is None:
+            local_layers = []
+        else:
             if isinstance(local_layers, tf.keras.layers.Layer):
                 local_layers = [local_layers]
             else:
@@ -1058,9 +1059,9 @@ if hasattr(tf, 'GradientTape'):
         local_vars = [var for layer in local_layers for var in layer.trainable_weights]
 
         _tape = DistributedGradientTape(gradtape, device_dense, device_sparse,
-                                compression, sparse_as_dense,
-                                op, gradient_predivide_factor,
-                                num_groups, groups, process_set)
+                                        compression, sparse_as_dense,
+                                        op, gradient_predivide_factor,
+                                        num_groups, groups, process_set)
         for var in local_vars:
             _tape.register_local_source(var)
         return _tape

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1031,7 +1031,7 @@ if hasattr(tf, 'GradientTape'):
                                 compression=Compression.none, sparse_as_dense=False,
                                 op=Average, gradient_predivide_factor=1.0,
                                 num_groups=0, groups=None, process_set=global_process_set,
-                                local_layers=[]):
+                                local_layers=None):
         """A tape that wraps another tf.GradientTape, using an allreduce to
         combine gradient values before applying gradients to model weights similar to
         DistributedGradientTape execpt it skips allreducing gradients of the local layers
@@ -1041,47 +1041,26 @@ if hasattr(tf, 'GradientTape'):
           gradtape:
             GradientTape to use for computing gradients and applying updates.
           local_layers:
-            A list of tf.keras.Layer local layers that their gradients need not
+            A collection of type tf.keras.layers.Layer local layers that their gradients need not
             to be synced accross ranks and is kept and applied locally.
             If not provided, the functionality of PartialDistributedGradientTape is
             identical to DistributedGradientTape.
 
         The rest of the arguments are similar to those of DistributedGradientTape.
         """
-        if gradient_predivide_factor != 1.0:
-            if rocm_built():
-                raise ValueError('gradient_predivide_factor not supported yet with ROCm')
-            if op != Average:
-                raise ValueError('gradient_predivide_factor not supported with op != Average')
-
-        if num_groups != 0:
-            warnings.warn('Parameter `num_groups` has been replaced by `groups` '
-                          'and will be removed in v0.23.0.', DeprecationWarning)
-            if groups is None:
-                groups = num_groups
-
-        if groups is not None:
-            if not (isinstance(groups, list) or groups > 0):
-                raise ValueError('groups should be a non-negative integer or '
-                                'a list of list of tf.Variable.')
-
-        if local_layers is not None:
-            if not isinstance(local_layers, list):
-                raise ValueError('local_layers should be a list of layers of type tf.keras.Layer.')
+        if local_layers:
+            if isinstance(local_layers, tf.keras.layers.Layer):
+                local_layers = [local_layers]
+            else:
+                if not all(isinstance(layer, tf.keras.layers.Layer) for layer in local_layers):
+                    raise ValueError("All local layers must be of tf.keras.Layer type.")
 
         local_vars = [var for layer in local_layers for var in layer.trainable_weights]
 
-        cls = type(gradtape.__class__.__name__, (gradtape.__class__,),
-                   dict(_DistributedGradientTape.__dict__))
-        if hasattr(gradtape, '_watch_accessed_variables'):
-            _tape = cls(gradtape._tape, device_dense, device_sparse, compression,
-                       sparse_as_dense, op, gradient_predivide_factor, groups,
-                       gradtape._persistent, gradtape._watch_accessed_variables,
-                       process_set=process_set)
-        else:
-            _tape = cls(gradtape._tape, device_dense, device_sparse, compression,
-                       sparse_as_dense, op, gradient_predivide_factor, groups,
-                       gradtape._persistent, process_set=process_set)
+        _tape = DistributedGradientTape(gradtape, device_dense, device_sparse,
+                                compression, sparse_as_dense,
+                                op, gradient_predivide_factor,
+                                num_groups, groups, process_set)
         for var in local_vars:
             _tape.register_local_source(var)
         return _tape

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -3844,9 +3844,12 @@ class TensorFlowTests(BaseTensorFlowTests):
 
     def test_partial_distributed_gradient_tape(self):
         """ Note: test makes most sense with more than 1 nodes. """
+        hvd.init()
+        if hvd.size() == 1:
+            self.skipTest("Only one worker available")
+
         # the keras model has 3 layers, we test cases with 0, 1, and 2 local layers.
         for num_local_layers in range(3):
-            hvd.init()
             model = tf.keras.models.Sequential()
             initializer = tf.keras.initializers.Constant(hvd.rank())
             model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))


### PR DESCRIPTION
Signed-off-by: Ata FatahiBaarzi <afatahibaarzi@linkedin.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR builds upon #3628 and adds a new API called `PartialDistributedGradientTape(tape, [local_layers], ...)` for model parallel use cases where unlike DistributedGradientTape() ranks only sync a subset of gradients and skip the gradients of their "local layers". A sample usage is shown in the unit test included with this PR.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
