### PR TITLE
Support pinning to local rank GPU index in Spark estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
+- Added `HOROVOD_USE_DEFAULT_GPU_INDEX` environment variable to support manually pin to default GPU index in spark estimators. ([#3737](https://github.com/horovod/horovod/pull/3737))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
-- Added `HOROVOD_USE_DEFAULT_GPU_INDEX` environment variable to support manually pin to default GPU index in spark estimators. ([#3737](https://github.com/horovod/horovod/pull/3737))
+- Added `HOROVOD_SPARK_USE_LOCAL_RANK_GPU_INDEX` environment variable to ignore GPU device indices assigned by Spark and always use local rank GPU device in Spark estimators. ([#3737](https://github.com/horovod/horovod/pull/3737))
 
 ### Changed
 

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -354,8 +354,7 @@ for the spark task from which ``get_available_devices()`` is called.
 See `keras_spark3_rossmann.py <../examples/spark/keras/keras_spark3_rossmann.py>`__ for an example of using
 ``get_available_devices()`` with the Run API.
 
-In some cases, ``get_available_devices()`` may not return the correct list of GPUs if the GPUs resource are not configured correctly
-in the spark cluster. In this case, you can set environment variable ``HOROVOD_USE_DEFAULT_GPU_INDEX`` to ``1`` to use the default
-GPU index (local rank) for each task.
+In some cases, you may want to set the GPU index manually. You can set environment variable ``HOROVOD_USE_DEFAULT_GPU_INDEX`` to
+``1`` to use the default GPU index (local rank) for each task.
 
 .. inclusion-marker-end-do-not-remove

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -354,4 +354,8 @@ for the spark task from which ``get_available_devices()`` is called.
 See `keras_spark3_rossmann.py <../examples/spark/keras/keras_spark3_rossmann.py>`__ for an example of using
 ``get_available_devices()`` with the Run API.
 
+In some cases, ``get_available_devices()`` may not return the correct list of GPUs if the GPUs resource are not configured correctly
+in the spark cluster. In this case, you can set environment variable ``HOROVOD_USE_DEFAULT_GPU_INDEX`` to ``1`` to use the default
+GPU index (local rank) for each task.
+
 .. inclusion-marker-end-do-not-remove

--- a/docs/spark.rst
+++ b/docs/spark.rst
@@ -354,7 +354,8 @@ for the spark task from which ``get_available_devices()`` is called.
 See `keras_spark3_rossmann.py <../examples/spark/keras/keras_spark3_rossmann.py>`__ for an example of using
 ``get_available_devices()`` with the Run API.
 
-In some cases, you may want to set the GPU index manually. You can set environment variable ``HOROVOD_USE_DEFAULT_GPU_INDEX`` to
-``1`` to use the default GPU index (local rank) for each task.
+In some cases, you may want to ignore GPU devices assigned by Spark and always use the local rank as the GPU index.
+You can set environment variable ``HOROVOD_SPARK_USE_LOCAL_RANK_GPU_INDEX`` to ``1`` to have Horovod use the local rank
+as the GPU index for each task.
 
 .. inclusion-marker-end-do-not-remove

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -763,15 +763,16 @@ def to_list(var, length):
     return var
 
 
-def _get_assigned_gpu_or_default(default):
+def _get_assigned_gpu_or_local_rank(local_rank):
     from horovod.spark.task import get_available_devices
     available_devices = get_available_devices()
-    if available_devices:
+    if available_devices and os.getenv('HOROVOD_SPARK_USE_LOCAL_RANK_GPU_INDEX', '0') == '0':
         # if GPU-aware scheduling is available, pin to the assigned GPU index
+        # this is always the first GPU index in available_devices as only one GPU is expected to be assigned
         return int(available_devices[0])
     else:
-        # pin to default GPU index (local rank)
-        return default
+        # pin to local rank GPU index
+        return local_rank
 
 
 def is_databricks():

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -763,17 +763,12 @@ def to_list(var, length):
     return var
 
 
-def _get_assigned_gpu_or_default(default, hvd=None):
+def _get_assigned_gpu_or_default(default):
     from horovod.spark.task import get_available_devices
     available_devices = get_available_devices()
     if available_devices:
-        if hvd and len(available_devices) >= hvd.local_size():
-            # if GPU-aware scheduling is available, pin to one of the assigned GPUs
-            # pin to GPU based on local rank index
-            return int(available_devices[hvd.local_rank()])
-        else:
-            # pin to first assigned GPU
-            return int(available_devices[0])
+        # if GPU-aware scheduling is available, pin to the assigned GPU index
+        return int(available_devices[0])
     else:
         # pin to default GPU index (local rank)
         return default

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -763,12 +763,17 @@ def to_list(var, length):
     return var
 
 
-def _get_assigned_gpu_or_default(default):
+def _get_assigned_gpu_or_default(default, hvd=None):
     from horovod.spark.task import get_available_devices
     available_devices = get_available_devices()
     if available_devices:
-        # if GPU-aware scheduling is available, pin to the assigned GPU index
-        return int(available_devices[0])
+        if hvd and len(available_devices) >= hvd.local_size():
+            # if GPU-aware scheduling is available, pin to one of the assigned GPUs
+            # pin to GPU based on local rank index
+            return int(available_devices[hvd.local_rank()])
+        else:
+            # pin to first assigned GPU
+            return int(available_devices[0])
     else:
         # pin to default GPU index (local rank)
         return default

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -763,20 +763,20 @@ def to_list(var, length):
     return var
 
 
-def _get_assigned_gpu_or_default(local_rank, local_size):
+def _get_assigned_gpu_or_default(default, hvd=None):
     from horovod.spark.task import get_available_devices
     available_devices = get_available_devices()
     if available_devices:
-        if len(available_devices) >= local_size:
+        if hvd and len(available_devices) >= hvd.local_size():
             # if GPU-aware scheduling is available, pin to one of the assigned GPUs
             # pin to GPU based on local rank index
-            return int(available_devices[local_rank])
+            return int(available_devices[hvd.local_rank()])
         else:
             # pin to first assigned GPU
             return int(available_devices[0])
     else:
         # pin to default GPU index (local rank)
-        return local_rank
+        return default
 
 
 def is_databricks():

--- a/horovod/spark/common/util.py
+++ b/horovod/spark/common/util.py
@@ -763,20 +763,20 @@ def to_list(var, length):
     return var
 
 
-def _get_assigned_gpu_or_default(default, hvd=None):
+def _get_assigned_gpu_or_default(local_rank, local_size):
     from horovod.spark.task import get_available_devices
     available_devices = get_available_devices()
     if available_devices:
-        if hvd and len(available_devices) >= hvd.local_size():
+        if len(available_devices) >= local_size:
             # if GPU-aware scheduling is available, pin to one of the assigned GPUs
             # pin to GPU based on local rank index
-            return int(available_devices[hvd.local_rank()])
+            return int(available_devices[local_rank])
         else:
             # pin to first assigned GPU
             return int(available_devices[0])
     else:
         # pin to default GPU index (local rank)
-        return default
+        return local_rank
 
 
 def is_databricks():

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,7 +313,7 @@ def _pin_gpu_tensorflow2_fn():
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
             tf.config.experimental.set_visible_devices(
-                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank())], 'GPU')
+                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd)], 'GPU')
     return fn
 
 
@@ -322,7 +322,7 @@ def _pin_gpu_tensorflow1_fn():
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list = \
-            str(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+            str(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
         keras.backend.set_session(tf.Session(config=config))
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 from packaging import version
 from horovod.spark.common import constants
 from horovod.spark.common.store import DBFSLocalStore
-from horovod.spark.common.util import _get_assigned_gpu_or_default, _set_mp_start_method
+from horovod.spark.common.util import _get_assigned_gpu_or_local_rank, _set_mp_start_method
 from horovod.runner.common.util import codec
 
 TOTAL_BUFFER_MEMORY_CAP_GIB = constants.TOTAL_BUFFER_MEMORY_CAP_GIB
@@ -313,7 +313,7 @@ def _pin_gpu_tensorflow2_fn():
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
             tf.config.experimental.set_visible_devices(
-                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank())], 'GPU')
+                gpus[_get_assigned_gpu_or_local_rank(local_rank=hvd.local_rank())], 'GPU')
     return fn
 
 
