### PR TITLE
GitHub CLI returns at most 30 elements, use --paginate to get all

### DIFF
--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -38,7 +38,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        conclusion=$(gh api "${{ github.event.workflow_run.jobs_url }}" -q '.jobs[] | select(.name | startswith("Build and Test (")) | .conclusion' | sort | uniq | paste -sd "," -)
+        conclusion=$(gh api --paginate "${{ github.event.workflow_run.jobs_url }}" -q '.jobs[] | select(.name | startswith("Build and Test (")) | .conclusion' | sort | uniq | paste -sd "," -)
         echo "build-and-test conclusion: ${conclusion}"
         echo "build-and-test=${conclusion}" >> $GITHUB_OUTPUT
       shell: bash
@@ -50,7 +50,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-        gh api "$artifacts_url" -q '.artifacts[] | select(.name == "PR Meta") .archive_download_url' | while read url
+        gh api --paginate "$artifacts_url" -q '.artifacts[] | select(.name == "PR Meta") .archive_download_url' | while read url
         do
           gh api "$url" > "pr.zip"
           unzip -o "pr.zip"


### PR DESCRIPTION
Without this, not all artifacts might be downloaded or conclusion could not be detected.