### PR TITLE
feat: support uint8 and int8 allreduce in tensorflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for `int8, uint8` allreduce and grouped_allreduce in tensorflow. ([#3649](https://github.com/horovod/horovod/pull/3649))
 - Added support for batched memory copies in GPUAllgather. ([#3590](https://github.com/horovod/horovod/pull/3590))
 - Added support for batched memory copies in GPUReducescatter. ([#3621](https://github.com/horovod/horovod/pull/3621))
 - Added `hvd.grouped_allgather()` and `hvd.grouped_reducescatter()` operations. ([#3594](https://github.com/horovod/horovod/pull/3594))

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -510,7 +510,7 @@ REGISTER_KERNEL_BUILDER(Name("HorovodAllreduce").Device(DEVICE_GPU),
 #endif
 
 REGISTER_OP("HorovodAllreduce")
-    .Attr("T: {int32, int64, float16, float32, float64}")
+    .Attr("T: {uint8, int8, int32, int64, float16, float32, float64}")
     .Attr("reduce_op: int")
     .Attr("prescale_factor: float")
     .Attr("postscale_factor: float")
@@ -647,7 +647,7 @@ REGISTER_KERNEL_BUILDER(Name("HorovodGroupedAllreduce").Device(DEVICE_GPU),
 #endif
 
 REGISTER_OP("HorovodGroupedAllreduce")
-    .Attr("T: {int32, int64, float16, float32, float64}")
+    .Attr("T: {uint8, int8, int32, int64, float16, float32, float64}")
     .Attr("reduce_op: int")
     .Attr("prescale_factor: float")
     .Attr("postscale_factor: float")

--- a/test/parallel/test_xla.py
+++ b/test/parallel/test_xla.py
@@ -110,14 +110,16 @@ class XLATests(tf.test.TestCase):
         size = hvd.size()
 
         def hvd_allreduce_test(self, dtype, dim):
-            tensor = self.random_uniform(
-                [17] * dim, -100, 100, dtype=dtype)
+            tensor = self.random_uniform([17] * dim, -100, 100)
+            tensor = tf.cast(tensor, dtype=dtype)
             summed = hvd.allreduce(tensor, average=False)
             multiplied = tensor * size
-            max_difference = tf.reduce_max(tf.abs(summed - multiplied))
+            difference = summed - multiplied
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
             return max_difference
 
-        dtypes = [tf.int32, tf.int64, tf.float32, tf.float16, tf.float64]
+        dtypes = [tf.uint8, tf.int8, tf.int32, tf.int64, tf.float32, tf.float16, tf.float64]
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/gpu:%d" % local_rank):
@@ -126,7 +128,7 @@ class XLATests(tf.test.TestCase):
 
             # Threshold for floating point equality depends on number of
             # ranks, since we're comparing against precise multiplication.
-            if size <= 3 or dtype in [tf.int32, tf.int64]:
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
                 threshold = 0
             elif size < 10:
                 threshold = 1e-4
@@ -160,8 +162,8 @@ class XLATests(tf.test.TestCase):
         def hvd_allreduce_test(self, dtype, dim):
             np.random.seed(1234)
             factor = np.random.uniform()
-            tensor = self.random_uniform(
-                [17] * dim, -100, 100, dtype=dtype)
+            tensor = self.random_uniform([17] * dim, -100, 100)
+            tensor = tf.cast(tensor, dtype=dtype)
             summed = hvd.allreduce(tensor, average=False,
                                    prescale_factor=factor)
 
@@ -171,12 +173,14 @@ class XLATests(tf.test.TestCase):
             factor = tf.convert_to_tensor(
                 factor, tf.float64 if dtype in int_types else dtype)
             multiplied = tf.cast(factor * tensor, dtype) * size
-            max_difference = tf.reduce_max(tf.abs(summed - multiplied))
+            difference = summed - multiplied
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
             return max_difference
 
         dtypes = self.filter_supported_types(
-            [tf.int32, tf.int64, tf.float16, tf.float32])
-        int_types = [tf.int32, tf.int64]
+            [tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32])
+        int_types = [tf.uint8, tf.int8, tf.int32, tf.int64]
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/gpu:%s" % local_rank):
@@ -216,8 +220,8 @@ class XLATests(tf.test.TestCase):
         def hvd_allreduce_test(self, dtype, dim):
             np.random.seed(1234)
             factor = np.random.uniform()
-            tensor = self.random_uniform(
-                [17] * dim, -100, 100, dtype=dtype)
+            tensor = self.random_uniform([17] * dim, -100, 100)
+            tensor = tf.cast(tensor, dtype=dtype)
             summed = hvd.allreduce(tensor, average=False,
                                    postscale_factor=factor)
 
@@ -228,13 +232,15 @@ class XLATests(tf.test.TestCase):
             factor = tf.convert_to_tensor(
                 factor, tf.float64 if dtype in int_types else dtype)
             multiplied = tf.cast(factor * multiplied, dtype)
-            max_difference = tf.reduce_max(tf.abs(summed - multiplied))
+            difference = summed - multiplied
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
             return max_difference
 
         local_rank = hvd.local_rank()
         dtypes = self.filter_supported_types(
-            [tf.int32, tf.int64, tf.float16, tf.float32])
-        int_types = [tf.int32, tf.int64]
+            [tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32])
+        int_types = [tf.uint8, tf.int8, tf.int32, tf.int64]
         dims = [1, 2, 3]
         for dtype, dim in itertools.product(dtypes, dims):
             with tf.device("/gpu:%s" % local_rank):


### PR DESCRIPTION


## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This PR adds support for `int8` and `uint8` allreduce in tensorflow along with the relevant tests. 
Corresponding issue:  https://github.com/horovod/horovod/issues/3642

Signed-off-by: Vignesh Kothapalli <k.vignesh1420@gmail.com>

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
