### PR TITLE
Fix Upload to PyPi workflow

### DIFF
--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Twine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine
+          python -m pip install setuptools wheel twine packaging
 
       - name: Build and upload to PyPI
         run: |


### PR DESCRIPTION
Adding `import packaging` to `setup.py` broke the `Upload to PyPi` workflow, which only runs on release. Fixing.