### PR TITLE
Timeline: Add MEMCPY_IN_FUSION_BUFFER event for Reducescatter

### DIFF
--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -1261,6 +1261,12 @@ Status NCCLReducescatter::Execute(std::vector<TensorTableEntry>& entries,
                    process_set_rank * recvcounts[0] * element_size;
     // ncclReduceScatter() will be performed in place on the fusion buffer, cf.:
     // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/inplace.html
+
+    if (global_state_->timeline.Initialized()) {
+      gpu_context_->RecordEvent(gpu_op_context_.event_queue,
+                                MEMCPY_IN_FUSION_BUFFER,
+                                *gpu_op_context_.stream);
+    }
   } else {
     fused_input_data = first_entry.tensor->data();
     buffer_data = (void*)first_entry.output->data();


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

The MEMCPY_IN_FUSION_BUFFER event accidentally wasn't recorded for NCCLReducescatter, which made Horovod timelines a bit confusing to read.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
