### PR TITLE
Pad fused GPU Allgathers for better memory alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Improved NCCL performance for fused Allgather operations by padding for better memory alignment. ([#3727](https://github.com/horovod/horovod/pull/3727))
+- Improved NCCL performance for fused allgather operations through padding for better memory alignment. ([#3727](https://github.com/horovod/horovod/pull/3727))
+- Improved look-ahead tensor fusion buffer size estimates when allgather and other operations are mixed. ([#3727](https://github.com/horovod/horovod/pull/3727))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Improved NCCL performance for fused Allgather operations by padding for better memory alignment. ([#3727](https://github.com/horovod/horovod/pull/3727))
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
 
 
 ## [v0.26.1] - 2022-10-14

--- a/horovod/common/controller.cc
+++ b/horovod/common/controller.cc
@@ -878,7 +878,7 @@ int64_t SumPairwisePadded(const std::vector<int64_t>& vec1,
 void AddVectorToVector(std::vector<int64_t>& vec1,
                        const std::vector<int64_t>& vec2) {
   assert(vec1.size() == vec2.size());
-  for (std::size_t i = 0; i < vec1.size(); ++i) {
+  for (size_t i = 0; i < vec1.size(); ++i) {
     vec1[i] += vec2[i];
   }
 }

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -171,10 +171,9 @@ protected:
                      HorovodGlobalState& state,
                      ResponseList& response_list);
 
-  // Byte size of each allgathered tensor.
-  std::vector<int64_t>
-  ByteSizeOfEachAllgatheredTensor(const std::vector<int64_t>& tensor_sizes,
-                                  const TensorTableEntry& entry);
+  void SetTensorByteSizesForAllgatheredTensors(
+      std::vector<int64_t>& tensor_byte_sizes,
+      const std::vector<int64_t>& tensor_sizes, const TensorTableEntry& entry);
 
   // Store the Request for a name, and return whether the total count of
   // Requests for that tensor is now equal to the HOROVOD size (and thus we are

--- a/horovod/common/controller.h
+++ b/horovod/common/controller.h
@@ -171,10 +171,10 @@ protected:
                      HorovodGlobalState& state,
                      ResponseList& response_list);
 
-  // Return the total byte size of the final allgathered output tensor
-  int64_t
-  TotalByteSizeOfAllgatherOutput(const std::vector<int64_t>& tensor_sizes,
-                                 const TensorTableEntry& entry);
+  // Byte size of each allgathered tensor.
+  std::vector<int64_t>
+  ByteSizeOfEachAllgatheredTensor(const std::vector<int64_t>& tensor_sizes,
+                                  const TensorTableEntry& entry);
 
   // Store the Request for a name, and return whether the total count of
   // Requests for that tensor is now equal to the HOROVOD size (and thus we are

--- a/horovod/common/ops/ccl_operations.cc
+++ b/horovod/common/ops/ccl_operations.cc
@@ -410,8 +410,8 @@ Status CCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
     SetRecvcounts(entry_component_sizes, entries.size(), global_size,
                   recvcounts);
     SetDisplacements(recvcounts, displcmnts, global_size);
-    SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                             entry_component_offsets);
+    SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                             global_size, entry_component_offsets);
 
     int element_size = global_state_->global_controller->GetTypeSize(
         first_entry.tensor->dtype());

--- a/horovod/common/ops/ccl_operations.cc
+++ b/horovod/common/ops/ccl_operations.cc
@@ -382,9 +382,7 @@ Status CCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
   // shortcut for single rank
   if (global_state_->global_controller->GetSize() == 1) {
     int64_t** entry_component_sizes = nullptr;
-    int* recvcounts = nullptr;
-    status =
-        AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+    status = AllocateOutput(entries, response, entry_component_sizes);
     return status.ok() ? cpyIn2Out(entries, this->ccl_context_->opctxt_)
                        : status;
   }
@@ -406,9 +404,11 @@ Status CCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
   }
 
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  status = AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  status = AllocateOutput(entries, response, entry_component_sizes);
   if (status.ok()) {
     timeline.ActivityEndAll(entries);
+    SetRecvcounts(entry_component_sizes, entries.size(), global_size,
+                  recvcounts);
     SetDisplacements(recvcounts, displcmnts, global_size);
     SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
                              entry_component_offsets);

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -222,16 +222,11 @@ void AllgatherOp::SetDisplacements(const int* recvcounts, int*& displcmnts,
 }
 
 void AllgatherOp::SetEntryComponentOffsets(
-    const std::vector<TensorTableEntry>& entries,
     const int64_t* const* entry_component_sizes, const int* recvcounts,
-    int64_t**& entry_component_offsets) {
-  assert(!entries.empty());
-  auto& process_set =
-      global_state_->process_set_table.Get(entries[0].process_set_id);
+    size_t num_entries, int global_size, int64_t**& entry_component_offsets) {
   unsigned int rank_displacement = 0;
-  int global_size = process_set.controller->GetSize();
   for (int rc = 0; rc < global_size; ++rc) {
-    for (size_t ec = 0; ec < entries.size(); ++ec) {
+    for (size_t ec = 0; ec < num_entries; ++ec) {
       if (ec == 0) {
         entry_component_offsets[ec][rc] = rank_displacement;
       } else {

--- a/horovod/common/ops/collective_operations.cc
+++ b/horovod/common/ops/collective_operations.cc
@@ -197,18 +197,18 @@ Status AllgatherOp::AllocateOutput(std::vector<TensorTableEntry>& entries,
 
 void AllgatherOp::SetRecvcounts(const int64_t* const* entry_component_sizes,
                                 size_t num_entries, int global_size,
-                                int*& recvcounts) {
+                                int*& recvcounts, int rank_padding_elements) {
   assert(num_entries > 0);
   for (int rc = 0; rc < global_size; ++rc) {
     recvcounts[rc] = (int)entry_component_sizes[0][rc];
-  }
-  for (size_t ec = 1; ec < num_entries; ++ec) {
-    for (int rc = 0; rc < global_size; ++rc) {
+    for (size_t ec = 1; ec < num_entries; ++ec) {
       recvcounts[rc] += (int)entry_component_sizes[ec][rc];
     }
+    recvcounts[rc] =
+        rank_padding_elements *
+        ((recvcounts[rc] + rank_padding_elements - 1) / rank_padding_elements);
   }
 }
-
 
 void AllgatherOp::SetDisplacements(const int* recvcounts, int*& displcmnts,
                                    int global_size) {

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -140,7 +140,7 @@ protected:
 
   static void SetRecvcounts(const int64_t* const* entry_component_sizes,
                             size_t num_entries, int global_size,
-                            int*& recvcounts);
+                            int*& recvcounts, int rank_padding_elements = 1);
 
   static void SetDisplacements(const int* recvcounts, int*& displcmnts,
                                int global_size);

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -138,18 +138,17 @@ protected:
                                 const Response& response,
                                 int64_t**& entry_component_sizes);
 
-  virtual void SetRecvcounts(const int64_t* const* entry_component_sizes,
-                             size_t num_entries, int global_size,
-                             int*& recvcounts);
+  static void SetRecvcounts(const int64_t* const* entry_component_sizes,
+                            size_t num_entries, int global_size,
+                            int*& recvcounts);
 
-  virtual void SetDisplacements(const int* recvcounts, int*& displcmnts,
-                                int global_size);
+  static void SetDisplacements(const int* recvcounts, int*& displcmnts,
+                               int global_size);
 
-  virtual void
-  SetEntryComponentOffsets(const std::vector<TensorTableEntry>& entries,
-                           const int64_t* const* entry_component_sizes,
-                           const int* recvcounts,
-                           int64_t**& entry_component_offsets);
+  static void
+  SetEntryComponentOffsets(const int64_t* const* entry_component_sizes,
+                           const int* recvcounts, size_t num_entries,
+                           int global_size, int64_t**& entry_component_offsets);
 
   virtual void
   MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries,

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -136,8 +136,11 @@ public:
 protected:
   virtual Status AllocateOutput(std::vector<TensorTableEntry>& entries,
                                 const Response& response,
-                                int64_t**& entry_component_sizes,
-                                int*& recvcounts);
+                                int64_t**& entry_component_sizes);
+
+  virtual void SetRecvcounts(const int64_t* const* entry_component_sizes,
+                             size_t num_entries, int global_size,
+                             int*& recvcounts);
 
   virtual void SetDisplacements(const int* recvcounts, int*& displcmnts,
                                 int global_size);

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -56,9 +56,6 @@ public:
 
   virtual ~AllreduceOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries,
-                         const Response& response) = 0;
-
   virtual bool Enabled(const ParameterManager& param_manager,
                        const std::vector<TensorTableEntry>& entries,
                        const Response& response) const = 0;
@@ -132,9 +129,6 @@ public:
 
   virtual ~AllgatherOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries,
-                         const Response& response) = 0;
-
   virtual bool Enabled(const ParameterManager& param_manager,
                        const std::vector<TensorTableEntry>& entries,
                        const Response& response) const = 0;
@@ -184,9 +178,6 @@ public:
 
   virtual ~BroadcastOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries,
-                         const Response& response) = 0;
-
   virtual bool Enabled(const ParameterManager& param_manager,
                        const std::vector<TensorTableEntry>& entries,
                        const Response& response) const = 0;
@@ -197,9 +188,6 @@ public:
   explicit AlltoallOp(HorovodGlobalState* global_state);
 
   virtual ~AlltoallOp() = default;
-
-  virtual Status Execute(std::vector<TensorTableEntry>& entries,
-                         const Response& response) = 0;
 
   virtual bool Enabled(const ParameterManager& param_manager,
                        const std::vector<TensorTableEntry>& entries,
@@ -284,9 +272,6 @@ public:
 
   virtual ~ReducescatterOp() = default;
 
-  Status Execute(std::vector<TensorTableEntry>& entries,
-                 const Response& response) override = 0;
-
   virtual bool Enabled(const ParameterManager& param_manager,
                        const std::vector<TensorTableEntry>& entries,
                        const Response& response) const = 0;
@@ -345,7 +330,8 @@ public:
 
   virtual ~BarrierOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries, const Response& response);
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 };
 
 class ErrorOp : public HorovodOp {
@@ -354,7 +340,8 @@ public:
 
   virtual ~ErrorOp() = default;
 
-  virtual Status Execute(std::vector<TensorTableEntry>& entries, const Response& response);
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 };
 
 } // namespace common

--- a/horovod/common/ops/gloo_operations.cc
+++ b/horovod/common/ops/gloo_operations.cc
@@ -264,8 +264,7 @@ Status GlooAllgather::Execute(std::vector<TensorTableEntry>& entries,
 
 
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status =
-      AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  Status status = AllocateOutput(entries, response, entry_component_sizes);
   if (!status.ok()) {
     /* Cleanup */
     for (size_t ec = 0; ec < entries.size(); ++ec) {
@@ -280,6 +279,7 @@ Status GlooAllgather::Execute(std::vector<TensorTableEntry>& entries,
   }
   timeline.ActivityEndAll(entries);
 
+  SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
   SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
                            entry_component_offsets);

--- a/horovod/common/ops/gloo_operations.cc
+++ b/horovod/common/ops/gloo_operations.cc
@@ -281,8 +281,8 @@ Status GlooAllgather::Execute(std::vector<TensorTableEntry>& entries,
 
   SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                           entry_component_offsets);
+  SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                           global_size, entry_component_offsets);
 
   std::unique_ptr<IGlooAlgorithms> gloo_algos(
       GetAlgorithmsForType(first_entry.tensor->dtype(), &gloo_context));

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -154,7 +154,6 @@ bool GPUAllreduce::Enabled(const ParameterManager& param_manager,
   return entries[0].device != CPU_DEVICE_ID;
 }
 
-#if HAVE_GPU
 void GPUAllreduce::MemcpyInFusionBuffer(
     const std::vector<TensorTableEntry>& entries, const void*& fused_input_data,
     void*& buffer_data, size_t& buffer_len) {
@@ -221,9 +220,7 @@ void GPUAllreduce::MemcpyInFusionBuffer(
   // Set the input data to originate from the buffer.
   fused_input_data = buffer_data;
 }
-#endif
 
-#if HAVE_GPU
 void GPUAllreduce::ScaleMemcpyInFusionBuffer(
     const std::vector<TensorTableEntry>& entries, const void*& fused_input_data,
     void*& buffer_data, size_t& buffer_len, double scale_factor) {
@@ -295,7 +292,6 @@ void GPUAllreduce::ScaleMemcpyInFusionBuffer(
   // Set the input data to originate from the buffer.
   fused_input_data = buffer_data;
 }
-#endif
 
 void GPUAllreduce::MemcpyEntryInFusionBuffer(
     const std::vector<TensorTableEntry>& entries, const TensorTableEntry& e,
@@ -307,7 +303,6 @@ void GPUAllreduce::MemcpyEntryInFusionBuffer(
           ->streams[global_state_->current_nccl_stream][first_entry.device]);
 }
 
-#if HAVE_GPU
 void GPUAllreduce::MemcpyOutFusionBuffer(
     const void* buffer_data, std::vector<TensorTableEntry>& entries) {
   if (global_state_->batch_d2d_memcopies) {
@@ -360,9 +355,7 @@ void GPUAllreduce::MemcpyOutFusionBuffer(
     }
   }
 }
-#endif
 
-#if HAVE_GPU
 void GPUAllreduce::ScaleMemcpyOutFusionBuffer(
     void* buffer_data, size_t buffer_len, double scale_factor,
     std::vector<TensorTableEntry>& entries) {
@@ -424,7 +417,6 @@ void GPUAllreduce::ScaleMemcpyOutFusionBuffer(
     }
   }
 }
-#endif
 
 void GPUAllreduce::MemcpyEntryOutFusionBuffer(
     const std::vector<TensorTableEntry>& entries,
@@ -459,7 +451,6 @@ bool GPUAllgather::Enabled(const ParameterManager& param_manager,
 }
 
 
-#if HAVE_GPU
 void GPUAllgather::MemcpyInFusionBuffer(
     const std::vector<TensorTableEntry>& entries, const int* displcmnts,
     int element_size, void*& buffer_data) {
@@ -522,7 +513,6 @@ void GPUAllgather::MemcpyInFusionBuffer(
     }
   }
 }
-#endif
 
 void GPUAllgather::MemcpyEntryInFusionBuffer(
     const std::vector<TensorTableEntry>& entries, const TensorTableEntry& e,
@@ -534,7 +524,6 @@ void GPUAllgather::MemcpyEntryInFusionBuffer(
           ->streams[global_state_->current_nccl_stream][first_entry.device]);
 }
 
-#if HAVE_GPU
 void GPUAllgather::MemcpyOutFusionBuffer(
     const int64_t* const* entry_component_offsets,
     const int64_t* const* entry_component_sizes, const void* buffer_data,
@@ -630,7 +619,6 @@ void GPUAllgather::MemcpyOutFusionBuffer(
     }
   }
 }
-#endif
 
 void GPUAllgather::MemcpyEntryOutFusionBuffer(
     const std::vector<TensorTableEntry>& entries,
@@ -693,7 +681,6 @@ void GPUReducescatter::MemcpyEntryOutFusionBuffer(
       gpu_context_->streams[global_state_->current_nccl_stream][e.device]);
 }
 
-#if HAVE_GPU
 void GPUReducescatter::MemcpyInFusionBuffer(
     const std::vector<TensorTableEntry>& entries,
     const std::vector<std::vector<TensorShape>>& output_shapes,
@@ -801,7 +788,6 @@ void GPUReducescatter::MemcpyOutFusionBuffer(
     ReducescatterOp::MemcpyOutFusionBuffer(buffer_data, entries);
   }
 }
-#endif // HAVE_GPU
 
 } // namespace common
 } // namespace horovod

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -462,7 +462,7 @@ void GPUAllgather::MemcpyInFusionBuffer(
   buffer_data = const_cast<void*>(buffer->AccessData(first_entry.context));
   auto& process_set =
       global_state_->process_set_table.Get(first_entry.process_set_id);
-  // offset incorporates rank padding via displcmnts
+  // offset incorporates rank padding via displacements
   int64_t offset = (int64_t)displcmnts[process_set.controller->GetRank()] *
                    (int64_t)element_size;
 

--- a/horovod/common/ops/gpu_operations.cc
+++ b/horovod/common/ops/gpu_operations.cc
@@ -471,12 +471,11 @@ void GPUAllgather::MemcpyInFusionBuffer(
   buffer_data = const_cast<void*>(buffer->AccessData(first_entry.context));
   auto& process_set =
       global_state_->process_set_table.Get(first_entry.process_set_id);
+  // offset incorporates rank padding via displcmnts
   int64_t offset = (int64_t)displcmnts[process_set.controller->GetRank()] *
                    (int64_t)element_size;
 
   if (global_state_->batch_d2d_memcopies) {
-    // enabled by default but can be modified via HOROVOD_BATCH_D2D_MEMCOPIES
-    // env var
     int idx = 0;
     int count = 0;
     BatchedD2DParams d2d_params;
@@ -556,6 +555,7 @@ void GPUAllgather::MemcpyOutFusionBuffer(
       int global_size = process_set.controller->GetSize();
       int64_t copy_offset = 0;
       for (int rc = 0; rc < global_size; rc++) {
+        // entry_component_offsets includes rank padding
         int64_t entry_offset = entry_component_offsets[ec][rc] * element_size;
         int64_t entry_size = entry_component_sizes[ec][rc] * element_size;
         void* buffer_data_at_offset = (uint8_t*)buffer_data + entry_offset;
@@ -618,6 +618,7 @@ void GPUAllgather::MemcpyOutFusionBuffer(
       int global_size = process_set.controller->GetSize();
       int64_t copy_offset = 0;
       for (int rc = 0; rc < global_size; ++rc) {
+        // entry_component_offsets includes rank padding
         int64_t entry_offset = entry_component_offsets[ec][rc] * element_size;
         int64_t entry_size = entry_component_sizes[ec][rc] * element_size;
         const void* buffer_data_at_offset =

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -160,7 +160,6 @@ public:
                const Response& response) const override;
 
 protected:
-#if HAVE_GPU
   void MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                             const void*& fused_input_data, void*& buffer_data,
                             size_t& buffer_len) override;
@@ -175,7 +174,6 @@ protected:
   void ScaleMemcpyOutFusionBuffer(void* buffer_data, size_t buffer_len,
                                   double scale_factor,
                                   std::vector<TensorTableEntry>& entries);
-#endif
 
   void MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                                  const TensorTableEntry& e,
@@ -203,7 +201,6 @@ public:
                const Response& response) const override;
 
 protected:
-#if HAVE_GPU
   void MemcpyInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                             const int* displcmnts, int element_size,
                             void*& buffer_data) override;
@@ -212,7 +209,6 @@ protected:
                              const int64_t* const* entry_component_sizes,
                              const void* buffer_data, int element_size,
                              std::vector<TensorTableEntry>& entries) override;
-#endif
   void MemcpyEntryInFusionBuffer(const std::vector<TensorTableEntry>& entries,
                                  const TensorTableEntry& e,
                                  void* buffer_data_at_offset) override;
@@ -267,7 +263,6 @@ protected:
   void MemcpyEntryOutFusionBuffer(const void* buffer_data_at_offset,
                                   TensorTableEntry& e) override;
 
-#if HAVE_GPU
   void MemcpyInFusionBuffer(
       const std::vector<TensorTableEntry>& entries,
       const std::vector<std::vector<TensorShape>>& output_shapes,
@@ -275,7 +270,6 @@ protected:
 
   void MemcpyOutFusionBuffer(const void* buffer_data,
                              std::vector<TensorTableEntry>& entries) override;
-#endif // HAVE_GPU
 
   GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -148,14 +148,16 @@ Status MPI_GPUAllgather::Execute(std::vector<TensorTableEntry>& entries, const R
   }
 
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  Status status = AllocateOutput(entries, response, entry_component_sizes);
   if (!status.ok()) {
     return status;
   }
   timeline.ActivityEndAll(entries);
 
+  SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts, entry_component_offsets);
+  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
+                           entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -150,6 +150,14 @@ Status MPI_GPUAllgather::Execute(std::vector<TensorTableEntry>& entries, const R
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
   Status status = AllocateOutput(entries, response, entry_component_sizes);
   if (!status.ok()) {
+    for (size_t ec = 0; ec < entries.size(); ++ec) {
+      delete[] entry_component_sizes[ec];
+      delete[] entry_component_offsets[ec];
+    }
+    delete[] entry_component_sizes;
+    delete[] entry_component_offsets;
+    delete[] recvcounts;
+    delete[] displcmnts;
     return status;
   }
   timeline.ActivityEndAll(entries);

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -156,8 +156,8 @@ Status MPI_GPUAllgather::Execute(std::vector<TensorTableEntry>& entries, const R
 
   SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                           entry_component_offsets);
+  SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                           global_size, entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 

--- a/horovod/common/ops/mpi_gpu_operations.h
+++ b/horovod/common/ops/mpi_gpu_operations.h
@@ -26,17 +26,19 @@ namespace common {
 class MPI_GPUAllreduce : public GPUAllreduce {
 public:
   MPI_GPUAllreduce(GPUContext* gpu_context, HorovodGlobalState* global_state);
-  virtual ~MPI_GPUAllreduce()=default;
+  ~MPI_GPUAllreduce() override = default;
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 };
 
 class MPI_GPUAllgather : public GPUAllgather {
 public:
   MPI_GPUAllgather(GPUContext* gpu_context, HorovodGlobalState* global_state);
-  virtual ~MPI_GPUAllgather()=default;
+  ~MPI_GPUAllgather() override = default;
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 };
 
 // TODO: Add MPI_GPUBroadcast implementation
@@ -44,9 +46,10 @@ public:
 class MPI_GPUAlltoall : public GPUAlltoall {
 public:
   MPI_GPUAlltoall(GPUContext* gpu_context, HorovodGlobalState* global_state);
-  virtual ~MPI_GPUAlltoall()=default;
+  ~MPI_GPUAlltoall() override = default;
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 };
 
 class MPI_GPUReducescatter : public GPUReducescatter {

--- a/horovod/common/ops/mpi_operations.cc
+++ b/horovod/common/ops/mpi_operations.cc
@@ -164,8 +164,8 @@ Status MPIAllgather::Execute(std::vector<TensorTableEntry>& entries, const Respo
 
   SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                           entry_component_offsets);
+  SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                           global_size, entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 
@@ -266,8 +266,8 @@ Status MPIHierarchicalAllgather::Execute(std::vector<TensorTableEntry>& entries,
 
   SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                           entry_component_offsets);
+  SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                           global_size, entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 

--- a/horovod/common/ops/mpi_operations.cc
+++ b/horovod/common/ops/mpi_operations.cc
@@ -147,7 +147,7 @@ Status MPIAllgather::Execute(std::vector<TensorTableEntry>& entries, const Respo
   }
 
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  Status status = AllocateOutput(entries, response, entry_component_sizes);
   if (!status.ok()) {
     /* Cleanup */
     for (size_t ec = 0; ec < entries.size(); ++ec) {
@@ -162,8 +162,10 @@ Status MPIAllgather::Execute(std::vector<TensorTableEntry>& entries, const Respo
   }
   timeline.ActivityEndAll(entries);
 
+  SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts, entry_component_offsets);
+  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
+                           entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 
@@ -247,7 +249,7 @@ Status MPIHierarchicalAllgather::Execute(std::vector<TensorTableEntry>& entries,
   }
 
   timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, response, entry_component_sizes, recvcounts);
+  Status status = AllocateOutput(entries, response, entry_component_sizes);
   if (!status.ok()) {
     /* Cleanup */
     for (size_t ec = 0; ec < entries.size(); ++ec) {
@@ -262,8 +264,10 @@ Status MPIHierarchicalAllgather::Execute(std::vector<TensorTableEntry>& entries,
   }
   timeline.ActivityEndAll(entries);
 
+  SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts, entry_component_offsets);
+  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
+                           entry_component_offsets);
 
   int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
 

--- a/horovod/common/ops/mpi_operations.h
+++ b/horovod/common/ops/mpi_operations.h
@@ -32,11 +32,12 @@ namespace common {
 
 class MPIAllreduce : public AllreduceOp {
 public:
-  MPIAllreduce(HorovodGlobalState* global_state);
+  explicit MPIAllreduce(HorovodGlobalState* global_state);
 
-  virtual ~MPIAllreduce() = default;
+  ~MPIAllreduce() override = default;
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -45,9 +46,10 @@ public:
 
 class MPIAllgather : public AllgatherOp {
 public:
-  MPIAllgather(HorovodGlobalState* global_state);
+  explicit MPIAllgather(HorovodGlobalState* global_state);
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -56,9 +58,10 @@ public:
 
 class MPIHierarchicalAllgather : public MPIAllgather {
 public:
-  MPIHierarchicalAllgather(HorovodGlobalState* global_state);
+  explicit MPIHierarchicalAllgather(HorovodGlobalState* global_state);
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -70,9 +73,10 @@ private:
 
 class MPIBroadcast : public BroadcastOp {
 public:
-  MPIBroadcast(HorovodGlobalState* global_state);
+  explicit MPIBroadcast(HorovodGlobalState* global_state);
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -81,9 +85,10 @@ public:
 
 class MPIAlltoall : public AlltoallOp {
 public:
-  MPIAlltoall(HorovodGlobalState* global_state);
+  explicit MPIAlltoall(HorovodGlobalState* global_state);
 
-  Status Execute(std::vector<TensorTableEntry>& entries, const Response& response) override;
+  Status Execute(std::vector<TensorTableEntry>& entries,
+                 const Response& response) override;
 
   bool Enabled(const ParameterManager& param_manager,
                const std::vector<TensorTableEntry>& entries,
@@ -92,7 +97,7 @@ public:
 
 class MPIReducescatter : public ReducescatterOp {
 public:
-  MPIReducescatter(HorovodGlobalState* global_state);
+  explicit MPIReducescatter(HorovodGlobalState* global_state);
 
   ~MPIReducescatter() override = default;
 

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -1019,8 +1019,8 @@ Status NCCLAllgather::Execute(std::vector<TensorTableEntry>& entries,
 
   SetRecvcounts(entry_component_sizes, entries.size(), global_size, recvcounts);
   SetDisplacements(recvcounts, displcmnts, global_size);
-  SetEntryComponentOffsets(entries, entry_component_sizes, recvcounts,
-                           entry_component_offsets);
+  SetEntryComponentOffsets(entry_component_sizes, recvcounts, entries.size(),
+                           global_size, entry_component_offsets);
 
   auto element_size = (int)DataType_Size(first_entry.tensor->dtype());
 

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -296,8 +296,7 @@ public:
 protected:
   Status AllocateOutput(std::vector<TensorTableEntry>& entries,
                         const Response& response,
-                        int64_t**& entry_component_sizes,
-                        int*& recvcounts) override;
+                        int64_t**& entry_component_sizes) override;
 
   void WaitForData(std::vector<TensorTableEntry>& entries) override;
 


### PR DESCRIPTION
# Performance of NCCL Allgather depends on memory alignment

I noticed in profiling that grouped Allgather operations can have vastly differing run times, in particular with FP16, although they add up to similar fused tensor sizes. For instance, an operation sending 6,292,992 bytes would take < 2 msec, but an operation sending 6,294,530 bytes would take > 7 msec. The decisive difference between these two examples is that, in the faster case, the buffer size is divisible by `2**9`, while there is only one factor of 2 in the other buffer size. 

![image](https://user-images.githubusercontent.com/1778667/194069306-76a29d7d-dae3-49fe-83bc-eb2816403969.png)

Sylvain Jeaugey has pointed out in comments that Allgather and Reducescatter in particular benefit from memory alignment to 16 bytes (`2**4`): https://github.com/NVIDIA/nccl/issues/413#issuecomment-718862629, https://github.com/NVIDIA/nccl/issues/256#issuecomment-534192899

I could also measure performance differences depending on input size alignment with both `all_gather_perf` and `reduce_scatter_perf` from [nccl-tests](https://github.com/NVIDIA/nccl-tests). The effect was less pronounced with Reducescatter than with Allgather, and it was less extreme than the profiling suggested with Horovod. I suspect the reason for the latter point is that I wasn't able to set the input element count to a value that's not a multiple of 4 with nccl-tests (so with FP16 the finest granularity would be 8 bytes rather than 2 bytes). 

# Changes proposed with this PR

For GPU implementations of Allgather this PR changes slightly how tensors are copied into the fusion buffer: The fused Allgather input from each rank is padded to a multiple of 16 bytes. This significantly improves performance in the profiling example shown above: Both Allgathers now take < 2 msec and the aggregate effect significantly improves average training step times.

![image](https://user-images.githubusercontent.com/1778667/194078501-bd9204b2-9257-4000-a2ae-a891d22a8fd6.png)

While we could also pad the input of individual (rather than fused) Allgather operations (at the cost of an extra mem copy), I think the problem is more likely to surface for fused tensors: Large tensors will typically be set up to be divisible by many powers of 2, but they may for instance be fused with scalar values.

I've implemented the change for both NCCL and GPU-based MPI. Besides that I've made a pass over some class definitions and mostly went with `clang-tidy` suggestions to reduce warning clutter a bit.

# Alternative padding approach

In a first attempt I added extra padding for each individual tensor incorporated in a fused Allgather. An advantage was that this would also improve memory alignment for `BatchedD2DMemcpy*` before and after the Allgather. However, while this approach also evened out transfer times in profiling, it slowed down otherwise well-aligned Allgathers. In my profiling example both fused Allgathers would take ~2.6 msec. (Changes in branch at https://github.com/horovod/horovod/compare/master...maxhgerlach:horovod:pad-allgather)