### PR TITLE
Handle tf.IndexedSlices types when scaling local gradients in TF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
+- Handle tf.IndexedSlices types when scaling local gradients in TF. ([#3786](https://github.com/horovod/horovod/pull/3786))
 
 
 ## [v0.26.1] - 2022-10-14

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -173,6 +173,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
+                                    v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
                     else:
@@ -188,6 +189,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
+                                    v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]
                 return __filtered_reduce_grads(grads, vars)

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -170,7 +170,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 if v_ref in self._local_vars and v2g[v_ref] is not None:
                                     grad = v2g[v_ref]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
 
@@ -185,7 +185,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 if v in self._local_vars and v2g[v] is not None:
                                     grad = v2g[v]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -678,11 +678,12 @@ if _LegacyOptimizer is not None:
                             # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
                             for v_ref in v2g:
                                 if v_ref in self._local_vars and v2g[v_ref]:
-                                    grad = v2g[v.ref()]
+                                    grad = v2g[v_ref]
                                     if isinstance(grad, tf.IndexedSlices):
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
+                                    v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
                     else:
@@ -698,6 +699,7 @@ if _LegacyOptimizer is not None:
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
+                                    v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]
 
@@ -1026,6 +1028,7 @@ if hasattr(tf, 'GradientTape'):
                                 grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
                                 grad /= horovod_size
+                            s2g[s_ref] = grad
 
                 return [s2g[s.ref()] for s in sources]
             else:
@@ -1041,6 +1044,7 @@ if hasattr(tf, 'GradientTape'):
                                 grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
                                 grad /= horovod_size
+                            s2g[s] = grad
 
                 return [s2g[s] for s in sources]
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -678,7 +678,11 @@ if _LegacyOptimizer is not None:
                             # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
                             for v_ref in v2g:
                                 if v_ref in self._local_vars and v2g[v_ref]:
-                                    v2g[v.ref()] /= horovod_size
+                                    grad = v2g[v.ref()]
+                                    if isinstance(grad, tf.IndexedSlices):
+                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                    else:
+                                        grad /= horovod_size
 
                         return [v2g[rv.ref()] for rv in vars]
                     else:
@@ -689,7 +693,11 @@ if _LegacyOptimizer is not None:
                             # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
                             for v in v2g:
                                 if v in self._local_vars and v2g[v]:
-                                    v2g[v] /= horovod_size
+                                    grad = v2g[v]
+                                    if isinstance(grad, tf.IndexedSlices):
+                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                    else:
+                                        grad /= horovod_size
 
                         return [v2g[rv] for rv in vars]
 
@@ -1013,7 +1021,11 @@ if hasattr(tf, 'GradientTape'):
                     # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
                     for s_ref in s2g:
                         if s_ref in self._local_sources and s2g[s_ref] is not None:
-                            s2g[s_ref] /= horovod_size
+                            grad = s2g[s_ref]
+                            if isinstance(grad, tf.IndexedSlices):
+                                grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                            else:
+                                grad /= horovod_size
 
                 return [s2g[s.ref()] for s in sources]
             else:
@@ -1024,7 +1036,11 @@ if hasattr(tf, 'GradientTape'):
                     # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
                     for s in s2g:
                         if s in self._local_sources and s2g[s] is not None:
-                            s2g[s] /= horovod_size
+                            grad = s2g[s]
+                            if isinstance(grad, tf.IndexedSlices):
+                                grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                            else:
+                                grad /= horovod_size
 
                 return [s2g[s] for s in sources]
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -680,7 +680,7 @@ if _LegacyOptimizer is not None:
                                 if v_ref in self._local_vars and v2g[v_ref]:
                                     grad = v2g[v.ref()]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
 
@@ -695,7 +695,7 @@ if _LegacyOptimizer is not None:
                                 if v in self._local_vars and v2g[v]:
                                     grad = v2g[v]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
                                         grad /= horovod_size
 
@@ -1023,7 +1023,7 @@ if hasattr(tf, 'GradientTape'):
                         if s_ref in self._local_sources and s2g[s_ref] is not None:
                             grad = s2g[s_ref]
                             if isinstance(grad, tf.IndexedSlices):
-                                grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
                                 grad /= horovod_size
 
@@ -1038,7 +1038,7 @@ if hasattr(tf, 'GradientTape'):
                         if s in self._local_sources and s2g[s] is not None:
                             grad = s2g[s]
                             if isinstance(grad, tf.IndexedSlices):
