### PR TITLE
Enable use of native ncclAvg op for NCCL allreduces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `register_local_source` and `use_generic_names` funtionality to DistributedGradientTape. ([#3628](https://github.com/horovod/horovod/pull/3628))
 - Added `transformation_edit_fields` and `transformation_removed_fields` param for EstimatorParams. ([#3651](https://github.com/horovod/horovod/pull/3651))
 - Added `PartialDistributedGradientTape()` API for model parallel use cases. ([#3643](https://github.com/horovod/horovod/pull/3643))
+- Enable use of native `ncclAvg` op for NCCL allreduces. ([#3646](https://github.com/horovod/horovod/pull/3646))
 
 ### Changed
 

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -206,7 +206,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
   // Copy (and possibly scale) tensors into the fusion buffer.
   if (entries.size() > 1) {
     ScaleMemcpyInFusionBuffer(entries, fused_input_data, buffer_data,
-                              buffer_len, response.prescale_factor());
+                              buffer_len, prescale_factor);
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue,
                                 MEMCPY_IN_FUSION_BUFFER,
@@ -220,7 +220,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
         buffer_len / DataType_Size(first_entry.tensor->dtype());
     if (prescale_factor != 1.0) {
       // Execute prescaling op
-      ScaleBuffer(response.prescale_factor(), entries, fused_input_data,
+      ScaleBuffer(prescale_factor, entries, fused_input_data,
                   buffer_data, num_elements);
       fused_input_data = buffer_data; // for unfused, scale is done out of place
     }

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -189,6 +189,20 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
   void* buffer_data;
   size_t buffer_len;
 
+  ncclRedOp_t ncclOp = ncclSum;
+  double prescale_factor = response.prescale_factor();
+  double postscale_factor = response.postscale_factor();
+#ifdef NCCL_AVG_SUPPORTED
+  auto& process_set =
+      global_state_->process_set_table.Get(entries[0].process_set_id);
+  if (prescale_factor == 1.0 &&
+      postscale_factor == 1.0 / process_set.controller->GetSize()) {
+    // Use NCCLAvg op in place of postscale_factor
+    ncclOp = ncclAvg;
+    postscale_factor = 1.0;
+  }
+#endif
+
   // Copy (and possibly scale) tensors into the fusion buffer.
   if (entries.size() > 1) {
     ScaleMemcpyInFusionBuffer(entries, fused_input_data, buffer_data,
@@ -204,7 +218,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
     buffer_len = (size_t)first_entry.output->size();
     int64_t num_elements =
         buffer_len / DataType_Size(first_entry.tensor->dtype());
-    if (response.prescale_factor() != 1.0) {
+    if (prescale_factor != 1.0) {
       // Execute prescaling op
       ScaleBuffer(response.prescale_factor(), entries, fused_input_data,
                   buffer_data, num_elements);
@@ -217,7 +231,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
       buffer_len / DataType_Size(first_entry.tensor->dtype());
   auto nccl_result =
       ncclAllReduce(fused_input_data, buffer_data, (size_t)num_elements,
-                    GetNCCLDataType(first_entry.tensor), ncclSum,
+                    GetNCCLDataType(first_entry.tensor), ncclOp,
                     *nccl_op_context_.nccl_comm_, *gpu_op_context_.stream);
   nccl_context_->ErrorCheck("ncclAllReduce", nccl_result,
                             *nccl_op_context_.nccl_comm_);
@@ -229,7 +243,7 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
   // Copy (and possible scale) tensors out of the fusion buffer.
   if (entries.size() > 1) {
     ScaleMemcpyOutFusionBuffer(buffer_data, buffer_len,
-                               response.postscale_factor(), entries);
+                               postscale_factor, entries);
 
     if (global_state_->timeline.Initialized()) {
       gpu_context_->RecordEvent(gpu_op_context_.event_queue,
@@ -237,9 +251,9 @@ Status NCCLAllreduce::Execute(std::vector<TensorTableEntry>& entries,
                                 *gpu_op_context_.stream);
     }
   } else {
-    if (response.postscale_factor() != 1.0) {
+    if (postscale_factor != 1.0) {
       // Execute postscaling op
-      ScaleBuffer(response.postscale_factor(), entries, buffer_data,
+      ScaleBuffer(postscale_factor, entries, buffer_data,
                   buffer_data, num_elements);
     }
   }

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -23,6 +23,9 @@
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 7, 0)
 #define NCCL_P2P_SUPPORTED
 #endif
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 10, 0)
+#define NCCL_AVG_SUPPORTED
+#endif
 #elif HAVE_ROCM
 #include <rccl.h>
 #define NCCL_P2P_SUPPORTED

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -47,10 +47,15 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
             raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 
         self._optimizer = optimizer
-        # Normalizing rescale_grad by Horovod size, which is equivalent to
-        # performing average in allreduce, has better performance.
-        self._optimizer.rescale_grad *= (gradient_predivide_factor / process_set.size())
         self._gradient_predivide_factor = gradient_predivide_factor
+        self._average_in_framework=False
+        self._postscale_factor = self._gradient_predivide_factor
+        if rocm_built() or nccl_built() < 21000:
+          # Perform average in framework via rescale_grad for ROCM or older NCCL versions
+          # without average support
+          self._optimizer.rescale_grad *= (gradient_predivide_factor / process_set.size())
+          self._postscale_factor = 1.0
+          self._average_in_framework=True
         self._num_groups = num_groups
         self._process_set = process_set
 
@@ -72,18 +77,21 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
                 index_split = split_list(index, self._num_groups)
 
                 for i, (grads, indices) in enumerate(zip(grad_split, index_split)):
-                    grouped_allreduce_(tensors=grads, average=False, name="{}:{}".format(indices[0], indices[-1]), priority=-i,
+                    grouped_allreduce_(tensors=grads, average=not self._average_in_framework, name="{}:{}".format(indices[0], indices[-1]), priority=-i,
                                        prescale_factor=1.0 / self._gradient_predivide_factor,
+                                       postscale_factor=self._postscale_factor,
                                        process_set=self._process_set)
             else:
               for i in range(len(index)):
-                  allreduce_(grad[i], average=False,
+                  allreduce_(grad[i], average=not self._average_in_framework,
                              name=str(index[i]), priority=-i,
                              prescale_factor=1.0 / self._gradient_predivide_factor,
+                             postscale_factor=self._postscale_factor,
                              process_set=self._process_set)
         else:
-            allreduce_(grad, average=False, name=str(index),
+            allreduce_(grad, average=not self._average_in_framework, name=str(index),
                        prescale_factor=1.0 / self._gradient_predivide_factor,
+                       postscale_factor=self._postscale_factor,
                        process_set=self._process_set)
 
     def update(self, index, weight, grad, state):
@@ -155,11 +163,15 @@ class DistributedTrainer(mx.gluon.Trainer):
         super(DistributedTrainer, self).__init__(
             params, optimizer, optimizer_params=optimizer_params, kvstore=None)
 
-        # _scale is used to check and set rescale_grad for optimizer in Trainer.step()
-        # function. Normalizing it by Horovod size, which is equivalent to performing
-        # average in allreduce, has better performance. 
-        self._scale *= (gradient_predivide_factor / process_set.size())
         self._gradient_predivide_factor = gradient_predivide_factor
+        self._average_in_framework=False
+        self._postscale_factor = self._gradient_predivide_factor
+        if rocm_built() or nccl_built() < 21000:
+          # Perform average in framework via rescale_grad for ROCM or older NCCL versions
+          # without average support
+          self._scale *= (gradient_predivide_factor / process_set.size())
+          self._postscale_factor = 1.0
+          self._average_in_framework=True
         assert prefix is None or isinstance(prefix, str)
         self._prefix = prefix if prefix else ""
         self._num_groups = num_groups
@@ -193,8 +205,10 @@ class DistributedTrainer(mx.gluon.Trainer):
 
                 for entries in entries_by_dtype.values():
                     grads, names = zip(*entries)
-                    grouped_allreduce_(tensors=grads, average=False, name="{}:{}".format(names[0], names[-1]), priority=-i,
+                    grouped_allreduce_(tensors=grads, average=not self._average_in_framework,
+                                       name="{}:{}".format(names[0], names[-1]), priority=-i,
                                        prescale_factor=1.0 / self._gradient_predivide_factor,
+                                       postscale_factor=self._postscale_factor,
                                        process_set=self._process_set)
 
             if self._compression != Compression.none:
@@ -208,9 +222,10 @@ class DistributedTrainer(mx.gluon.Trainer):
             for i, param in enumerate(self._params):
                 if param.grad_req != 'null':
                     tensor_compressed, ctx = self._compression.compress(param.list_grad()[0])
-                    allreduce_(tensor_compressed, average=False,
+                    allreduce_(tensor_compressed, average=not self._average_in_framework,
                                name=self._prefix + str(i), priority=-i,
                                prescale_factor=1.0 / self._gradient_predivide_factor,
+                               postscale_factor=self._postscale_factor,
                                process_set=self._process_set)
 
                     if self._compression != Compression.none:

--- a/horovod/mxnet/__init__.py
+++ b/horovod/mxnet/__init__.py
@@ -49,6 +49,7 @@ class DistributedOptimizer(mx.optimizer.Optimizer):
         self._optimizer = optimizer
         self._gradient_predivide_factor = gradient_predivide_factor
         self._average_in_framework=False
+        # C++ backend will apply additional 1 / size() factor to postscale_factor for op == Average.
         self._postscale_factor = self._gradient_predivide_factor
         if rocm_built() or nccl_built() < 21000:
           # Perform average in framework via rescale_grad for ROCM or older NCCL versions
@@ -165,6 +166,7 @@ class DistributedTrainer(mx.gluon.Trainer):
 
         self._gradient_predivide_factor = gradient_predivide_factor
         self._average_in_framework=False
+        # C++ backend will apply additional 1 / size() factor to postscale_factor for op == Average.
         self._postscale_factor = self._gradient_predivide_factor
         if rocm_built() or nccl_built() < 21000:
           # Perform average in framework via rescale_grad for ROCM or older NCCL versions


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
NCCL 2.10+ introduced a native `ncclAvg` operation (https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#c.ncclAvg). This PR enables the use of this feature for versions of NCCL that support it. 
