### PR TITLE
Skip EarlyStopping and ModelCheckpoint Callbacks for Torch 1.13+

### DIFF
--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -769,6 +769,9 @@ class SparkLightningTests(unittest.TestCase):
             self.skipTest('Spark PyTorch Lightning tests conflict with Tensorflow 2.5.x: '
                           'https://github.com/horovod/horovod/pull/3263')
 
+        if version.parse(torch.__version__) >= version.parse('1.13'):
+            self.skipTest('Torch 1.13+ fails EarlyStopping CB usage with Horovd.')
+
         from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
         with spark_session('test_fit_model') as spark:

--- a/test/integration/test_spark_lightning.py
+++ b/test/integration/test_spark_lightning.py
@@ -770,7 +770,7 @@ class SparkLightningTests(unittest.TestCase):
                           'https://github.com/horovod/horovod/pull/3263')
 
         if version.parse(torch.__version__) >= version.parse('1.13'):
-            self.skipTest('Torch 1.13+ fails EarlyStopping CB usage with Horovd.')
+            self.skipTest('Torch 1.13+ fails EarlyStopping CB usage with Horovod.')
 
         from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 


### PR DESCRIPTION
Related to the failures we have observed for Torch 1.13+.

https://github.com/horovod/horovod/actions/runs/3492107499/jobs/5845520947#step:219:162

Broken line in PyTorch lightning side:
https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/strategies/horovod.py#L179

Reproducible error with `ReduceOp` in Torch 1.13:

```
>>> from torch.distributed import ReduceOp
>>> op = None
>>> op in (ReduceOp.SUM, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __eq__(): incompatible function arguments. The following argument types are supported:
    1. (self: torch._C._distributed_c10d.ReduceOp, arg0: c10d::ReduceOp::RedOpType) -> bool
    2. (self: torch._C._distributed_c10d.ReduceOp, arg0: torch._C._distributed_c10d.ReduceOp) -> bool

Invoked with: <torch.distributed.distributed_c10d.ReduceOp object at 0x7fba78c9e0b0>, None
```


## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