-                                grad = tf.IndexedSlices(grad.values / hvd.size(), grad.indices, grad.dense_shape)
+                                grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
                                 grad /= horovod_size
 

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -4200,7 +4200,7 @@ class TensorFlowTests(BaseTensorFlowTests):
 
         mp_model = DummyMPModel2Devices()
         optimizer = tf.keras.optimizers.SGD(learning_rate=1)
-        bce = tf.keras.losses.BinaryCrossentropy(reduction=tf.keras.losses.Reduction.NONE, from_logits=True)
+        bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
         labels = tf.constant([1.])
 
         if rank == 0:

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -4201,7 +4201,7 @@ class TensorFlowTests(BaseTensorFlowTests):
         mp_model = DummyMPModel2Devices()
         optimizer = tf.keras.optimizers.SGD(learning_rate=1)
         bce = tf.keras.losses.BinaryCrossentropy(from_logits=True)
-        labels = tf.constant([1.])
+        labels = tf.constant(1., shape=[1, 1])
 
         if rank == 0:
             dp_inputs = tf.constant([rank + 1, rank], dtype=tf.int64)

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -4169,7 +4169,65 @@ class TensorFlowTests(BaseTensorFlowTests):
                         # non-local gradients shouldn't be equal given that the initial weights are set to ranks
                         self.assertNotAllClose(grad, var_grad[var])
 
+    def test_model_parallel_model(self):
+        class DummyMPModel2Devices(tf.keras.Model):
+            def __init__(self):
+                # For demonstation purpose, only supports 2 way parallel
+                super().__init__()
+                if hvd.rank() == 0:
+                    self.embedding = tf.keras.layers.Embedding(7, 3, embeddings_initializer=tf.keras.initializers.Constant(1.))
+                else:
+                    self.embedding = tf.keras.layers.Embedding(9, 3, embeddings_initializer=tf.keras.initializers.Constant(2.))
+                self.concat = tf.keras.layers.Concatenate()
+                self.dense = tf.keras.layers.Dense(
+                    1, use_bias=False, kernel_initializer=tf.keras.initializers.Constant(1.))
 
+
+            def call(self, inputs):
+                x = self.embedding(inputs)
+                y = hvd.alltoall(x)
+                out = self.dense(tf.reshape(y, [1, 6]))
+                return out
+
+        tf.config.set_soft_device_placement(True)
+
+        hvd.init()
+        if hvd.size() != 2:
+            self.skipTest("Test requires 2 workers.")
+
+        rank = hvd.rank()
+        local_rank = hvd.local_rank()
+
+        mp_model = DummyMPModel2Devices()
+        optimizer = tf.keras.optimizers.SGD(learning_rate=1)
+        bce = tf.keras.losses.BinaryCrossentropy(reduction=tf.keras.losses.Reduction.NONE, from_logits=True)
+        labels = tf.constant([1.])
+
+        if rank == 0:
+            dp_inputs = tf.constant([rank + 1, rank], dtype=tf.int64)
+        else:
+            dp_inputs = tf.constant([rank + 2, rank + 3], dtype=tf.int64)
+
+        @tf.function
+        def mp_train_step(inputs):
+            with tf.GradientTape() as tape:
+                predictions = mp_model(inputs)
+                loss = tf.math.reduce_mean(bce(labels, predictions))
+            tape = hvd.DistributedGradientTape(tape)
+            tape.register_local_source(mp_model.embedding.weights[0])
+            gradients = tape.gradient(loss, mp_model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, mp_model.trainable_variables))
+            return loss
+
+        if tf.test.is_gpu_available(cuda_only=True):
+            with tf.device("/gpu:%d" % local_rank):
+                # "Transpose" input from data parallel to model parallel
+                mp_inputs = hvd.alltoall(dp_inputs)
+                mp_loss = mp_train_step(mp_inputs)
+        else:
+            # "Transpose" input from data parallel to model parallel
+            mp_inputs = hvd.alltoall(dp_inputs)
+            mp_loss = mp_train_step(mp_inputs)
 
 
 from tensorflow.python.framework.test_util import run_all_in_graph_and_eager_modes


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This PR fixes the local gradient scaling introduced in #3719 when the gradients are sparse (e.g. of type `tf.IndexedSlices`). 
