### PR TITLE
Keras: Support only legacy optimizers in Keras 2.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Default Petastorm reader pool is changed from `process` to `thread` for lower memory usage. ([#3665](https://github.com/horovod/horovod/pull/3665))
+- Keras: Support only legacy optimizers in Keras 2.11+. ([#3725](https://github.com/horovod/horovod/pull/3725))
 
 ### Deprecated
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -19,6 +19,7 @@ import os
 import numpy as np
 import tensorflow as tf
 
+from packaging import version
 from pyspark import keyword_only
 from pyspark.ml.util import MLWritable, MLReadable
 from pyspark.ml.param.shared import Param, Params, TypeConverters
@@ -228,8 +229,13 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
         if optimizer:
             if isinstance(optimizer, str):
                 pass
-            elif not isinstance(optimizer, tf.keras.optimizers.Optimizer):
-                raise ValueError("optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer")
+            else:
+                if version.parse(tf.keras.__version__) < version.parse("2.11"):
+                    if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
+                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
+                else:
+                    if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
+                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
 
         return TFKerasUtil
 

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -42,6 +42,12 @@ def save_tf_keras_optimizer(optimizer, h5py_file):
             'You will have to compile your model again after loading it. '
             'Prefer using a Keras optimizer instead '
             '(see keras.io/optimizers).')
+    elif (hasattr(optimizers, "optimizer_experimental.Optimizer") and
+          isinstance(optimizer, optimizers.optimizer_experimental.Optimizer)):
+        logging.warning(
+            'Horovod Spark Keras estimator does not support Keras reworked optimizers after Keras 2.11'
+            'You will have to change to tf.keras.optimizers.legacy.Optimizer in Keras 2.11+.'
+            '(see reworked optimizers at https://github.com/keras-team/keras/tree/master/keras/optimizers/optimizer_experimental)')
     else:
         h5py_file.attrs['training_config'] = json.dumps(
             {

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -63,7 +63,10 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_train_model_lr_schedule(self):
         initial_lr = 0.1 * hvd.size()
-        opt = tf.keras.optimizers.Adam()
+        if version.parse(tf.keras.__version__) < version.parse("2.11"):
+            opt = tf.keras.optimizers.Adam()
+        else:
+            opt = tf.keras.optimizers.legacy.Adam()
         opt = hvd.DistributedOptimizer(opt)
 
         def linear_multiplier(epoch):
@@ -153,7 +156,10 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_sparse_as_dense_with_grad_aggregation(self):
         backward_passes_per_step = 2
-        opt = keras.optimizers.RMSprop(lr=0.0001)
+        if version.parse(keras.__version__) < version.parse("2.11"):
+            opt = keras.optimizers.RMSprop(lr=0.0001)
+        else:
+            opt = keras.optimizers.legacy.RMSprop(lr=0.0001)
         opt = hvd.DistributedOptimizer(
             opt,
             sparse_as_dense=True,
@@ -179,9 +185,12 @@ class Tf2KerasTests(tf.test.TestCase):
     def test_grad_aggregation_with_inf_grad(self):
         backward_passes_per_step = 2
         step_count = tf.Variable(0, trainable=False, dtype=tf.int32)
-        opt = tf.optimizers.SGD()
+        if version.parse(tf.keras.__version__) < version.parse("2.11"):
+            opt = tf.keras.optimizers.SGD()
+        else:
+            opt = tf.keras.optimizers.legacy.SGD()
         opt = hvd.DistributedOptimizer(
-            opt, 
+            opt,
             backward_passes_per_step=backward_passes_per_step,
             sparse_as_dense=True
         )
@@ -204,7 +213,10 @@ class Tf2KerasTests(tf.test.TestCase):
         assert tf.math.is_finite(grads_and_vars[0][0])
 
     def test_from_config(self):
-        opt = keras.optimizers.Adam()
+        if version.parse(keras.__version__) < version.parse("2.11"):
+            opt = keras.optimizers.Adam()
+        else:
+            opt = keras.optimizers.legacy.Adam()
         hopt = hvd.DistributedOptimizer(opt)
         cfg = hopt.get_config()
 
@@ -517,7 +529,10 @@ class Tf2KerasTests(tf.test.TestCase):
             model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))
             model.add(tf.keras.layers.RepeatVector(3))
             model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(3, kernel_initializer=initializer, bias_initializer=initializer)))
-            opt = tf.keras.optimizers.Adam()
+            if version.parse(tf.keras.__version__) < version.parse("2.11"):
+                opt = tf.keras.optimizers.Adam()
+            else:
+                opt = tf.keras.optimizers.legacy.Adam()
             model.compile(loss=tf.keras.losses.MSE,
                             metrics=[tf.keras.metrics.categorical_accuracy])
 

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -60,7 +60,12 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         if size == 1:
             self.skipTest("Only one worker available")
 
-        class TestOptimizer(keras.optimizers.Optimizer):
+        if version.parse(keras.__version__) < version.parse("2.11"):
+            optimizer_class = keras.optimizers.Optimizer
+        else:
+            optimizer_class = keras.optimizers.legacy.Optimizer
+
+        class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
                 super(TestOptimizer, self).__init__(name, **kwargs)
 


### PR DESCRIPTION
We haven't figured out a way to save and load wegihts for default reworked optimizers in Keras 2.11+.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
