### PR TITLE
Test installation via setup.py

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -172,6 +172,23 @@ def main():
                '        name: Event File\n' \
                '        path: ${{ github.event_path }}\n' \
                '\n' + \
+               '  setup-py:\n' \
+               '    name: "setup.py"\n' \
+               '    runs-on: ubuntu-latest\n' \
+               '    steps:\n' \
+               '      - name: Checkout\n' \
+               '        uses: actions/checkout@v2\n' \
+               '      - name: Setup Python\n' \
+               '        uses: actions/setup-python@v2\n' \
+               '        with:\n' \
+               '          python-version: 3.8\n' \
+               '      - name: Test setup.py\n' \
+               '        run: |\n' \
+               '          python -m pip install --upgrade pip\n' \
+               '          python -m pip install setuptools wheel\n' \
+               '          python setup.py sdist\n' \
+               '          pip install dist/horovod-*.tar.gz\n' \
+               '\n' + \
                '\n'.join(jobs)
 
     def init_workflow_job() -> str:

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -183,11 +183,17 @@ def main():
                '        with:\n' \
                '          python-version: 3.8\n' \
                '      - name: Test setup.py\n' \
+               '        env:\n' \
+               '          HOROVOD_WITHOUT_TENSORFLOW: 1\n' \
+               '          HOROVOD_WITHOUT_PYTORCH: 1\n' \
+               '          HOROVOD_WITHOUT_MXNET: 1\n' \
+               '          HOROVOD_WITHOUT_GLOO: 1\n' \
+               '          HOROVOD_WITHOUT_MPI: 1\n' \
                '        run: |\n' \
                '          python -m pip install --upgrade pip\n' \
                '          python -m pip install setuptools wheel\n' \
                '          python setup.py sdist\n' \
-               '          pip install dist/horovod-*.tar.gz\n' \
+               '          pip -v install dist/horovod-*.tar.gz\n' \
                '\n' + \
                '\n'.join(jobs)
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,11 +61,17 @@ jobs:
         with:
           python-version: 3.8
       - name: Test setup.py
+        env:
+          HOROVOD_WITHOUT_TENSORFLOW: 1
+          HOROVOD_WITHOUT_PYTORCH: 1
+          HOROVOD_WITHOUT_MXNET: 1
+          HOROVOD_WITHOUT_GLOO: 1
+          HOROVOD_WITHOUT_MPI: 1
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
           python setup.py sdist
-          pip install dist/horovod-*.tar.gz
+          pip -v install dist/horovod-*.tar.gz
 
   init-workflow:
     name: "Init Workflow"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,23 @@ jobs:
         name: Event File
         path: ${{ github.event_path }}
 
+  setup-py:
+    name: "setup.py"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Test setup.py
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel
+          python setup.py sdist
+          pip install dist/horovod-*.tar.gz
+
   init-workflow:
     name: "Init Workflow"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tests that `setup.py` can build the source package and install Horovod from it. This should catch #3741 and #3739 in the future.

Together with #3741, this builds (without compiling anything) and installs horovod:
https://github.com/horovod/horovod/actions/runs/3245078387/jobs/5322133719#step:4:1068