### PR TITLE
Fix parsing Keras version identifiers like `2.2.4-tf`

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -254,7 +254,7 @@ def reducescatter(backend, value, name, op):
 
 
 def load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects):
-    if version.parse(keras.__version__) < version.parse("2.11"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         keras_subclasses = keras.optimizers.Optimizer.__subclasses__()
     else:
         keras_subclasses = keras.optimizers.legacy.Optimizer.__subclasses__()

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -282,7 +282,7 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    if version.parse(keras.__version__) < version.parse("2.11"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         optimizer_modules = {keras.optimizers.Optimizer.__module__}
     else:
         optimizer_modules = {keras.optimizers.legacy.Optimizer.__module__}

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -230,7 +230,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
             if isinstance(optimizer, str):
                 pass
             else:
-                if version.parse(tf.keras.__version__) < version.parse("2.11"):
+                if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
                     if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
                         raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
                 else:

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -25,7 +25,7 @@ def serialize_bare_keras_optimizer(x):
     import keras
     from horovod.spark.keras.bare import save_bare_keras_optimizer
 
-    if version.parse(keras.__version__) < version.parse("2.11"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         optimizer_class = keras.optimizers.Optimizer
     else:
         optimizer_class = keras.optimizers.legacy.Optimizer
@@ -45,7 +45,7 @@ def serialize_tf_keras_optimizer(x):
     import tensorflow as tf
     from horovod.spark.keras.tensorflow import save_tf_keras_optimizer
 
-    if version.parse(tf.keras.__version__) < version.parse("2.11"):
+    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         optimizer_class = tf.keras.optimizers.Optimizer
     else:
         optimizer_class = tf.keras.optimizers.legacy.Optimizer

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -49,7 +49,7 @@ from horovod.tensorflow.keras import callbacks, elastic
 try:
     # In later versions of TensorFlow, optimizers are spread across multiple modules. This set is used to distinguish
     # stock optimizers that come with tf.keras from custom optimizers that may need to be wrapped specially.
-    if version.parse(keras.__version__) < version.parse("2.11"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         optimizer_type = tf.keras.optimizers.Optimizer
     else:
         optimizer_type = keras.optimizers.legacy.Optimizer

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -80,7 +80,7 @@ def get_mock_fit_fn():
 
 
 def get_sgd_optimizer():
-    if version.parse(tf.keras.__version__) < version.parse("2.11"):
+    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
         optimizer = tf.keras.optimizers.SGD(lr=0.1)
     else:
         optimizer = tf.keras.optimizers.legacy.SGD(lr=0.1)
@@ -212,7 +212,7 @@ class SparkKerasTests(tf.test.TestCase):
 
     def test_fit_model_multiclass(self):
         model = create_mnist_model()
-        if version.parse(tf.keras.__version__) < version.parse("2.11"):
+        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             optimizer = tf.keras.optimizers.Adadelta(1.0)
         else:
             optimizer = tf.keras.optimizers.legacy.Adadelta(1.0)

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -29,7 +29,7 @@ from tensorflow import keras
 from horovod.common.util import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
-    if version.parse(keras.__version__) < version.parse("2.9.0"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2 import optimizer_v2
     else:
         from keras.optimizers.optimizer_v2 import optimizer_v2
@@ -64,7 +64,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_train_model_lr_schedule(self):
         initial_lr = 0.1 * hvd.size()
-        if version.parse(tf.keras.__version__) < version.parse("2.11"):
+        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             opt = tf.keras.optimizers.Adam()
         else:
             opt = tf.keras.optimizers.legacy.Adam()
@@ -157,7 +157,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_sparse_as_dense_with_grad_aggregation(self):
         backward_passes_per_step = 2
-        if version.parse(keras.__version__) < version.parse("2.11"):
+        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             opt = keras.optimizers.RMSprop(lr=0.0001)
         else:
             opt = keras.optimizers.legacy.RMSprop(lr=0.0001)
@@ -186,7 +186,7 @@ class Tf2KerasTests(tf.test.TestCase):
     def test_grad_aggregation_with_inf_grad(self):
         backward_passes_per_step = 2
         step_count = tf.Variable(0, trainable=False, dtype=tf.int32)
-        if version.parse(tf.keras.__version__) < version.parse("2.11"):
+        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             opt = tf.keras.optimizers.SGD()
         else:
             opt = tf.keras.optimizers.legacy.SGD()
@@ -214,7 +214,7 @@ class Tf2KerasTests(tf.test.TestCase):
         assert tf.math.is_finite(grads_and_vars[0][0])
 
     def test_from_config(self):
-        if version.parse(keras.__version__) < version.parse("2.11"):
+        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             opt = keras.optimizers.Adam()
         else:
             opt = keras.optimizers.legacy.Adam()
@@ -536,7 +536,7 @@ class Tf2KerasTests(tf.test.TestCase):
             model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))
             model.add(tf.keras.layers.RepeatVector(3))
             model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(3, kernel_initializer=initializer, bias_initializer=initializer)))
-            if version.parse(tf.keras.__version__) < version.parse("2.11"):
+            if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
                 opt = tf.keras.optimizers.Adam()
             else:
                 opt = tf.keras.optimizers.legacy.Adam()

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -60,7 +60,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         if size == 1:
             self.skipTest("Only one worker available")
 
-        if version.parse(keras.__version__) < version.parse("2.11"):
+        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
             optimizer_class = keras.optimizers.Optimizer
         else:
             optimizer_class = keras.optimizers.legacy.Optimizer

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -30,7 +30,7 @@ from horovod.common.util  import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     from keras import backend as K
-    if version.parse(keras.__version__) < version.parse("2.9.0"):
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2 import optimizer_v2
     else:
         from keras.optimizers.optimizer_v2 import optimizer_v2


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes #3793.

This is a band-aid solution; alternatively we could switch to a more lenient version parser.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
