### PR TITLE
Use macos-11 as macos-latest moved to macOS 12.6.2

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -405,7 +405,7 @@ def main():
                 f'    if: >\n'
                 f"      needs.init-workflow.outputs.run-at-all == 'true' &&\n"
                 f"      needs.init-workflow.outputs.run-builds-and-tests == 'true'\n"
-                f'    runs-on: macos-latest\n'
+                f'    runs-on: macos-11\n'
                 f'\n'
                 f'    strategy:\n'
                 f'      max-parallel: 3\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4427,7 +4427,7 @@ jobs:
     if: >
       needs.init-workflow.outputs.run-at-all == 'true' &&
       needs.init-workflow.outputs.run-builds-and-tests == 'true'
-    runs-on: macos-latest
+    runs-on: macos-11
 
     strategy:
       max-parallel: 3


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

It looks like installing Python on macOS 12 is broken, it used to work with macOS 11, so pinning tests to `macos-11` rather than `macos-latest` (which recently moved to `macos-12`).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
