### PR TITLE
TF: Add register_local_var to distributed optimizers and gradient aggrega…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `transformation_edit_fields` and `transformation_removed_fields` param for EstimatorParams. ([#3651](https://github.com/horovod/horovod/pull/3651))
 - Added `PartialDistributedGradientTape()` API for model parallel use cases. ([#3643](https://github.com/horovod/horovod/pull/3643))
 - Enable use of native `ncclAvg` op for NCCL allreduces. ([#3646](https://github.com/horovod/horovod/pull/3646))
+- Tensorflow: Added `register_local_var` functionality to distributed optimizers and local gradient aggregators. ([3695](https://github.com/horovod/horovod/pull/3695))
 
 ### Changed
 

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -23,6 +23,7 @@ from horovod.tensorflow.mpi_ops import rank
 
 
 _PRE_TF_2_4_0 = version.parse(tf.__version__) < version.parse('2.4.0')
+_IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
 
 
 def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
@@ -50,6 +51,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                 groups,
                 process_set=process_set)
 
+            self._local_vars = set()
             self._agg_helper = None
             if backward_passes_per_step > 1:
                 if hvd._executing_eagerly():
@@ -68,6 +70,17 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                         rank=rank(),
                         optimizer_type=LocalGradientAggregationHelper._OPTIMIZER_TYPE_KERAS,
                     )
+
+        def register_local_var(self, var):
+            """Registers a source/variable as worker local. Horovod will not perform any global
+            operations on gradients corresponding to these sources and will instead return the local
+            gradient."""
+            if self._agg_helper:
+                self._agg_helper.register_local_var(var)
+            elif _IS_TF2:
+                self._local_vars.add(var.ref())
+            else:
+                self._local_vars.add(var)
 
         def _compute_gradients(self, loss, var_list, grad_loss=None, tape=None):
             """
@@ -121,7 +134,32 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
             if self._agg_helper:
                 return self._agg_helper.compute_gradients(tuple(grads), tuple(vars))
             else:
-                return self._allreduce_grads(grads, vars)
+                def __filtered_reduce_grads(grads, vars):
+                    rv = []
+                    rg = []
+                    if _IS_TF2:
+                        v2g = {var.ref(): grad for var, grad in zip(vars, grads)}
+                        for var, grad in zip(vars, grads):
+                            if var.ref() not in self._local_vars:
+                                rv.append(var)
+                                rg.append(grad)
+                    else:
+                        v2g = {var: grad for var, grad in zip(vars, grads)}
+                        for var, grad in zip(vars, grads):
+                            if var not in self._local_vars:
+                                rv.append(var)
+                                rg.append(grad)
+
+                    rg = self._allreduce_grads(rg, rv)
+                    if _IS_TF2:
+                        for rv, rg in zip(rv, rg):
+                            v2g[rv.ref()] = rg
+                        return [v2g[rv.ref()] for rv in vars]
+                    else:
+                        for rv, rg in zip(rv, rg):
+                            v2g[rv] = rg
+                        return [v2g[rv] for rv in vars]
+                return __filtered_reduce_grads(grads, vars)
 
         def apply_gradients(self, *args, **kwargs):
             if self._agg_helper:

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -604,6 +604,7 @@ if _LegacyOptimizer is not None:
                 name, device_dense, device_sparse, compression, sparse_as_dense, op,
                 gradient_predivide_factor, groups, process_set=process_set)
 
+            self._local_vars = set()
             self._agg_helper = None
             if backward_passes_per_step > 1:
                 if _executing_eagerly():
@@ -621,6 +622,17 @@ if _LegacyOptimizer is not None:
                     optimizer_type=LocalGradientAggregationHelper._OPTIMIZER_TYPE_LEGACY,
                 )
 
+        def register_local_var(self, var):
+            """Registers a source/variable as worker local. Horovod will not perform any global
+            operations on gradients corresponding to these sources and will instead return the local
+            gradient."""    
+            if self._agg_helper:
+                self._agg_helper.register_local_var(var)
+            elif _IS_TF2:
+                self._local_vars.add(var.ref())
+            else:
+                self._local_vars.add(var)
+
         def compute_gradients(self, *args, **kwargs):
             """Compute gradients of all trainable variables.
 
@@ -634,7 +646,33 @@ if _LegacyOptimizer is not None:
             if self._agg_helper:
                 avg_grads = self._agg_helper.compute_gradients(grads, vars)
             else:
-                avg_grads = self._allreduce_grads(grads, vars)
+                def _filtered_reduce_grads(grads, vars):
+                    rv = []
+                    rg = []
+                    if _IS_TF2:
+                        v2g = {var.ref(): grad for var, grad in zip(vars, grads)}
+                        for var, grad in zip(vars, grads):
+                            if var.ref() not in self._local_vars:
+                                rv.append(var)
+                                rg.append(grad)
+                    else:
+                        v2g = {var: grad for var, grad in zip(vars, grads)}
+                        for var, grad in zip(vars, grads):
+                            if var not in self._local_vars:
+                                rv.append(var)
+                                rg.append(grad)
+
+                    rg = self._allreduce_grads(rg, rv)
+                    if _IS_TF2:
+                        for rv,rg in zip(rv, rg):
+                            v2g[rv.ref()] = rg
+                        return [v2g[rv.ref()] for rv in vars]
+                    else:
+                        for rv, rg in zip(rv, rg):
+                            v2g[rv] = rg
+                        return [v2g[rv] for rv in vars]
+
+                avg_grads = _filtered_reduce_grads(grads, vars)
             return list(zip(avg_grads, vars))
 
         def apply_gradients(self, grads_and_vars, global_step=None, name=None):

--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -1,4 +1,7 @@
 import tensorflow as tf
+from distutils.version import LooseVersion
+
+_IS_TF2 = LooseVersion(tf.__version__) >= LooseVersion('2.0.0')
 
 
 def apply_op_to_not_none_tensors(tensor_op, tensors, *args):
@@ -62,6 +65,17 @@ class LocalGradientAggregationHelper:
         # the list into a tf.cond().
         self.not_none_indexes = {}
         self.num_none_grad_updates = 0
+
+        self._local_vars = set()
+
+    def register_local_var(self, var):
+        """Registers a source/variable as worker local. Horovod will not perform any global
+        operations on gradients corresponding to these sources and will instead return the local
+        gradient."""
+        if _IS_TF2:
+            self._local_vars.add(var.ref())
+        else:
+            self._local_vars.add(var)
 
     def _maybe_convert_grad(self, grad):
         # Handle IndexedSlices.
@@ -147,6 +161,32 @@ class LocalGradientAggregationHelper:
         return aggregation_ops_list
 
     def _allreduce_grads_helper(self, vars):
+        def __filtered_reduce_grads(grads, vars):
+            rv = []
+            rg = []
+            if _IS_TF2:
+                v2g = {var.ref(): grad for var, grad in zip(vars, grads)}
+                for var, grad in zip(vars, grads):
+                    if var.ref() not in self._local_vars:
+                        rv.append(var)
+                        rg.append(grad)
+            else:
+                v2g = {var: grad for var, grad in zip(vars, grads)}
+                for var, grad in zip(vars, grads):
+                    if var not in self._local_vars:
+                        rv.append(var)
+                        rg.append(grad)
+
+            rg = self._allreduce_grads(rg, rv)
+            if _IS_TF2:
+                for rv, rg in zip(rv, rg):
+                    v2g[rv.ref()] = rg
+                return [v2g[rv.ref()] for rv in vars]
+            else:
+                for rv, rg in zip(rv, rg):
+                    v2g[rv] = rg
+                return [v2g[rv] for rv in vars]
+
         # Read in latest variables values.
         aggregated_grads = []
         aggregation_read_ops_list = []
@@ -157,7 +197,7 @@ class LocalGradientAggregationHelper:
         aggregation_read_ops = tf.group(*aggregation_read_ops_list)
 
         with tf.control_dependencies([aggregation_read_ops]):
-            averaged_gradients = self._allreduce_grads(aggregated_grads, vars)
+            averaged_gradients = __filtered_reduce_grads(aggregated_grads, vars)
 
             # Reset counter.
             with tf.control_dependencies([g.op for g in averaged_gradients if g is not None]):

--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
-from distutils.version import LooseVersion
+from packaging import version
 
-_IS_TF2 = LooseVersion(tf.__version__) >= LooseVersion('2.0.0')
+_IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
 
 
 def apply_op_to_not_none_tensors(tensor_op, tensors, *args):

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -379,3 +379,207 @@ class Tf2KerasTests(tf.test.TestCase):
 
         aggregation_counter = hvd_optimizer._agg_helper.counter.numpy()
         assert aggregation_counter == total_num_of_steps % backward_passes_per_step
+
+    @parameterized.expand([
+        [True],
+        [False]
+    ])
+    def test_gradient_aggregation_with_local_vars(self, average_aggregated_gradients):
+        class TestingOptimizer(optimizer_v2.OptimizerV2):
+            """
+            Custom optimizer we use for testing gradient aggregation.
+            """
+
+            def get_config(self):
+                config = super(TestingOptimizer, self).get_config()
+                return config
+
+            def _create_slots(self, var_list):
+                # Only needed for TF < 2.2.
+                pass
+
+            def _resource_apply_dense(self, grad, var, apply_state=None):
+                return var.assign_add(grad)
+
+        backward_passes_per_step = 4
+        local_rank = hvd.local_rank()
+        if tf.test.is_gpu_available(cuda_only=True):
+            with tf.device("/gpu:%d" % local_rank):
+                hvd_optimizer = hvd.DistributedOptimizer(
+                    optimizer=TestingOptimizer("test"),
+                    backward_passes_per_step=backward_passes_per_step,
+                    average_aggregated_gradients=average_aggregated_gradients,
+                    sparse_as_dense=True,
+                )
+        else:
+            hvd_optimizer = hvd.DistributedOptimizer(
+                    optimizer=TestingOptimizer("test"),
+                    backward_passes_per_step=backward_passes_per_step,
+                    average_aggregated_gradients=average_aggregated_gradients,
+                    sparse_as_dense=True,
+                )
+
+        _ = hvd_optimizer.iterations
+
+        total_num_variables = 8
+        num_local_vars = 4
+        X_0 = [0.0]*total_num_variables
+        Y_0, Y_1 = [1.0]*total_num_variables, [2.0]*total_num_variables
+        X = [tf.Variable([x_0]) for x_0 in X_0]
+        Y = [tf.Variable([y_0, y_1]) for y_0, y_1 in zip(Y_0, Y_1)]
+        variables = [X, Y]
+
+        for i in range(num_local_vars):
+            x_var = X[i]
+            y_var = Y[i]
+            hvd_optimizer.register_local_var(x_var)
+            hvd_optimizer.register_local_var(y_var)
+
+        def loss():
+            """
+            loss = x - y * er where er = [float(hvd.rank()+1), 0.0]
+            """
+            # Gather the first row of y. It is equivalent to y * er.
+            # Use tf.gather to produce tf.IndexedSlices gradient to improve test coverage.
+            gathered_y_1 = tf.gather(Y, [0], axis=1)
+            return X - (float(hvd.rank()+1) * gathered_y_1)
+
+        def compute_expected_value(batch_id):
+            """
+            Given the loss function above, the gradient of x and y can be derived.
+              dloss/dx = 1.0
+              dloss/dy = [-float(hvd.rank()+1), 0.0]
+            Therefore, for each step, the value of x increases by 1.0 and
+            the value of y increases by [-float(hvd.rank()), 0.0].
+            """
+            num_of_steps = (batch_id + 1) // backward_passes_per_step
+
+            gradient_of_x = num_of_steps * 1.0
+
+            # At each rank, the gradient of y_0 evaluates to (hvd.rank()+1).
+            # For non-local variables we need to average the value accross the ranks.
+            # The average value is (1+2+...hvd.size())/hvd.size() wich is
+            # equivalent to the following expression:
+            gradient_of_y_multiplier = float(hvd.size()+1)/2
+            gradient_of_y_0 = num_of_steps * gradient_of_y_multiplier * -1.0
+
+            if not average_aggregated_gradients:
+                gradient_of_x *= backward_passes_per_step
+                gradient_of_y_0 *= backward_passes_per_step
+
+            expected_x = np.array(X_0) + gradient_of_x
+
+            expected_y_0 = np.array(Y_0)
+            for i in range(len(Y_0)):
+                if i < num_local_vars:
+                    # recover the gradient of local vars
+                    expected_y_0[i] += (gradient_of_y_0/gradient_of_y_multiplier)*float(hvd.rank()+1)
+                else:
+                    expected_y_0[i] += gradient_of_y_0
+
+            # It should remain constant as gradient is always 0.
+            expected_y_1 = np.array(Y_1)
+            expected_y = [[ey0, ey1] for ey0,ey1 in zip(expected_y_0, expected_y_1)]
+
+            return np.array(expected_x), np.array(expected_y)
+
+        @tf.function
+        def compute_and_apply_gradients_in_tf_function(var_list, **kwargs):
+            # Compute and apply gradient updates in tf.function to reproduce
+            # how it is done inside `model.fit()`.
+            if tf.test.is_gpu_available(cuda_only=True):
+                with tf.device("/gpu:%d" % local_rank):
+                    grads_and_vars = hvd_optimizer._compute_gradients(
+                        loss, var_list=var_list)
+                    hvd_optimizer.apply_gradients(grads_and_vars, **kwargs)
+            else:
+                grads_and_vars = hvd_optimizer._compute_gradients(
+                    loss, var_list=var_list)
+                hvd_optimizer.apply_gradients(grads_and_vars, **kwargs)
+
+        total_num_of_steps = 10
+        for idx in range(total_num_of_steps):
+            if _PRE_TF_2_2_0:
+                compute_and_apply_gradients_in_tf_function(var_list=variables)
+            else:
+                # In 2.2 and 2.3 the horovod optimizer sets `_HAS_AGGREGATE_GRAD = True`.
+                # This configures tf.keras to call `_aggregate_gradients()` outside of
+                # `apply_gradients()` and to set `experimental_aggregate_gradients` to
+                # False when calling `apply_gradients()` to prevent it from calling
+                # `_aggregate_gradients()` again.
+                compute_and_apply_gradients_in_tf_function(
+                    var_list=variables,
+                    experimental_aggregate_gradients=False)
+
+            expected_x, expected_y = compute_expected_value(idx)
+            updated_x = np.array(variables[0])
+            updated_y = np.array(variables[1])
+            assert np.isclose(updated_x, expected_x).all()
+            assert np.isclose(updated_y, expected_y).all()
+            assert idx + 1 == hvd_optimizer.iterations.numpy()
+
+        aggregation_counter = hvd_optimizer._agg_helper.counter.numpy()
+        assert aggregation_counter == total_num_of_steps % backward_passes_per_step
+
+    def test_distributed_optimizer_with_local_vars(self):
+        """ Note: test makes most sense with more than 1 nodes. """
+        hvd.init()
+        if hvd.size() == 1:
+            self.skipTest("Only one worker available")
+
+        # the keras model has 3 layers, we test cases with 0, 1, and 2 local layers.
+        for num_local_layers in range(3):
+            model = tf.keras.models.Sequential()
+            initializer = tf.keras.initializers.Constant(hvd.rank())
+            model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))
+            model.add(tf.keras.layers.RepeatVector(3))
+            model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(3, kernel_initializer=initializer, bias_initializer=initializer)))
+            opt = tf.keras.optimizers.Adam()
+            model.compile(loss=tf.keras.losses.MSE,
+                            metrics=[tf.keras.metrics.categorical_accuracy])
+
+            X = np.random.random((1, 3))
+            Y = np.random.random((1, 3, 3))
+
+            try:
+                init = tf.global_variables_initializer()
+            except AttributeError:
+                init = tf.compat.v1.global_variables_initializer()
+            self.evaluate(init)
+
+            with tf.GradientTape(persistent=True) as tape:
+                p = model(X, training=True)
+                l = model.loss(Y, p)
+
+            gradients_tape = tape.gradient(l, model.trainable_weights)
+
+            # deem local layers
+            local_layers = model.layers[:num_local_layers]
+            local_vars = [var for layer in local_layers for var in layer.trainable_weights]
+
+            local_rank = hvd.local_rank()
+            if tf.test.is_gpu_available(cuda_only=True):
+                with tf.device("/gpu:%d" % local_rank):
+                    opt = hvd.DistributedOptimizer(opt, sparse_as_dense=True)
+                    # register local vars to the opt
+                    for var in local_vars:
+                        opt.register_local_var(var)
+                    gradients_vars_opt = opt._compute_gradients(l, model.trainable_weights, tape=tape)
+            else:
+                opt = hvd.DistributedOptimizer(opt, sparse_as_dense=True)
+                # register local vars to the opt
+                for var in local_vars:
+                    opt.register_local_var(var)
+                gradients_vars_opt = opt._compute_gradients(l, model.trainable_weights, tape=tape)
+
+            var_grad_tape = {var.ref():grad for var,grad in zip(model.trainable_weights, gradients_tape)}
+            var_grad_opt = {var.ref():grad for grad,var in gradients_vars_opt}
+            local_vars = [var.ref() for layer in local_layers for var in layer.trainable_weights]
+
+            for var in model.trainable_weights:
+                if var.ref() in local_vars:
+                    # local gradients should not change.
+                    self.assertAllClose(var_grad_tape[var.ref()], var_grad_opt[var.ref()])
+                else:
+                    # non-local gradients shouldn't be equal given that the initial weights are set to ranks
+                    self.assertNotAllClose(var_grad_tape[var.ref()], var_grad_opt[var.ref()])


### PR DESCRIPTION
Signed-off-by: Ata FatahiBaarzi <afatahibaarzi@linkedin.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?


## Description
This is to continue work done in #3628 and #3643 and adds the same functionality to the Distributed Optimizers and Local Gradient Aggregators. This is useful for model parallel use cases that use distributed optimizers and want to skip syncing their "local" gradients.

An example usage is shown in the unit tests included PR, but in short it's like the following:
```python
    ...
    opt = hvd.DistributedOptimizer(opt)

    # Register worker local variables (i.e. local source)
    for var in model.trainable_variables:
      if <var is worker local>:
          opt.register_local_var(var)

    # Compute gradients. Any gradient associated with a var passed to register_local_var will not be modified by Horovod.
    gradients = opt.compute_gradients(loss, model.trainable_variables, tape)
```

If this change get merged, similar to #3643 we can possibly add a new API called `PartialDistributedOptimizer`.
