### PR TITLE
Upgrade Tensorflow and Spark test dependencies

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1"
+baseline="test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -22,19 +22,19 @@ code_files=$(python "$dir/get_changed_code_files.py" || echo failure)
 tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-}" ]] || [[ -n "$code_files" ]] ); then
   # we vary the baseline along the Python dimension and PySpark together
   # run_gloo_integration expects these to have Gloo mpi kind to run 'Elastic Spark * Tests'
-  printf "test-cpu-gloo-py3_7-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8 "
-  printf "test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2 "
+  printf "test-cpu-gloo-py3_7-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8 "
+  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2 "
   # our baseline
   printf "$baseline "
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-mpich-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-oneccl-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-openmpi-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-mpich-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-oneccl-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-openmpi-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -43,10 +43,10 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
   printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1 "
-  printf "test-cpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1 "
-  printf "test-cpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1 "
+  printf "test-cpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1 "
+  printf "test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
   printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
@@ -60,15 +60,15 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # so we test with mxnet 1.5.1
   printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  printf "test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1 "
-  printf "test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1 "
+  printf "test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
   printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_7-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8
+          - image: test-cpu-gloo-py3_7-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -229,7 +229,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -254,7 +254,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -279,7 +279,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -302,7 +302,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -325,7 +325,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-mpich-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-mpich-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -341,7 +341,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -376,7 +376,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -400,16 +400,16 @@ jobs:
           - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+          - image: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+          - image: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
             build_timeout: 40
 
     steps:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
         GPP_VERSION: 7
         MPI_KIND: None
         PYTHON_VERSION: 3.8
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.10.0
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
         PYTORCH_PACKAGE: torch==1.12.1+cpu
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
@@ -22,29 +22,29 @@ services:
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-mpich-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-oneccl-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
@@ -68,20 +68,20 @@ services:
         PYTORCH_PACKAGE: torch==1.8.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.9.1+cpu
         MXNET_PACKAGE: mxnet==1.5.1.post0
-  test-cpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p2-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.8.3
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.8.4
         KERAS_PACKAGE: keras==2.8.0
         PYTORCH_PACKAGE: torch==1.10.2+cpu
         TORCHVISION_PACKAGE: torchvision==0.11.3+cpu
         MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.9.2
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.9.3
         KERAS_PACKAGE: keras==2.9.0
         PYTORCH_PACKAGE: torch==1.11.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
@@ -115,7 +115,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-cpu-gloo-py3_7-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8:
+  test-cpu-gloo-py3_7-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark2_4_8:
     extends: test-cpu-base
     build:
       args:
@@ -125,7 +125,7 @@ services:
         PYTHON_VERSION: 3.7
         PYSPARK_PACKAGE: pyspark==2.4.8
         SPARK_PACKAGE: spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
-  test-cpu-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_2_2:
     extends: test-cpu-base
     build:
       args:
@@ -180,7 +180,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.9.1+cu101
         MXNET_PACKAGE: mxnet-cu100==1.5.1.post0
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1:
+  test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
@@ -194,20 +194,20 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.11.3+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1:
+  test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.9.2
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.9.3
         KERAS_PACKAGE: keras==2.9.0
         PYTORCH_PACKAGE: torch==1.11.0+cu115
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.12.0+cu115
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
@@ -215,7 +215,7 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
         PYTORCH_PACKAGE: torch==1.12.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
@@ -254,7 +254,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
+  test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
@@ -262,7 +262,7 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
         PYTORCH_PACKAGE: torch==1.12.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -15,12 +15,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      build: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      build: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      build: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      build: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -151,14 +151,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -169,14 +169,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -187,14 +187,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -656,14 +656,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -674,14 +674,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -692,14 +692,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -710,14 +710,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -728,14 +728,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -746,14 +746,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -764,14 +764,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -782,14 +782,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -800,14 +800,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -818,14 +818,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_8_3-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_8_4-keras2_8_0-torch1_10_2-mxnet1_7_0_p1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,14 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -908,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -998,14 +998,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_2-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_8_0_p0-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1502,14 +1502,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1520,14 +1520,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1538,14 +1538,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1556,14 +1556,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1574,14 +1574,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_10_0-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3


### PR DESCRIPTION
Adds the following changes
- Upgrade Tensorflow to 2.10.1, 2.9.3, and 2.8.4
- Add Torch 1.13.0, remove 1.10.2
- Upgrade Spark to 3.2.3 (pending imminent release)