### PR TITLE
Build: Fix finding nvcc (if not in $PATH) with older versions of CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - PyTorch: Fixed Reducescatter functions to raise `HorovodInternalError` rather than `RuntimeError`. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - PyTorch on GPUs without GPU operations: Fixed grouped allreduce to set CPU device in tensor table. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - Fixed race condition in PyTorch allocation handling. ([#3639](https://github.com/horovod/horovod/pull/3639))
+- Build: Fixed finding nvcc (if not in $PATH) with older versions of CMake. ([#3682](https://github.com/horovod/horovod/pull/3682))
 
 
 ## [v0.25.0] - 2022-06-20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(NOT CMAKE_CUDA_COMPILER)
     find_package(CUDAToolkit)
     if(CUDAToolkit_BIN_DIR)
         message("CUDA compiler was not found in $PATH, but searching again in CUDA Toolkit binary directory")
+        unset(CMAKE_CUDA_COMPILER CACHE)  # need to clear this from cache, else some versions of CMake go into an infinite loop
         set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc")
         check_language(CUDA)
     endif()


### PR DESCRIPTION
In #3444 we've added a mechanism that helps CMake find `nvcc` when it's missing in `$PATH`, but the CUDA toolkit can still be found at a typical location. It has now been observed that this does not work as intended on older versions of CMake like 3.13 or 3.16 (#3545). 

CMake would go into an infinite loop with messages like 
```
  You have changed variables that require your cache to be deleted.
  Configure will be re-run and you may have to reset some variables.
  The following variables have changed:
  CMAKE_CUDA_COMPILER= NOTFOUND
```
`NOTFOUND` is the initial value assigned to `CMAKE_CUDA_COMPILER` by `check_language`, which is written to CMake's build cache then. We override it to a proper value `set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc")`, but this change only appears to be effective with more recent versions of cmake (I was using 3.23).

In my tests with CMake 3.13 and 3.16 the problem is resolved by clearing the `CMAKE_CUDA_COMPILER` variable from the cache before setting it to a new value.

Similar infinite loops have been reported earlier (https://public.kitware.com/Bug/view.php?id=14841) and it has been  discouraged to override `CMAKE_<LANG>_COMPILER` inside `CMakeLists.txt`, but I'd still prefer to contain this logic inside the CMake script.

Fixes #3545 

