### PR TITLE
Use CUDA 11.6 on Buildkite workers

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -7,9 +7,9 @@ set -eu
 repository=823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
 
 # our queues
-cpu_queue="cpu-v572"
-gpux2_queue="2x-gpu-v572"
-gpux4_queue="4x-gpu-v572"
+cpu_queue="cpu-v5111"
+gpux2_queue="2x-gpu-v5111"
+gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
 baseline="test-cpu-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0"

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -14,7 +14,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - wait
 - wait
 - label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
@@ -34,7 +34,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -52,7 +52,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -70,7 +70,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -88,7 +88,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -106,7 +106,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -124,7 +124,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - wait
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
@@ -143,7 +143,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
@@ -161,7 +161,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
@@ -179,7 +179,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -197,7 +197,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -215,7 +215,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet2_mnist.py
   artifact_paths: "artifacts/**"
@@ -233,7 +233,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
@@ -251,7 +251,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
@@ -269,7 +269,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
@@ -287,7 +287,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: MPI MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet2_mnist.py"
   artifact_paths: "artifacts/**"
@@ -305,7 +305,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
@@ -323,7 +323,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
@@ -341,7 +341,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c " horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -359,7 +359,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -377,7 +377,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -395,7 +395,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -413,4 +413,4 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -14,7 +14,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - label: ':docker: Build test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -30,7 +30,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - label: ':docker: Build test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -46,7 +46,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -62,7 +62,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - label: ':docker: Build test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -78,7 +78,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
@@ -94,7 +94,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: cpu-v572
+    queue: cpu-v5111
 - wait
 - wait
 - label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
@@ -114,7 +114,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -132,7 +132,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -150,7 +150,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -168,7 +168,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -186,7 +186,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -204,7 +204,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -222,7 +222,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -240,7 +240,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -258,7 +258,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -276,7 +276,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -294,7 +294,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -312,7 +312,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -330,7 +330,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -348,7 +348,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -366,7 +366,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -384,7 +384,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
@@ -402,7 +402,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -420,7 +420,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -438,7 +438,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
@@ -456,7 +456,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
@@ -474,7 +474,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 4x-gpu-v572
+    queue: 4x-gpu-v5111
 - wait
 - label: ':tensorflow: Gloo TensorFlow MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow/tensorflow_mnist.py
@@ -493,7 +493,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras/keras_mnist_advanced.py
   artifact_paths: "artifacts/**"
@@ -511,7 +511,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -529,7 +529,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
@@ -547,7 +547,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow.py test_elastic_tensorflow_keras.py"
   artifact_paths: "artifacts/**"
@@ -565,7 +565,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
@@ -583,7 +583,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
@@ -601,7 +601,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -619,7 +619,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -637,7 +637,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -655,7 +655,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
@@ -673,7 +673,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
@@ -691,7 +691,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
@@ -709,7 +709,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -727,7 +727,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -745,7 +745,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet MNIST (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
@@ -763,7 +763,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
@@ -781,7 +781,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -799,7 +799,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -817,7 +817,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_7_3-keras2_7_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -835,7 +835,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
@@ -853,7 +853,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
@@ -871,7 +871,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
@@ -889,7 +889,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -907,7 +907,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -925,7 +925,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet MNIST (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
@@ -943,7 +943,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
@@ -961,7 +961,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -979,7 +979,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -997,7 +997,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_8_2-keras2_8_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -1015,7 +1015,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
@@ -1033,7 +1033,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
@@ -1051,7 +1051,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
@@ -1069,7 +1069,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1087,7 +1087,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -1105,7 +1105,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet MNIST (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
@@ -1123,7 +1123,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
@@ -1141,7 +1141,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
@@ -1159,7 +1159,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
@@ -1177,7 +1177,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: MPI MXNet MNIST (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1195,7 +1195,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1213,7 +1213,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1231,7 +1231,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1249,7 +1249,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1267,7 +1267,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -1285,7 +1285,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -1303,7 +1303,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
@@ -1321,7 +1321,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
@@ -1339,7 +1339,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
@@ -1357,7 +1357,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1375,7 +1375,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
@@ -1393,7 +1393,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: Gloo MXNet MNIST (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
@@ -1411,7 +1411,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
@@ -1429,7 +1429,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
@@ -1447,7 +1447,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
@@ -1465,7 +1465,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':muscle: MPI MXNet MNIST (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1483,7 +1483,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1501,7 +1501,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
@@ -1519,7 +1519,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c " horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1537,7 +1537,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
@@ -1555,7 +1555,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -1573,7 +1573,7 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111
 - label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_9_1-keras2_9_0-torch1_12_1-mxnet1_9_1-pyspark3_3_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
@@ -1591,4 +1591,4 @@ steps:
   retry:
     automatic: true
   agents:
-    queue: 2x-gpu-v572
+    queue: 2x-gpu-v5111


### PR DESCRIPTION
Signed-off-by: Enrico Minack <github@enrico.minack.dev>

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This uses upgraded Buildkite workers without moving CI to CUDA 11.6 (as done in #3673).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