@@ -322,7 +322,7 @@ def _pin_gpu_tensorflow1_fn():
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list = \
-            str(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+            str(_get_assigned_gpu_or_local_rank(local_rank=hvd.local_rank()))
         keras.backend.set_session(tf.Session(config=config))
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,7 +313,7 @@ def _pin_gpu_tensorflow2_fn():
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
             tf.config.experimental.set_visible_devices(
-                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd)], 'GPU')
+                gpus[_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size())], 'GPU')
     return fn
 
 
@@ -322,7 +322,7 @@ def _pin_gpu_tensorflow1_fn():
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list = \
-            str(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+            str(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
         keras.backend.set_session(tf.Session(config=config))
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,7 +313,7 @@ def _pin_gpu_tensorflow2_fn():
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
             tf.config.experimental.set_visible_devices(
-                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd)], 'GPU')
+                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank())], 'GPU')
     return fn
 
 
@@ -322,7 +322,7 @@ def _pin_gpu_tensorflow1_fn():
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list = \
-            str(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+            str(_get_assigned_gpu_or_default(default=hvd.local_rank()))
         keras.backend.set_session(tf.Session(config=config))
     return fn
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -313,7 +313,7 @@ def _pin_gpu_tensorflow2_fn():
             tf.config.experimental.set_memory_growth(gpu, True)
         if gpus:
             tf.config.experimental.set_visible_devices(
-                gpus[_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size())], 'GPU')
+                gpus[_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd)], 'GPU')
     return fn
 
 
