### PR TITLE
Support registering local variables for BroadcastGlobalVariablesCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `PartialDistributedGradientTape()` API for model parallel use cases. ([#3643](https://github.com/horovod/horovod/pull/3643))
 - Enable use of native `ncclAvg` op for NCCL allreduces. ([#3646](https://github.com/horovod/horovod/pull/3646))
 - Tensorflow: Added `register_local_var` functionality to distributed optimizers and local gradient aggregators. ([3695](https://github.com/horovod/horovod/pull/3695))
+- Tensorflow: Added support for local variables for `BroadcastGlobalVariablesCallback`. ([3703](https://github.com/horovod/horovod/pull/3703))
 
 ### Changed
 

--- a/horovod/_keras/callbacks.py
+++ b/horovod/_keras/callbacks.py
@@ -34,6 +34,10 @@ class BroadcastGlobalVariablesCallbackImpl(object):
         Registers a variable as worker local. Horovod will not perform broadcasting
             operation on this variable.
         """
+        if version.parse(tf.__version__) < version.parse('2.0.0'):
+            raise Exception('Registering local variables for '
+                            'BroadcastGlobalVariablesCallback is not supported in TF 1.*')
+
         self._local_vars.add(var.ref())
 
     def on_batch_end(self, batch, logs=None):

--- a/horovod/tensorflow/keras/callbacks.py
+++ b/horovod/tensorflow/keras/callbacks.py
@@ -36,7 +36,7 @@ class BroadcastGlobalVariablesCallback(_impl.BroadcastGlobalVariablesCallbackImp
     training is started with random weights or restored from a checkpoint.
     """
 
-    def __init__(self, root_rank, device=''):
+    def __init__(self, root_rank, device='', local_variables=None):
         """
         Construct a new BroadcastGlobalVariablesCallback that will broadcast all
         global variables from root rank to all other processes during initialization.
@@ -45,8 +45,17 @@ class BroadcastGlobalVariablesCallback(_impl.BroadcastGlobalVariablesCallbackImp
             root_rank: Rank that will send data, other ranks will receive data.
             device: Device to be used for broadcasting. Uses GPU by default
                     if Horovod was build with HOROVOD_GPU_OPERATIONS.
+            local_variables: A collection of variables that need not to be broadcasted.
         """
         super(BroadcastGlobalVariablesCallback, self).__init__(K, root_rank, device)
+        if local_variables is None:
+            local_variables = []
+        elif isinstance(local_variables, tf.Variable):
+            local_variables = [local_variables]
+        elif not all(isinstance(var, tf.Variable) for var in local_variables):
+            raise ValueError("All local variables must be of tf.Variable type.")
+        for var in local_variables:
+            self.register_local_var(var)
 
 
 class MetricAverageCallback(_impl.MetricAverageCallbackImpl, keras.callbacks.Callback):


### PR DESCRIPTION
Signed-off-by: Ata FatahiBaarzi <afatahibaarzi@linkedin.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
This PR is continuation of #3695, #3643, and #3628  and adds support for local variables for BroadcastGlobalVariablesCallback. So in model parallel use cases, the only the initial value of non-local variables are broadcasted.
An example use case is provided in the unit test included with this PR, but, in short, the callback will be used as follows:

```bash
...
local_variables = <local variables to current rank>
callbacks = [hvd.callbacks.BroadcastGlobalVariablesCallback(root_rank=root_rank, local_variables=local_variables)]
model.fit(..., callbacks=callbacks)
...
```


