### PR TITLE
Grant status write permissions to update status step

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -76,7 +76,7 @@ jobs:
     outputs:
       url: ${{ steps.build.outputs.url }}
     permissions:
-      # steps "Create check status" and "Update check status"
+      # step "Create check status"
       statuses: write
 
     steps:
@@ -108,6 +108,9 @@ jobs:
     name: "Build and Test GPU (download Builtkite)"
     needs: [buildkite-trigger]
     runs-on: ubuntu-latest
+    permissions:
+      # step "Update check status"
+      statuses: write
 
     steps:
       - name: Download Buildkite Artifacts
@@ -163,7 +166,7 @@ jobs:
     outputs:
       url: ${{ steps.build.outputs.url }}
     permissions:
-      # steps "Create check status" and "Update check status"
+      # step "Create check status"
       statuses: write
 
     steps:
@@ -195,6 +198,9 @@ jobs:
     name: "Build and Test GPU heads (download Builtkite)"
     needs: [buildkite-heads-trigger]
     runs-on: ubuntu-latest
+    permissions:
+      # step "Update check status"
+      statuses: write
 
     steps:
       - name: Download Buildkite Artifacts


### PR DESCRIPTION
Buildkite tests on forks are run via `ci-results.yaml`. Statuses are created when Buildkite is started and updated as `success` or `failure` when finished. That update did not work because permissions were missing for update step.