### PR TITLE
Fixed packaging import to occur after install_requires

### DIFF
--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Twine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine packaging
+          python -m pip install setuptools wheel twine
 
       - name: Build and upload to PyPI
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed packaging import during install to occur after install_requires. ([#3741](https://github.com/horovod/horovod/pull/3741))
+
 
 ## [v0.26.0] - 2022-10-13
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ import textwrap
 
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
-from packaging import version
 
 from horovod import __version__
 
@@ -65,6 +64,8 @@ def is_build_action():
         return True
 
 def get_cmake_bin():
+    from packaging import version
+
     if 'HOROVOD_CMAKE' in os.environ:
         return os.environ['HOROVOD_CMAKE']
 


### PR DESCRIPTION
Previous import was occurring in `setup.py` before `install_requires` had a chance to run, resulting in import failures if `packaging` wasn't already installed:

```
Collecting horovod[pytorch]>=0.24.0
  Downloading horovod-0.26.0.tar.gz (3.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.5/3.5 MB 78.7 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-lthh9g2p/horovod_ef63b9a15f0346eeadef7d18c3901759/setup.py", line 30, in <module>
          from packaging import version
      ModuleNotFoundError: No module named 'packaging'
      [end of output]
```

With this change, the import occurs in a function that is called after the requirements are installed.