### PR TITLE
Fix reducescatter() and grouped_reducescatter() to raise clean exceptions for scalar inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - PyTorch on GPUs without GPU operations: Fixed grouped allreduce to set CPU device in tensor table. ([#3594](https://github.com/horovod/horovod/pull/3594))
 - Fixed race condition in PyTorch allocation handling. ([#3639](https://github.com/horovod/horovod/pull/3639))
 - Build: Fixed finding nvcc (if not in $PATH) with older versions of CMake. ([#3682](https://github.com/horovod/horovod/pull/3682))
+- Fixed reducescatter() and grouped_reducescatter() to raise clean exceptions for scalar inputs. ([#3699](https://github.com/horovod/horovod/pull/3699))
 
 
 ## [v0.25.0] - 2022-06-20

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -686,7 +686,14 @@ Response Controller::ConstructResponse(const std::string& name, int joined_size)
     for (auto dim : requests[0].tensor_shape()) {
       tensor_shape.AddDim(dim);
     }
-    tensor_sizes.push_back(tensor_shape.num_elements());
+    if (tensor_shape.dims() == 0) {
+      error = true;
+      error_message_stream << "Process-set rank zero tried to "
+                           << Request::RequestType_Name(message_type)
+                           << " a rank-zero tensor.";
+    } else {
+      tensor_sizes.push_back(tensor_shape.num_elements());
+    }
   }
 
   if (message_type == Request::ALLREDUCE || message_type == Request::ADASUM) {

--- a/horovod/mxnet/mpi_ops.py
+++ b/horovod/mxnet/mpi_ops.py
@@ -564,6 +564,8 @@ def reducescatter(tensor, op=Average, name=None, priority=0,
     """
     assert(isinstance(tensor, mx.nd.NDArray))
     assert(op in [Average, Sum])
+    if tensor.shape == ():
+        raise ValueError("reducescatter does not support scalar inputs")
     # Size of output is unknown, create output array that
     # will be resized during Horovod operation
     output = mx.nd.empty(shape=(1,), ctx=tensor.context,
@@ -618,6 +620,8 @@ def grouped_reducescatter(tensors, op=Average, name=None, priority=0,
     """
     assert(all(isinstance(t, mx.nd.NDArray) for t in tensors))
     assert(op in [Average, Sum])
+    if any(tensor.shape == () for tensor in tensors):
+        raise ValueError("groued_reducescatter does not support scalar inputs")
     # Sizes of outputs are unknown, create output arrays that
     # will be resized during Horovod operation
     outputs = [mx.nd.empty(shape=(1,), ctx=t.context, dtype=t.dtype)

--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -1321,6 +1321,10 @@ REGISTER_OP("HorovodReducescatter")
     .Input("tensor: T")
     .Output("output: T")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
+      if (shape_inference::InferenceContext::Rank(c->input(0)) == 0) {
+        return errors::InvalidArgument(
+            "HorovodReducescatter does not support scalar inputs.");
+      }
       shape_inference::ShapeHandle output;
       TF_RETURN_IF_ERROR(
           c->ReplaceDim(c->input(0), 0, c->UnknownDim(), &output));
@@ -1449,6 +1453,10 @@ REGISTER_OP("HorovodGroupedReducescatter")
     .Output("outputs: num_tensors*T")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       for (int i = 0; i < c->num_inputs(); ++i) {
+        if (shape_inference::InferenceContext::Rank(c->input(i)) == 0) {
+          return errors::InvalidArgument(
+              "HorovodGroupedReducescatter does not support scalar inputs.");
+        }
         shape_inference::ShapeHandle output;
         TF_RETURN_IF_ERROR(
             c->ReplaceDim(c->input(i), 0, c->UnknownDim(), &output));

--- a/horovod/torch/__init__.py
+++ b/horovod/torch/__init__.py
@@ -51,6 +51,7 @@ if _MPI_LIB_AVAILABLE:
     from horovod.torch.mpi_ops import nccl_built, ddl_built, ccl_built, cuda_built, rocm_built
     from horovod.torch.mpi_ops import ProcessSet, global_process_set, add_process_set, remove_process_set
     from horovod.torch.mpi_ops import Average, Sum, Adasum
+    from horovod.torch.mpi_ops import HorovodInternalError
     from horovod.torch.optimizer import DistributedOptimizer
     from horovod.torch.sync_batch_norm import SyncBatchNorm
 

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -3529,6 +3529,20 @@ class TorchTests(unittest.TestCase):
             max_difference = averaged.data.sub(expected).max()
             assert max_difference <= threshold, 'hvd.reducescatter produces incorrect results'
 
+    def test_horovod_reducescatter_scalar_error(self):
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        tensor_types = self.filter_supported_types([torch.FloatTensor])
+        if torch.cuda.is_available():
+            tensor_types += [torch.cuda.FloatTensor]
+        for tensor_type in tensor_types:
+            scalar = self.cast_and_place(torch.tensor(rank), tensor_type)
+            with self.assertRaises((torch.FatalError, RuntimeError)):
+                _ = hvd.reducescatter(scalar, op=hvd.Average)
 
     def test_horovod_reducescatter_adasum(self):
         """Test that the reducescatter raises an error if we use Adasum operation."""
@@ -3970,6 +3984,22 @@ class TorchTests(unittest.TestCase):
 
             assert all([torch.allclose(t1, t2, threshold) for t1, t2 in zip(expected, averaged)]), \
                 'hvd.grouped_reducescatter produces incorrect results for average'
+
+    def test_horovod_grouped_reducescatter_scalar_error(self):
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        tensor_types = self.filter_supported_types([torch.FloatTensor])
+        if torch.cuda.is_available():
+            tensor_types += [torch.cuda.FloatTensor]
+        for tensor_type in tensor_types:
+            scalar = self.cast_and_place(torch.tensor(rank), tensor_type)
+            tensor = self.cast_and_place(torch.zeros((3,1)), tensor_type)
+            with self.assertRaises((torch.FatalError, RuntimeError)):
+                _ = hvd.grouped_reducescatter([tensor, scalar])
 
     def test_horovod_grouped_reducescatter_process_sets(self):
         """Test that grouped reducescatter correctly sums and scatters 1D, 2D, 3D tensors if restricted to process sets."""


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This fixes Horovod crashing when scalar inputs are passed to `hvd.reducescatter` or `hvd.grouped_reducescatter`. Attempts to do so now raise exceptions that users can deal with appropriately.

Initially I thought it would be a good idea to have `hvd.reducescatter(3.14)` do exactly the same thing as `hvd.reducescatter([3.14])`, i.e., return a single-element 1D tensor on rank 0 and an empty 1D tensor on the other ranks. However, having given this some consideration, I feel that it would be confusing and potentially error prone if zero-rank inputs produced higher ranked outputs. It seems less surprising to deal with such a possibility explicitly in user code if necessary (just as it is the case with `hvd.allgather`).

Fixes #3698.