@@ -322,7 +322,7 @@ def _pin_gpu_tensorflow1_fn():
         config = tf.ConfigProto()
         config.gpu_options.allow_growth = True
         config.gpu_options.visible_device_list = \
-            str(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
+            str(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
         keras.backend.set_session(tf.Session(config=config))
     return fn
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -28,7 +28,7 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger, CometLogger
 
 from horovod.spark.common import constants
-from horovod.spark.common.util import _get_assigned_gpu_or_default, _set_mp_start_method
+from horovod.spark.common.util import _get_assigned_gpu_or_local_rank, _set_mp_start_method
 from horovod.spark.lightning.datamodule import PetastormDataModule
 from horovod.spark.lightning.util import deserialize_fn
 
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
             if cuda_available:
                 # Horovod: pin GPU to local rank or the assigned GPU from spark.
-                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+                torch.cuda.set_device(_get_assigned_gpu_or_local_rank(local_rank=hvd.local_rank()))
                 # Move model to GPU.
                 model.cuda()
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
             if cuda_available:
                 # Horovod: pin GPU to local rank or the assigned GPU from spark.
-                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
                 # Move model to GPU.
                 model.cuda()
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
             if cuda_available:
                 # Horovod: pin GPU to local rank or the assigned GPU from spark.
-                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+                torch.cuda.set_device(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
                 # Move model to GPU.
                 model.cuda()
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
             if cuda_available:
                 # Horovod: pin GPU to local rank or the assigned GPU from spark.
-                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
                 # Move model to GPU.
                 model.cuda()
 

--- a/horovod/spark/lightning/remote.py
+++ b/horovod/spark/lightning/remote.py
@@ -222,7 +222,7 @@ def RemoteTrainer(estimator, metadata, ckpt_bytes, run_id, dataset_idx, train_ro
 
             if cuda_available:
                 # Horovod: pin GPU to local rank or the assigned GPU from spark.
-                torch.cuda.set_device(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
+                torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
                 # Move model to GPU.
                 model.cuda()
 

--- a/horovod/spark/task/task_info.py
+++ b/horovod/spark/task/task_info.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import os
 
 
 class TaskInfo(object):

--- a/horovod/spark/task/task_info.py
+++ b/horovod/spark/task/task_info.py
@@ -24,7 +24,7 @@ _info = TaskInfo()
 
 
 def get_available_devices():
-    if 'gpu' not in _info.resources or os.getenv('USE_DEFAULT_GPU_INDEX') == '1':
+    if 'gpu' not in _info.resources or os.getenv('HOROVOD_USE_DEFAULT_GPU_INDEX') == '1':
         return []
     return _info.resources['gpu'].addresses
 

--- a/horovod/spark/task/task_info.py
+++ b/horovod/spark/task/task_info.py
@@ -24,7 +24,7 @@ _info = TaskInfo()
 
 
 def get_available_devices():
-    if 'gpu' not in _info.resources or os.getenv('HOROVOD_USE_DEFAULT_GPU_INDEX') == '1':
+    if 'gpu' not in _info.resources:
         return []
     return _info.resources['gpu'].addresses
 

--- a/horovod/spark/task/task_info.py
+++ b/horovod/spark/task/task_info.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import os
 
 
 class TaskInfo(object):
@@ -23,7 +24,7 @@ _info = TaskInfo()
 
 
 def get_available_devices():
-    if 'gpu' not in _info.resources:
+    if 'gpu' not in _info.resources or os.getenv('USE_DEFAULT_GPU_INDEX') == '1':
         return []
     return _info.resources['gpu'].addresses
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -154,7 +154,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         if cuda_available:
             # Horovod: pin GPU to local rank or the assigned GPU from spark.
-            torch.cuda.set_device(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
+            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -154,7 +154,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         if cuda_available:
             # Horovod: pin GPU to local rank or the assigned GPU from spark.
-            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -154,7 +154,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         if cuda_available:
             # Horovod: pin GPU to local rank or the assigned GPU from spark.
-            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -24,7 +24,7 @@ import torch
 from torch.utils.tensorboard import SummaryWriter
 
 from horovod.spark.common import constants
-from horovod.spark.common.util import _get_assigned_gpu_or_default, to_list, _set_mp_start_method
+from horovod.spark.common.util import _get_assigned_gpu_or_local_rank, to_list, _set_mp_start_method
 from horovod.spark.common.store import DBFSLocalStore
 from horovod.spark.torch.util import deserialize_fn
 
@@ -154,7 +154,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         if cuda_available:
             # Horovod: pin GPU to local rank or the assigned GPU from spark.
-            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank()))
+            torch.cuda.set_device(_get_assigned_gpu_or_local_rank(local_rank=hvd.local_rank()))
             # Move model to GPU.
             model.cuda()
 

--- a/horovod/spark/torch/remote.py
+++ b/horovod/spark/torch/remote.py
@@ -154,7 +154,7 @@ def RemoteTrainer(estimator, metadata, last_checkpoint_state, run_id, dataset_id
 
         if cuda_available:
             # Horovod: pin GPU to local rank or the assigned GPU from spark.
-            torch.cuda.set_device(_get_assigned_gpu_or_default(default=hvd.local_rank(), hvd=hvd))
+            torch.cuda.set_device(_get_assigned_gpu_or_default(local_rank=hvd.local_rank(), local_size=hvd.local_size()))
             # Move model to GPU.
             model.cuda()
 


### PR DESCRIPTION
Signed-off-by: Li Jiang <bnujli@gmail.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

When using spark estimators (torch/lightning/keras) in GPU clusters, `get_available_devices` will be called

https://github.com/horovod/horovod/blob/d29bc04488f00426b5a18946d667ee04b4544956/horovod/spark/task/task_info.py#L25-L28

in `_get_assigned_gpu_or_default`.

https://github.com/horovod/horovod/blob/d29bc04488f00426b5a18946d667ee04b4544956/horovod/spark/common/util.py#L766-L774

And the `get_available_devices` will get the devices by calling `_get_resources`.

https://github.com/horovod/horovod/blob/d29bc04488f00426b5a18946d667ee04b4544956/horovod/spark/task/task_service.py#L98-L107


It works well in single-GPU per node clusters. However, when it comes to clusters with multi-GPUs per node. Wrong GPU index may be returned.

For spark clusters, usually [getGpusResources.sh](https://github.com/apache/spark/blob/master/examples/src/main/scripts/getGpusResources.sh) is used for discovering GPU resources. 

For clusters with multi-GPUs per node, if multi-GPUs are assigned to one executor, then the resources will be like:

![image](https://user-images.githubusercontent.com/3197038/194999333-c45dca5b-cc8f-4c3a-9621-eb027646c031.png)

In this case, `_get_resources` will return {"name": "gpu", "addresses":["0","1"]}, thus `_get_assigned_gpu_or_default` will always return 0, which then be pined to different horovod processes. As a result, only one GPU (always index 0) of each node can be used by horovod spark estimators.

If one GPU is assigned to one executor, then the resources will be like:

![image](https://user-images.githubusercontent.com/3197038/195000757-e00ad218-f897-4212-bb67-7a3971749b44.png)

In this case, still only one GPU (always index 0) of each node can be used by horovod spark estimators.

Only when each node has multi-executors and each executor has been assigned different GPUs, will all the GPUs be available to horovod spark estimators. Like below:

![image](https://user-images.githubusercontent.com/3197038/195001272-8254d583-fbbf-4838-965b-10a77c48f310.png)

However, in this case, GPUs must be configured in `EXCLUSIVE_PROCESS` mode. Unfortunately, for spark clusters with GPUs, spark-rapids is usually needed. Which means, if we configure GPUs in `EXCLUSIVE_PROCESS` mode, we can only use spark-rapids or horovod, but not both.

To solve the issue, and let us use all GPUs in all nodes, and leverage both spark-rapids and horovod seems to be meaningful.

In fact, it's quite easy to handle. Just add an env `USE_DEFAULT_GPU_INDEX` for manually pin to default GPU index (local rank) will do the trick.

```python
import os
def get_available_devices():
    if 'gpu' not in _info.resources or os.getenv('USE_DEFAULT_GPU_INDEX') == '1':
        return []
    return _info.resources['gpu'].addresses
```

With this small change, users can maually pin to default GPU index (local rank) just like they do for horovod runners.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
