### PR TITLE
Skip mxnet v1 tests for v2 pre-release

### DIFF
--- a/test/parallel/base_test_mxnet.py
+++ b/test/parallel/base_test_mxnet.py
@@ -1687,7 +1687,7 @@ class MXTests:
         g = mx.random.uniform(shape=shape, ctx=ctx, dtype=np.float32)
         
         # Update that is only averaged over even_set
-        if version.parse(mx.__version__) >= version.parse('2.0.0'):
+        if version.parse(mx.__version__).major >= 2:
             opt.update([0], [w], [g], [opt.create_state(0, w)])
         else:
             opt.update(0, w, g, opt.create_state(0, w))

--- a/test/parallel/test_mxnet1.py
+++ b/test/parallel/test_mxnet1.py
@@ -35,7 +35,7 @@ else:
 
 
 @pytest.mark.skipif(not HAS_MXNET, reason='MXNet unavailable')
-@pytest.mark.skipif(version.parse(mx.__version__) >= version.parse('2.0.0'), reason='MXNet v1.x tests')
+@pytest.mark.skipif(version.parse(mx.__version__).major != 1, reason='MXNet v1.x tests')
 class MX1Tests(MXTests, unittest.TestCase):
     """
     Tests for ops in horovod.mxnet. This tests MXNet 1.x specifically.

--- a/test/parallel/test_mxnet2.py
+++ b/test/parallel/test_mxnet2.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, 'utils'))
 from base_test_mxnet import *
 
 
-@pytest.mark.skipif(version.parse(mx.__version__) < version.parse('2.0.0'), reason='MXNet v2 tests')
+@pytest.mark.skipif(version.parse(mx.__version__).major != 2, reason='MXNet v2 tests')
 class MX2Tests(MXTests, unittest.TestCase):
     """
     Tests for ops in horovod.mxnet. This tests MXNet 2.x specifically.


### PR DESCRIPTION
Interestingly, `2.0.0beta1` is smaller than `2.0.0`, so we run v1 tests with v2 beta1.