### PR TITLE
Several fixes for allreduce and grouped allreduce handling of tf.IndexedSlices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
 - Handle tf.IndexedSlices types when scaling local gradients in TF. ([#3786](https://github.com/horovod/horovod/pull/3786))
+- Use correct indices in grouped allreduce of tf.IndexedSlices. ([#3813](https://github.com/horovod/horovod/pull/3813))
 
 
 ## [v0.26.1] - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
 - Handle tf.IndexedSlices types when scaling local gradients in TF. ([#3786](https://github.com/horovod/horovod/pull/3786))
-- Use correct indices in grouped allreduce of tf.IndexedSlices. ([#3813](https://github.com/horovod/horovod/pull/3813))
+- Several fixes for allreduce and grouped allreduce handling of tf.IndexedSlices. ([#3813](https://github.com/horovod/horovod/pull/3813))
 
 
 ## [v0.26.1] - 2022-10-14

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -105,7 +105,7 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
             raise NotImplementedError('The Adasum reduction does not currently support sparse tensors. As a '
                                       'workaround please pass sparse_as_dense=True to DistributedOptimizer')
         if op != Sum and op != Average:
-            raise NotImplementedError('Only Sum and Average ops are not supported with tf.IndexedSlices')
+            raise NotImplementedError('Only Sum and Average ops are supported with tf.IndexedSlices')
 
 
         with tf.device(device_sparse):

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -383,6 +383,237 @@ class TensorFlowTests(BaseTensorFlowTests):
             self.assertTrue(diff <= threshold,
                             "hvd.allreduce produces incorrect results")
 
+    def test_horovod_allreduce_indexed_slices_cpu(self):
+        """Test on CPU that the allreduce correctly sums tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                # prevent underflows/overflows in uint8, int8
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = self.random_uniform([17] * dim, minval, maxval)
+                slice_values = tf.cast(slice_values, dtype=dtype)
+                tensor = tf.IndexedSlices(tf.stack([slice_values] * 2),
+                                          tf.convert_to_tensor([hvd.rank(), hvd.rank()+1]))
+                result = hvd.allreduce(tensor, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            keys = result.indices
+            result = tf.math.unsorted_segment_sum(result.values, keys, tf.size(tf.unique(keys)[0]))
+
+            slices = [slice_values] * (hvd.size() + 1)
+            for i in range(1, hvd.size()):
+                slices[i] *= 2
+            reference = tf.stack(slices)
+
+            difference = result - reference
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
+
+    def test_horovod_allreduce_indexed_slices_average_cpu(self):
+        """Test on CPU that the allreduce correctly averages tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                # prevent underflows/overflows in uint8, int8
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = self.random_uniform([17] * dim, minval, maxval)
+                slice_values = tf.cast(slice_values, dtype=dtype)
+                tensor = tf.IndexedSlices(tf.stack([slice_values] * 2),
+                                          tf.convert_to_tensor([hvd.rank(), hvd.rank()+1]))
+                result = hvd.allreduce(tensor, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            keys = result.indices
+            result = tf.math.unsorted_segment_sum(result.values, keys, tf.size(tf.unique(keys)[0]))
+
+            slices = [slice_values] * (hvd.size() + 1)
+            for i in range(0, hvd.size()+1):
+                if i == 0 or i == hvd.size():
+                    slices[i] /= hvd.size()
+                else:
+                    slices[i] *= 2
+                    slices[i] /= hvd.size()
+            reference = tf.stack(slices)
+
+            difference = result - reference
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
+
+
+    def test_horovod_allreduce_indexed_slices_gpu(self):
+        """Test on GPU that the allreduce correctly sums tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest("No GPUs available")
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        local_rank = hvd.local_rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % local_rank):
+                # prevent underflows/overflows in uint8, int8
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = self.random_uniform([17] * dim, minval, maxval)
+                slice_values = tf.cast(slice_values, dtype=dtype)
+                tensor = tf.IndexedSlices(tf.stack([slice_values] * 2),
+                                          tf.convert_to_tensor([hvd.rank(), hvd.rank()+1]))
+                result = hvd.allreduce(tensor, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            keys = result.indices
+            result = tf.math.unsorted_segment_sum(result.values, keys, tf.size(tf.unique(keys)[0]))
+
+            slices = [slice_values] * (hvd.size() + 1)
+            for i in range(1, hvd.size()):
+                slices[i] *= 2
+            reference = tf.stack(slices)
+
+            difference = result - reference
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
+
+    def test_horovod_allreduce_indexed_slices_average_gpu(self):
+        """Test on GPU that the allreduce correctly averages tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest("No GPUs available")
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        local_rank = hvd.local_rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % local_rank):
+                # prevent underflows/overflows in uint8, int8
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = self.random_uniform([17] * dim, minval, maxval)
+                slice_values = tf.cast(slice_values, dtype=dtype)
+                tensor = tf.IndexedSlices(tf.stack([slice_values] * 2),
+                                          tf.convert_to_tensor([hvd.rank(), hvd.rank()+1]))
+                result = hvd.allreduce(tensor, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            keys = result.indices
+            result = tf.math.unsorted_segment_sum(result.values, keys, tf.size(tf.unique(keys)[0]))
+
+            slices = [slice_values] * (hvd.size() + 1)
+            for i in range(0, hvd.size()+1):
+                if i == 0 or i == hvd.size():
+                    slices[i] /= hvd.size()
+                else:
+                    slices[i] *= 2
+                    slices[i] /= hvd.size()
+            reference = tf.stack(slices)
+
+            difference = result - reference
+            difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
+            max_difference = tf.reduce_max(tf.abs(difference))
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.allreduce produces incorrect results")
+
+    def test_horovod_allreduce_indexed_slices_op_error(self):
+        """Tests that the allreduce errors out on unsupported op for tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        tensor = tf.IndexedSlices(tf.ones(1,3),
+                                  tf.convert_to_tensor([hvd.rank()]))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, op=hvd.Min))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, op=hvd.Max))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, op=hvd.Product))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, op=hvd.Adasum))
+
+    def test_horovod_allreduce_indexed_slices_prescale_postscale_error(self):
+        """Test on CPU that the allreduce correctly errors with tf.IndexedSlices with pre/postscaling."""
+        hvd.init()
+        factor = 0.5
+        tensor = tf.IndexedSlices(tf.ones(1,3),
+                                  tf.convert_to_tensor([hvd.rank()]))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, average=False,
+                                        prescale_factor=factor))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.allreduce(tensor, average=False,
+                                        postscale_factor=factor))
+
     def test_horovod_allreduce_gpu(self):
         """Test that the allreduce works on GPUs."""
         # Only do this test if there are GPUs available.
@@ -1034,6 +1265,377 @@ class TensorFlowTests(BaseTensorFlowTests):
             diff = self.evaluate(max_difference)
             self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
 
+    def test_horovod_grouped_allreduce_indexed_slices_cpu(self):
+        """Test on CPU that the grouped allreduce correctly sums tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+                results = hvd.grouped_allreduce(tensors, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            processed_results = []
+            for x in results:
+                keys = x.indices
+                processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+
+            references = []
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(1, hvd.size()):
+                    slices[i] *= 2
+                references.append(tf.stack(slices))
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_mixed_indexed_slices_cpu(self):
+        """Test on CPU that the grouped allreduce correctly sums a mix of tensors and tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                # Create indexed slices
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+
+                # Append additional set of regular tensors
+                for x in slice_values:
+                    tensors.append(x)
+                results = hvd.grouped_allreduce(tensors, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices) or append standard tensor results
+            processed_results = []
+            for x in results:
+                if isinstance(x, tf.IndexedSlices):
+                    keys = x.indices
+                    processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+                else:
+                    processed_results.append(x)
+
+            references = []
+            # First append references for indexed slices
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(1, hvd.size()):
+                    slices[i] *= 2
+                references.append(tf.stack(slices))
+
+            # Next, append references for standard tensors
+            for x in slice_values:
+                references.append(x * size)
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_average_cpu(self):
+        """Test on CPU that the grouped allreduce correctly averages 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [tf.cast(self.random_uniform(
+                    [17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Average)
+            differences = [t1 - t2 for t1, t2 in zip(result, tensors)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_min_cpu(self):
+        """Test on CPU that the grouped allreduce correctly finds minimum of 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Min)
+            reference = [tf.math.reduce_min(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            threshold = 0
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_max_cpu(self):
+        """Test on CPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Max)
+            reference = [tf.math.reduce_max(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            threshold = 0
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_product_cpu(self):
+        """Test on CPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Product)
+            reference = [tf.math.reduce_prod(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_indexed_slices_average_cpu(self):
+        """Test on CPU that the grouped allreduce correctly averages tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+                results = hvd.grouped_allreduce(tensors, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            processed_results = []
+            for x in results:
+                keys = x.indices
+                processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+
+            references = []
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(0, hvd.size()+1):
+                    if i == 0 or i == hvd.size():
+                        slices[i] /= hvd.size()
+                    else:
+                        slices[i] *= 2
+                        slices[i] /= hvd.size()
+                references.append(tf.stack(slices))
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_mixed_indexed_slices_average_cpu(self):
+        """Test on CPU that the grouped allreduce correctly averages a mix of tensors and tf.IndexedSlices."""
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/cpu:0"):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                # Create indexed slices
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+
+                # Append additional set of regular tensors
+                for x in slice_values:
+                    tensors.append(x)
+                results = hvd.grouped_allreduce(tensors, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices) or append standard tensor results
+            processed_results = []
+            for x in results:
+                if isinstance(x, tf.IndexedSlices):
+                    keys = x.indices
+                    processed_results.append(tf.cast(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])),
+                                                     dtype=dtype))
+                else:
+                    processed_results.append(x)
+
+            references = []
+            # First append references for indexed slices
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(0, hvd.size() + 1):
+                    if i == 0 or i == hvd.size():
+                        slices[i] /= hvd.size()
+                    else:
+                        slices[i] *= 2
+                        slices[i] /= hvd.size()
+                references.append(tf.cast(tf.stack(slices), dtype=dtype))
+
+            # Next, append references for standard tensors
+            for x in slice_values:
+                references.append(x)
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype in [tf.int8, tf.uint8] else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_indexed_slices_op_error(self):
+        """Tests that the grouped allreduce errors out on unsupported op for tf.IndexedSlices."""
+        hvd.init()
+        slice_values = [tf.ones(1,3) for _ in range(5)]
+        tensors = [tf.IndexedSlices(slice_values,
+                                    tf.convert_to_tensor([hvd.rank()])) for x in slice_values]
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Min))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Max))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Product))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Adasum))
+
+    def test_horovod_grouped_allreduce_mixed_indexed_slices_op_error(self):
+        """Tests that the grouped allreduce errors out on unsupported op for tf.IndexedSlices in list
+           with a mix of tensors and tf.IndexedSlice."""
+        hvd.init()
+        slice_values = [tf.ones(1,3) for _ in range(5)]
+        tensors = [tf.IndexedSlices(slice_values,
+                                    tf.convert_to_tensor([hvd.rank()])) for x in slice_values]
+
+        # Append additional set of regular tensors
+        for x in slice_values:
+            tensors.append(x)
+
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Min))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Max))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Product))
+        with self.assertRaises(NotImplementedError):
+            self.evaluate(hvd.grouped_allreduce(tensors, op=hvd.Adasum))
+
     def test_horovod_grouped_allreduce_gpu(self):
         """Test on GPU that the grouped allreduce correctly sums 1D, 2D, 3D tensors."""
         # Only do this test if there are GPUs available.
@@ -1074,6 +1676,405 @@ class TensorFlowTests(BaseTensorFlowTests):
 
             diff = self.evaluate(max_difference)
             self.assertTrue(diff <= threshold, "hvd.grouped_allreduce on GPU produces incorrect results")
+
+    def test_horovod_grouped_allreduce_indexed_slices_gpu(self):
+        """Test on GPU that the grouped allreduce correctly sums tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+                results = hvd.grouped_allreduce(tensors, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            processed_results = []
+            for x in results:
+                keys = x.indices
+                processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+
+            references = []
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(1, hvd.size()):
+                    slices[i] *= 2
+                references.append(tf.stack(slices))
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_mixed_indexed_slices_gpu(self):
+        """Test on GPU that the grouped allreduce correctly sums a mix of tensors and tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                # Create indexed slices
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+
+                # Append additional set of regular tensors
+                for x in slice_values:
+                    tensors.append(x)
+                results = hvd.grouped_allreduce(tensors, average=False)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices) or append standard tensor results
+            processed_results = []
+            for x in results:
+                if isinstance(x, tf.IndexedSlices):
+                    keys = x.indices
+                    processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+                else:
+                    processed_results.append(x)
+
+            references = []
+            # First append references for indexed slices
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(1, hvd.size()):
+                    slices[i] *= 2
+                references.append(tf.stack(slices))
+
+            # Next, append references for standard tensors
+            for x in slice_values:
+                references.append(x * size)
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_average_gpu(self):
+        """Test on GPU that the grouped allreduce correctly averages 1D, 2D, 3D tensors."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [tf.cast(self.random_uniform(
+                    [17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Average)
+            differences = [t1 - t2 for t1, t2 in zip(result, tensors)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_min_gpu(self):
+        """Test on GPU that the grouped allreduce correctly finds minimum of 1D, 2D, 3D tensors."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Min)
+            reference = [tf.math.reduce_min(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            threshold = 0
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_max_gpu(self):
+        """Test on GPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Max)
+            reference = [tf.math.reduce_max(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            threshold = 0
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_product_gpu(self):
+        """Test on GPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        rank = hvd.rank()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                full_tensors = [tf.cast(self.random_uniform([size] + [17] * dim, -100, 100),
+                                        dtype=dtype) for _ in range(5)]
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                tensors = [t[rank, ...]  for t in full_tensors]
+                result = hvd.grouped_allreduce(tensors, op=hvd.Product)
+            reference = [tf.math.reduce_prod(t, axis=0) for t in full_tensors]
+            differences = [t1 - t2 for t1, t2 in zip(result, reference)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_indexed_slices_average_gpu(self):
+        """Test on GPU that the grouped allreduce correctly averages tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+                results = hvd.grouped_allreduce(tensors, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices)
+            processed_results = []
+            for x in results:
+                keys = x.indices
+                processed_results.append(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])))
+
+            references = []
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(0, hvd.size()+1):
+                    if i == 0 or i == hvd.size():
+                        slices[i] /= hvd.size()
+                    else:
+                        slices[i] *= 2
+                        slices[i] /= hvd.size()
+                references.append(tf.stack(slices))
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
+
+    def test_horovod_grouped_allreduce_mixed_indexed_slices_average_gpu(self):
+        """Test on GPU that the grouped allreduce correctly averages a mix of tensors and tf.IndexedSlices."""
+        # Only do this test if there are GPUs available.
+        if not tf.test.is_gpu_available(cuda_only=True):
+            self.skipTest(("No GPUs available"))
+
+        if int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+            # Skip if compiled with CUDA but without HOROVOD_GPU_OPERATIONS.
+            self.skipTest("Not compiled with HOROVOD_GPU_OPERATIONS")
+
+        hvd.init()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([tf.uint8, tf.int8, tf.int32, tf.int64, tf.float16, tf.float32, tf.float64])
+        dims = [1, 2, 3]
+
+        for dtype, dim in itertools.product(dtypes, dims):
+            with tf.device("/gpu:%d" % hvd.local_rank()):
+                maxval = 100 if dtype not in [tf.uint8, tf.int8] else 1
+                minval = -maxval if dtype not in [tf.uint8] else 0
+                # Create indexed slices
+                slice_values = [tf.cast(self.random_uniform([17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
+                tensors = [tf.IndexedSlices(tf.stack([x]*2),
+                                            tf.convert_to_tensor([hvd.rank(), hvd.rank()+1])) for x in slice_values]
+
+                # Append additional set of regular tensors
+                for x in slice_values:
+                    tensors.append(x)
+                results = hvd.grouped_allreduce(tensors, op=hvd.Average)
+
+            # Convert indexed slice to tensor (summing entries for duplicate indices) or append standard tensor results
+            processed_results = []
+            for x in results:
+                if isinstance(x, tf.IndexedSlices):
+                    keys = x.indices
+                    processed_results.append(tf.cast(tf.math.unsorted_segment_sum(x.values, keys, tf.size(tf.unique(keys)[0])),
+                                                     dtype=dtype))
+                else:
+                    processed_results.append(x)
+
+            references = []
+            # First append references for indexed slices
+            for x in slice_values:
+                slices = [x] * (hvd.size() + 1)
+                for i in range(0, hvd.size() + 1):
+                    if i == 0 or i == hvd.size():
+                        slices[i] /= hvd.size()
+                    else:
+                        slices[i] *= 2
+                        slices[i] /= hvd.size()
+                references.append(tf.cast(tf.stack(slices), dtype=dtype))
+
+            # Next, append references for standard tensors
+            for x in slice_values:
+                references.append(x)
+
+            differences = [t1 - t2 for t1, t2 in zip(processed_results, references)]
+            differences = [tf.cast(diff, tf.int32) if dtype in [tf.int8, tf.uint8] else diff for diff in differences]
+            max_difference = tf.reduce_max([tf.reduce_max(tf.abs(diff)) for diff in differences])
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in [tf.uint8, tf.int8, tf.int32, tf.int64]:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                self.skipTest("Horovod cluster too large for precise multiplication comparison")
+
+            diff = self.evaluate(max_difference)
+            self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
 
     def test_horovod_grouped_allreduce_grad_cpu(self):
         """Test the correctness of the grouped allreduce gradient on CPU."""
@@ -3465,11 +4466,8 @@ class TensorFlowTests(BaseTensorFlowTests):
 
             test = max_difference <= threshold
             tests.append(test)
-            # infos.append({"0_t": tensor, "1_e": expected, "2_s": summed, "3_ok": tf.reduce_all(test)})
         i = self.evaluate([tf.reduce_all(tests)] + infos)
         successful = i.pop(0)
-        # from pprint import pprint
-        # pprint(i)
         self.assertTrue(successful,
                         "hvd.reducescatter produces incorrect results")
 
@@ -3689,7 +4687,6 @@ class TensorFlowTests(BaseTensorFlowTests):
             # infos.append({"0_t": tensor, "1_e": expected, "2_s": summed, "3_ok": tf.reduce_all(test)})
         i = self.evaluate([tf.reduce_all(tests)] + infos)
         succesful = i.pop(0)
-        # pprint(i)
         self.assertTrue(succesful,
                         "hvd.reducescatter produces incorrect results")
 

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -1452,7 +1452,7 @@ class TensorFlowTests(BaseTensorFlowTests):
             self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
 
     def test_horovod_grouped_allreduce_product_cpu(self):
-        """Test on CPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        """Test on CPU that the grouped allreduce correctly finds product of 1D, 2D, 3D tensors."""
         hvd.init()
         size = hvd.size()
         rank = hvd.rank()
@@ -1904,7 +1904,7 @@ class TensorFlowTests(BaseTensorFlowTests):
             self.assertTrue(diff <= threshold, "hvd.grouped_allreduce produces incorrect results")
 
     def test_horovod_grouped_allreduce_product_gpu(self):
-        """Test on GPU that the grouped allreduce correctly finds maximum of 1D, 2D, 3D tensors."""
+        """Test on GPU that the grouped allreduce correctly finds product of 1D, 2D, 3D tensors."""
         # Only do this test if there are GPUs available.
         if not tf.test.is_gpu_available(cuda_only=True):
             self.skipTest(("No GPUs available"))


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
In the `grouped_allreduce` routine for TensorFlow, the existing code uses the wrong `indices` array when forming the result. This PR corrects this issue and also adds proper support for mixed argument lists of tensors and `tf.IndexedSlices` to `grouped_allreduce`. It was also discovered during development of this PR that there were issues in properly handling `op` and `prescale_factor` and `postscale_factor` for both `allreduce` and `grouped_allreduce` so that was fixed as well. 

To catch these issues better in the future, numerous tests of the `tf.IndexedSlices` path for allreduce, as well as expanded testing of the `grouped_allreduce` were added. 


