### PR TITLE
Spark: adapt Petastorm 0.12.0 changes to speedup data shuffling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for Petastorm reader level parallel shuffling. ([#3665](https://github.com/horovod/horovod/pull/3665))
+- Added random seed support for Lightning datamodule to generate reproducible data loading outputs. ([#3665](https://github.com/horovod/horovod/pull/3665))
 - Added support for `int8, uint8` allreduce and grouped_allreduce in tensorflow. ([#3649](https://github.com/horovod/horovod/pull/3649))
 - Added support for batched memory copies in GPUAllgather. ([#3590](https://github.com/horovod/horovod/pull/3590))
 - Added support for batched memory copies in GPUReducescatter. ([#3621](https://github.com/horovod/horovod/pull/3621))
@@ -20,7 +22,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Default Petastorm reader pool is changed from `process` to `thread` for lower memory usage. ([#3665](https://github.com/horovod/horovod/pull/3665))
+
 ### Deprecated
+
+- Deprecated field `shuffle_buffer_size` from `EstimatorParams`. Use `shuffle` to enable shuffle or not. ([#3665](https://github.com/horovod/horovod/pull/3665))
 
 ### Removed
 

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -74,8 +74,13 @@ class EstimatorParams(Params):
 
     shuffle_buffer_size = Param(Params._dummy(),
                                 'shuffle_buffer_size',
-                                'shuffling buffer size of data before training in number of samples',
+                                '(Deprecated) shuffling buffer size used for training samples',
                                 typeConverter=TypeConverters.toInt)
+
+    shuffle = Param(Params._dummy(),
+                    'shuffle',
+                    'Whether to shuffle training samples or not. Defaults to True',
+                    typeConverter=TypeConverters.toBoolean)
 
     verbose = Param(Params._dummy(), 'verbose', 'verbose flag (0=silent, 1=enabled, other values used by frameworks)',
                     typeConverter=TypeConverters.toInt)
@@ -149,6 +154,7 @@ class EstimatorParams(Params):
             callbacks=[],
             random_seed=None,
             shuffle_buffer_size=None,
+            shuffle=True,
             partitions_per_process=10,
             run_id=None,
             train_steps_per_epoch=None,
@@ -158,7 +164,7 @@ class EstimatorParams(Params):
             transformation_removed_fields=None,
             train_reader_num_workers=2,
             val_reader_num_workers=2,
-            reader_pool_type='process',
+            reader_pool_type='thread',
             label_shapes=None,
             inmemory_cache_all=False,
             use_gpu=True,
@@ -316,8 +322,14 @@ class EstimatorParams(Params):
     def setShufflingBufferSize(self, value):
         return self._set(shuffle_buffer_size=value)
 
+    def setShuffle(self, value):
+        return self._set(shuffle=value)
+
     def getShufflingBufferSize(self):
         return self.getOrDefault(self.shuffle_buffer_size)
+
+    def getShuffle(self):
+        return self.getOrDefault(self.shuffle)
 
     def setOptimizer(self, value):
         return self._set(optimizer=value)

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -116,10 +116,11 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         epochs: Number of epochs to train.
         verbose: Verbosity level [0, 2] (default: 1).
         random_seed: Optional random seed to use for Tensorflow. Default: None.
-        shuffle_buffer_size: Optional size of in-memory shuffle buffer in rows (on training data).
+        shuffle_buffer_size: (Deprecated) Optional size of in-memory shuffle buffer in rows (on training data).
                              Allocating a larger buffer size increases randomness of shuffling at
                              the cost of more host memory. Defaults to estimating with an assumption
                              of 4GB of memory per host. Set shuffle_buffer_size=0 would turn off shuffle.
+        shuffle: (Optional) Whether to shuffle training samples or not. Defaults to True.
         partitions_per_process: Number of Parquet partitions to assign per worker process from `num_proc` (default: 10).
         run_id: Optional unique ID for this run for organization in the Store. Will be automatically assigned if not
                 provided.
@@ -142,8 +143,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                                high enough, or users need to apply transformation such as
                                decompression or data augmentation on raw data.
         val_reader_num_workers: Similar to the train_reader_num_workers.
-        reader_pool_type: Type of worker pool used to parallelize reading data from the dataset.
-                          Should be one of ['thread', 'process']. Defaults to 'process'.
+        reader_pool_type: Type of Petastorm worker pool used to parallelize reading data from the dataset.
+                          Should be one of ['thread', 'process', 'dummy']. Defaults to 'thread'.
         inmemory_cache_all: boolean value. Cache the data in memory for training and validation. Default: False.
         backend_env: dict to add to the environment of the backend.  Defaults to setting the java heap size to
                      2G min and max for libhdfs through petastorm
@@ -180,6 +181,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  verbose=None,
                  random_seed=None,
                  shuffle_buffer_size=None,
+                 shuffle=True,
                  partitions_per_process=None,
                  run_id=None,
                  train_steps_per_epoch=None,
@@ -187,7 +189,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  transformation_fn=None,
                  train_reader_num_workers=None,
                  val_reader_num_workers=None,
-                 reader_pool_type=None,
+                 reader_pool_type='thread',
                  label_shapes=None,
                  checkpoint_callback=None,
                  inmemory_cache_all=False,

--- a/horovod/spark/lightning/datamodule.py
+++ b/horovod/spark/lightning/datamodule.py
@@ -20,9 +20,9 @@ class PetastormDataModule(pl.LightningDataModule):
             has_val: bool = True,
             train_batch_size: int = 32,
             val_batch_size: int = 32,
-            shuffle_size: int = 1000,
+            shuffle: bool = True,
             num_reader_epochs=None,
-            reader_pool_type: str = "process",
+            reader_pool_type: str = "thread",
             reader_worker_count: int = 2,
             transformation=None,
             transformation_edit_fields=None,
@@ -38,6 +38,7 @@ class PetastormDataModule(pl.LightningDataModule):
             debug_data_loader: bool = False,
             train_async_data_loader_queue_size: int = None,
             val_async_data_loader_queue_size: int = None,
+            seed: int = None,
             **kwargs):
         super().__init__()
         self.train_dir = train_dir
@@ -46,7 +47,7 @@ class PetastormDataModule(pl.LightningDataModule):
         self.has_val = has_val
         self.train_batch_size = train_batch_size
         self.val_batch_size = val_batch_size
-        self.shuffle_size = shuffle_size
+        self.shuffle = shuffle
         self.num_reader_epochs = num_reader_epochs
         self.reader_pool_type = reader_pool_type
         self.reader_worker_count = reader_worker_count
@@ -64,6 +65,7 @@ class PetastormDataModule(pl.LightningDataModule):
         self.debug_data_loader = debug_data_loader
         self.train_async_data_loader_queue_size = train_async_data_loader_queue_size
         self.val_async_data_loader_queue_size = val_async_data_loader_queue_size
+        self.seed = seed
 
         if debug_data_loader:
             print("Creating data_module")
@@ -101,9 +103,9 @@ class PetastormDataModule(pl.LightningDataModule):
                                                schema_fields=self.schema_fields,
                                                storage_options=self.storage_options,
                                                transform_spec=transform_spec,
-                                               # Don't shuffle row groups
-                                               # without shuffling.
-                                               shuffle_row_groups=True if self.shuffle_size > 0 else False,
+                                               shuffle_rows=self.shuffle,
+                                               shuffle_row_groups=self.shuffle,
+                                               seed=self.seed,
                                                **reader_factory_kwargs)
             if self.has_val:
                 self.val_reader = reader_factory(
@@ -117,6 +119,7 @@ class PetastormDataModule(pl.LightningDataModule):
                     schema_fields=self.schema_fields,
                     storage_options=self.storage_options,
                     transform_spec=transform_spec,
+                    shuffle_rows=False,
                     shuffle_row_groups=False,
                     **reader_factory_kwargs)
 
@@ -151,11 +154,13 @@ class PetastormDataModule(pl.LightningDataModule):
         if self.inmemory_cache_all:
             # Use inmem dataloader
             dataloader_class = PytorchInmemAsyncDataLoader
-            kwargs['shuffle'] = self.shuffle_size > 0
+            kwargs['shuffle'] = self.shuffle
             kwargs['num_epochs'] = self.num_train_epochs
         else:
             dataloader_class = PytorchInfiniteAsyncDataLoader
-            kwargs['shuffling_queue_capacity'] = self.shuffle_size
+            # Don't need to shuffle again in dataloder level.
+            # Reader shuffles rows in every row group since Petastorm 0.12.0.
+            kwargs['shuffling_queue_capacity'] = 0
 
             if self.debug_data_loader:
                 kwargs['debug_data_loader'] = self.debug_data_loader

--- a/horovod/spark/lightning/estimator.py
+++ b/horovod/spark/lightning/estimator.py
@@ -135,17 +135,18 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                     for training. Not needed for lightning model.
         partitions_per_process: (Optional) Number of Parquet partitions to assign per worker
                                 process from `num_proc` (default: 10).
-        reader_pool_type:   (Optional) Type of worker pool used to parallelize reading data from
-                            the dataset. Should be one of ['thread', 'process']. Defaults to
-                            'process'.
+        reader_pool_type:   (Optional) Type of Petastorm worker pool used to parallelize reading data from
+                            the dataset. Should be one of ['thread', 'process', 'dummy']. Defaults to
+                            'thread'.
         run_id:     (Optional) unique ID for this run for organization in the Store. Will be
                     automatically assigned if not provided.
         sample_weight_col:  (Optional) column indicating the weight of each sample.
         random_seed: Optional random seed to use for PyTorch Lightning. Default: None.
-        shuffle_buffer_size: Optional size of in-memory shuffle buffer in rows (on training data).
+        shuffle_buffer_size: (Deprecated) Optional size of in-memory shuffle buffer in rows (on training data).
                              Allocating a larger buffer size increases randomness of shuffling at
                              the cost of more host memory. Defaults to estimating with an assumption
                              of 4GB of memory per host. Set shuffle_buffer_size=0 would turn off shuffle.
+        shuffle: (Optional) Whether to shuffle training samples or not. Defaults to True.
         store:      Store object that abstracts reading and writing of intermediate data and
                     run results.
         terminate_on_nan : (Optinoal) terminate the training process on seeing NaN output.
@@ -249,6 +250,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  verbose=1,
                  random_seed=None,
                  shuffle_buffer_size=None,
+                 shuffle=True,
                  partitions_per_process=None,
                  run_id=None,
                  train_minibatch_fn=None,

--- a/horovod/spark/torch/estimator.py
+++ b/horovod/spark/torch/estimator.py
@@ -117,10 +117,11 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
         epochs: Number of epochs to train.
         verbose: Verbosity level [0, 2] (default: 1).
         random_seed: Optional random seed to use for Torch. Default: None.
-        shuffle_buffer_size: Optional size of in-memory shuffle buffer in rows (on training data).
+        shuffle_buffer_size: (Deprecated) Optional size of in-memory shuffle buffer in rows (on training data).
                              Allocating a larger buffer size increases randomness of shuffling at
                              the cost of more host memory. Defaults to estimating with an assumption
                              of 4GB of memory per host. Set shuffle_buffer_size=0 would turn off shuffle.
+        shuffle: (Optional) Whether to shuffle training samples or not. Defaults to True.
         partitions_per_process: Number of Parquet partitions to assign per worker process from `num_proc` (default: 10).
         run_id: Optional unique ID for this run for organization in the Store. Will be automatically assigned if not
                 provided.
@@ -145,8 +146,8 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                                high enough, or users need to apply transformation such as
                                decompression or data augmentation on raw data.
         val_reader_num_workers: Similar to the train_reader_num_workers.
-        reader_pool_type: Type of worker pool used to parallelize reading data from the dataset.
-                          Should be one of ['thread', 'process']. Defaults to 'process'.
+        reader_pool_type: Type of Petastorm worker pool used to parallelize reading data from the dataset.
+                          Should be one of ['thread', 'process', 'dummy']. Defaults to 'thread'.
         inmemory_cache_all: (Optional) Cache the data in memory for training and validation.
         use_gpu: Whether to use the GPU for training. Defaults to True.
         mp_start_method: The method to use to start multiprocessing. Defaults to None.
@@ -182,6 +183,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  verbose=1,
                  random_seed=None,
                  shuffle_buffer_size=None,
+                 shuffle=True,
                  partitions_per_process=None,
                  run_id=None,
                  train_minibatch_fn=None,
@@ -190,7 +192,7 @@ class TorchEstimator(HorovodEstimator, TorchEstimatorParamsWritable,
                  transformation_fn=None,
                  train_reader_num_workers=None,
                  val_reader_num_workers=None,
-                 reader_pool_type=None,
+                 reader_pool_type='thread',
                  label_shapes=None,
                  inmemory_cache_all=False,
                  use_gpu=True,

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ pytorch_require_list = ['torch']
 mxnet_require_list = ['mxnet>=1.4.1']
 pyspark_require_list = ['pyspark>=2.3.2;python_version<"3.8"',
                         'pyspark>=3.0.0;python_version>="3.8"']
-spark_require_list = ['numpy', 'petastorm>=0.11.0', 'pyarrow>=0.15.0', 'fsspec>=2021.07.0']
+spark_require_list = ['numpy', 'petastorm>=0.12.0', 'pyarrow>=0.15.0', 'fsspec>=2021.07.0']
 # https://github.com/ray-project/ray/pull/17465
 ray_require_list = ['ray', 'aioredis<2']
 pytorch_spark_require_list = pytorch_require_list + \

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -391,34 +391,6 @@ class SparkKerasTests(tf.test.TestCase):
         serialized_dummy_param = _serialize_param_value('dummy_param_name', None, None, None)
         assert serialized_dummy_param is None
 
-    def test_calculate_shuffle_buffer_size_small_row_size(self):
-        hvd_size = 4
-        local_size = 2
-        hvd_mock = mock.MagicMock()
-        hvd_mock.local_size.return_value = local_size
-        hvd_mock.allgather.return_value = [local_size for _ in range(hvd_size)]
-
-        avg_row_size = 100
-        train_row_count_per_worker = 100
-
-        calculate_shuffle_buffer_size = remote._calculate_shuffle_buffer_size_fn()
-        shuffle_size = calculate_shuffle_buffer_size(hvd_mock, avg_row_size, train_row_count_per_worker)
-        assert shuffle_size == train_row_count_per_worker
-
-    def test_calculate_shuffle_buffer_size(self):
-        # case with 2 workers, one with 5 ranks and second with 3 ranks
-        hvd_mock = mock.MagicMock()
-        hvd_mock.allgather.return_value = [5, 5, 5, 5, 5, 3, 3, 3]
-        hvd_mock.local_size.return_value = 2
-
-        avg_row_size = 100000
-        train_row_count_per_worker = 1000000
-
-        calculate_shuffle_buffer_size = remote._calculate_shuffle_buffer_size_fn()
-        shuffle_size = calculate_shuffle_buffer_size(hvd_mock, avg_row_size, train_row_count_per_worker)
-
-        assert int(shuffle_size) == int(constants.TOTAL_BUFFER_MEMORY_CAP_GIB * constants.BYTES_PER_GIB / avg_row_size / 5)
-
     def test_custom_sparse_to_dense_fn(self):
         dense_shape = 10
         custom_sparse_to_dense = _custom_sparse_to_dense_fn()


### PR DESCRIPTION
Added:
- Petastorm reader level is used to parallelize shuffling samples.
- Random seed is added for Lightning datamodule to generate
  reproducible data loading outputs.

Changed:
- Default reader pool is changed from `process` to `thread` for lower
  memory usage.

Deprecated:
- `shuffle_buffer_size` field is removed. Global shuffle is enabled by default.
  Use `shuffle` to enable shuffle or not.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
