### PR TITLE
Add prescale_factor and postscale_factor for Reducescatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Reducescatter: Added support for prescale_factor and postscale_factor and moved averaging into Horovod backend. ([#3815](https://github.com/horovod/horovod/pull/3815))
+
 ### Changed
 
 - Improved NCCL performance for fused allgather operations through padding for better memory alignment. ([#3727](https://github.com/horovod/horovod/pull/3727))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
 - Handle tf.IndexedSlices types when scaling local gradients in TF. ([#3786](https://github.com/horovod/horovod/pull/3786))
 - Several fixes for allreduce and grouped allreduce handling of tf.IndexedSlices. ([#3813](https://github.com/horovod/horovod/pull/3813))
+- PyTorch, ROCm: Fixed allreduce average on process sets. ([#3815](https://github.com/horovod/horovod/pull/3815))
 
 
 ## [v0.26.1] - 2022-10-14

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -236,22 +236,21 @@ Status EnqueueTensorAlltoall(std::shared_ptr<OpContext> context,
                              StatusCallback callback,
                              int32_t process_set_id = 0);
 
-Status EnqueueTensorReducescatter(std::shared_ptr<OpContext> context,
-                                  std::shared_ptr<Tensor> tensor,
-                                  ReadyEventList ready_event_list,
-                                  const std::string& name, int device,
-                                  StatusCallback callback,
-                                  ReduceOp reduce_op = ReduceOp::SUM,
-                                  int32_t process_set_id = 0);
+Status EnqueueTensorReducescatter(
+    std::shared_ptr<OpContext> context, std::shared_ptr<Tensor> tensor,
+    ReadyEventList ready_event_list, const std::string& name, int device,
+    StatusCallback callback, ReduceOp reduce_op = ReduceOp::SUM,
+    int32_t process_set_id = 0, double prescale_factor = 1.0,
+    double postscale_factor = 1.0);
 
-Status
-EnqueueTensorReducescatters(std::vector<std::shared_ptr<OpContext>>& contexts,
-                            std::vector<std::shared_ptr<Tensor>>& tensors,
-                            std::vector<ReadyEventList>& ready_event_lists,
-                            std::vector<std::string>& names, int device,
-                            std::vector<StatusCallback>& callbacks,
-                            ReduceOp reduce_op = ReduceOp::SUM,
-                            int32_t process_set_id = 0);
+Status EnqueueTensorReducescatters(
+    std::vector<std::shared_ptr<OpContext>>& contexts,
+    std::vector<std::shared_ptr<Tensor>>& tensors,
+    std::vector<ReadyEventList>& ready_event_lists,
+    std::vector<std::string>& names, int device,
+    std::vector<StatusCallback>& callbacks, ReduceOp reduce_op = ReduceOp::SUM,
+    int32_t process_set_id = 0, double prescale_factor = 1.0,
+    double postscale_factor = 1.0);
 
 Status EnqueueJoin(std::shared_ptr<OpContext> context,
                    std::shared_ptr<Tensor> output_last_joined_rank,

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -47,6 +47,11 @@ protected:
 
   virtual void WaitForData(std::vector<TensorTableEntry>& entries);
 
+  virtual void ScaleBuffer(double scale_factor,
+                           const std::vector<TensorTableEntry>& entries,
+                           const void* fused_input_data, void* buffer_data,
+                           int64_t num_elements);
+
   HorovodGlobalState* global_state_;
 };
 
@@ -78,11 +83,6 @@ protected:
   MemcpyEntryOutFusionBuffer(const std::vector<TensorTableEntry>& entries,
                              const void* buffer_data_at_offset,
                              TensorTableEntry& e);
-
-  virtual void
-  ScaleBuffer(double scale_factor, const std::vector<TensorTableEntry>& entries,
-              const void* fused_input_data, void* buffer_data, int64_t num_elements);
-
 };
 
 template <typename T, typename TS>
@@ -296,7 +296,7 @@ protected:
   virtual void MemcpyInFusionBuffer(
       const std::vector<TensorTableEntry>& entries,
       const std::vector<std::vector<TensorShape>>& output_shapes,
-      std::size_t element_size, void*& buffer_data);
+      std::size_t element_size, void*& buffer_data, size_t& buffer_len);
 
   virtual void MemcpyOutFusionBuffer(const void* buffer_data,
                                      std::vector<TensorTableEntry>& entries);

--- a/horovod/common/ops/gpu_operations.h
+++ b/horovod/common/ops/gpu_operations.h
@@ -266,10 +266,24 @@ protected:
   void MemcpyInFusionBuffer(
       const std::vector<TensorTableEntry>& entries,
       const std::vector<std::vector<TensorShape>>& output_shapes,
-      std::size_t element_size, void*& buffer_data) override;
+      std::size_t element_size, void*& buffer_data,
+      size_t& buffer_len) override;
+
+  void ScaleMemcpyInFusionBuffer(
+      const std::vector<TensorTableEntry>& entries,
+      const std::vector<std::vector<TensorShape>>& output_shapes,
+      std::size_t element_size, void*& buffer_data, double scale_factor);
 
   void MemcpyOutFusionBuffer(const void* buffer_data,
                              std::vector<TensorTableEntry>& entries) override;
+
+  void ScaleMemcpyOutFusionBuffer(const void* buffer_data, double scale_factor,
+                                  std::vector<TensorTableEntry>& entries);
+
+  void ScaleBuffer(double scale_factor,
+                   const std::vector<TensorTableEntry>& entries,
+                   const void* fused_input_data, void* buffer_data,
+                   int64_t num_elements) override;
 
   GPUContext* gpu_context_;
   GPUOpContext gpu_op_context_;

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -296,8 +296,13 @@ Status MPI_GPUReducescatter::Execute(std::vector<TensorTableEntry>& entries,
 
   WaitForData(entries);
 
+  double prescale_factor = response.prescale_factor();
+  double postscale_factor = response.postscale_factor();
+
+  void* fusion_buffer = nullptr;
   const void* sendbuf = nullptr;
-  void* buffer_data = nullptr;
+  void* recvbuf = nullptr;
+
   int global_rank = process_set.controller->GetRank();
   int global_size = process_set.controller->GetSize();
   auto output_shapes = ComputeOutputShapes(entries, global_size);
@@ -310,26 +315,45 @@ Status MPI_GPUReducescatter::Execute(std::vector<TensorTableEntry>& entries,
   }
   timeline.ActivityEndAll(entries);
 
-  // Copy memory into the fusion buffer.
-  if (entries.size() > 1) {
+  // Copy memory into the fusion buffer. Execute prescaling op if necessary.
+  if (entries.size() > 1 || prescale_factor != 1.0) {
     timeline.ActivityStartAll(entries, MEMCPY_IN_FUSION_BUFFER);
     int element_size = mpi_context.GetMPITypeSize(first_entry.tensor->dtype());
-    MemcpyInFusionBuffer(entries, output_shapes, element_size, buffer_data);
-
+    size_t buffer_len;
+    MemcpyInFusionBuffer(entries, output_shapes, element_size, fusion_buffer,
+                         buffer_len);
+    if (prescale_factor != 1.0) {
+      // Prescale in place on the fusion buffer.
+      int64_t num_elements =
+          buffer_len / DataType_Size(first_entry.tensor->dtype());
+      ScaleBuffer(prescale_factor, entries, fusion_buffer, fusion_buffer,
+                  num_elements);
+      if (entries.size() == 1) {
+        // Unfused prescaled: Send from fusion buffer, receive at output tensor
+        sendbuf = fusion_buffer;
+        recvbuf = (void*)first_entry.output->data();
+      }
+    }
+    if (entries.size() > 1) {
+      // Fused: MPI_Reduce_scatter in place
+      sendbuf = nullptr;
+      recvbuf = fusion_buffer;
+    }
     gpu_context_->StreamSynchronize(
         gpu_context_
             ->streams[global_state_->current_nccl_stream][first_entry.device]);
 
     timeline.ActivityEndAll(entries);
   } else {
+    // Unfused without prescaling
     sendbuf = first_entry.tensor->data();
-    buffer_data = (void*)first_entry.output->data();
+    recvbuf = (void*)first_entry.output->data();
   }
 
   // Do reducescatter.
   timeline.ActivityStartAll(entries, MPI_REDUCESCATTER);
   int op = MPI_Reduce_scatter(
-      sendbuf != nullptr ? sendbuf : MPI_IN_PLACE, buffer_data,
+      sendbuf != nullptr ? sendbuf : MPI_IN_PLACE, recvbuf,
       recvcounts.data(), mpi_context.GetMPIDataType(first_entry.tensor),
       mpi_context.GetMPISumOp(first_entry.tensor->dtype()),
       mpi_context.GetMPICommunicator(Communicator::GLOBAL));
@@ -342,13 +366,21 @@ Status MPI_GPUReducescatter::Execute(std::vector<TensorTableEntry>& entries,
   // Copy memory out of the fusion buffer.
   if (entries.size() > 1) {
     timeline.ActivityStartAll(entries, MEMCPY_OUT_FUSION_BUFFER);
-    MemcpyOutFusionBuffer(buffer_data, entries);
+    MemcpyOutFusionBuffer(fusion_buffer, entries);
 
     gpu_context_->StreamSynchronize(
         gpu_context_
             ->streams[global_state_->current_nccl_stream][first_entry.device]);
 
     timeline.ActivityEndAll(entries);
+  }
+  if (postscale_factor != 1.0) {
+    // Execute postscaling ops
+    for (auto& e : entries) {
+      ScaleBuffer(postscale_factor, entries, e.output->data(),
+                  const_cast<void*>(e.output->data()),
+                  e.output->shape().num_elements());
+    }
   }
 
   return Status::OK();

--- a/horovod/common/ops/nccl_operations.cc
+++ b/horovod/common/ops/nccl_operations.cc
@@ -719,8 +719,6 @@ Status NCCLTorusAllreduce::Execute(std::vector<TensorTableEntry>& entries,
                                        ? num_elements % local_size
                                        : num_elements;
 
-  size_t buffer_len_remaining = element_size * num_elements_remaining;
-
   void* buffer_data_remainder =
       (uint8_t*)buffer_data + buffer_len_per_rank * local_size;
 
@@ -733,9 +731,6 @@ Status NCCLTorusAllreduce::Execute(std::vector<TensorTableEntry>& entries,
   int64_t total_num_elements =
       is_root_rank ? num_elements_per_rank + num_elements_remaining
                    : num_elements_per_rank;
-  int64_t total_buffer_len = is_root_rank
-                                 ? buffer_len_per_rank + buffer_len_remaining
-                                 : buffer_len_per_rank;
 
   auto& timeline = global_state_->timeline;
   if (num_elements_per_rank > 0) {

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -272,8 +272,8 @@ protected:
   void WaitForData(std::vector<TensorTableEntry>& entries) override;
 
   NCCLContext* local_nccl_context_;
-  NCCLOpContext local_nccl_op_context_;
   NCCLContext* cross_nccl_context_;
+  NCCLOpContext local_nccl_op_context_;
   NCCLOpContext cross_nccl_op_context_;
   HorovodGlobalState* global_state_;
 };

--- a/horovod/mxnet/mpi_ops.h
+++ b/horovod/mxnet/mpi_ops.h
@@ -134,11 +134,10 @@ extern "C" int horovod_mxnet_alltoall_async(NDArray* input,
                                             NDArray* output_received_splits,
                                             int priority,
                                             int process_set_id);
-extern "C" int horovod_mxnet_reducescatter_async(NDArray* const* inputs,
-                                                 NDArray* const* outputs,
-                                                 const char* name, int priority,
-                                                 int process_set_id,
-                                                 int num_tensors);
+extern "C" int horovod_mxnet_reducescatter_async(
+    NDArray* const* inputs, NDArray* const* outputs, const char* name,
+    int priority, int process_set_id, int num_tensors, int reduce_op_int,
+    double prescale_factor, double postscale_factor);
 
 } // namespace mxnet
 } // namespace horovod

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -199,8 +199,8 @@ def reducescatter(tensor, device_dense='', compression=Compression.none, op=Aver
         name: A name of the reduce_scatter operation
         ignore_name_scope: If True, ignores any outer name scope applied by
                            TensorFlow in the name used by the Horovod operation.
-        prescale_factor: Multiplicative factor to scale tensor before allreduce.
-        postscale_factor: Multiplicative factor to scale tensor after allreduce.
+        prescale_factor: Multiplicative factor to scale tensor before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensor after reducescatter.
 
     Returns:
         A tensor of the same rank and type as `tensor`, summed across all processes.
@@ -428,8 +428,8 @@ def grouped_reducescatter(tensors, device_dense='', compression=Compression.none
             Defaults to Average if None is given.
         process_set: Process set object to limit this operation to a subset of
             Horovod processes. Default is the global process set.
-        prescale_factor: Multiplicative factor to scale tensor before allreduce.
-        postscale_factor: Multiplicative factor to scale tensor after allreduce.
+        prescale_factor: Multiplicative factor to scale tensors before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensors after reducescatter.
 
     Returns:
         A list of tensors of the same rank and type as those in `tensors`,

--- a/horovod/tensorflow/mpi_ops.py
+++ b/horovod/tensorflow/mpi_ops.py
@@ -456,7 +456,7 @@ def _alltoall_grad(op, grad_wrt_output, grad_wrt_received_splits):
 
 def _reducescatter(tensor, name=None, op=Sum, ignore_name_scope=False,
                    process_set=global_process_set, prescale_factor=1.0,
-                   postscale_factor=1.0,):
+                   postscale_factor=1.0):
     """An op which reduces an input tensor over all the Horovod processes, then
     scatters the result across all the Horovod processes. The default reduction
     is a sum.
@@ -508,7 +508,7 @@ def _reducescatter_grad(op, grad):
 
 def _grouped_reducescatter(tensors, name=None, op=Sum, ignore_name_scope=False,
                            process_set=global_process_set,
-                           prescale_factor=1.0, postscale_factor=1.0,):
+                           prescale_factor=1.0, postscale_factor=1.0):
     """An op which sums an input tensor over all the Horovod processes, then
     scatters the result across all the Horovod processes.
 

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -112,7 +112,7 @@ def _allreduce_async(tensor, output, name, op, prescale_factor, postscale_factor
     if op == Average:
         if rocm_built():
             # For ROCm, perform averaging at framework level
-            divisor = size()
+            divisor = process_set.size()
             op = Sum
         else:
             divisor = 1
@@ -338,7 +338,7 @@ def _grouped_allreduce_async(tensors, outputs, name, op, prescale_factor, postsc
     if op == Average:
         if rocm_built():
             # For ROCm, perform averaging at framework level
-            divisor = size()
+            divisor = process_set.size()
             op = Sum
         else:
             divisor = 1

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -1116,7 +1116,6 @@ def reducescatter(tensor, name=None, compression=Compression.none, op=Average,
         prescale_factor: Multiplicative factor to scale tensor before reducescatter.
         postscale_factor: Multiplicative factor to scale tensor after reducescatter.
 
-
     Returns:
         A tensor of the same rank and type as `tensor` across all processes. The shape
         is identical to the input shape, except for the first dimension, which will be

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -1018,19 +1018,22 @@ def _reducescatter_function_factory(tensor):
     return 'horovod_torch_reducescatter_async_' + tensor.type().replace('.', '_')
 
 
-def _reducescatter_async(tensor, output, name, op, process_set: ProcessSet):
+def _reducescatter_async(tensor, output, name, op, process_set: ProcessSet,
+                         prescale_factor, postscale_factor):
     function = _check_function(_reducescatter_function_factory, tensor)
     try:
         handle = getattr(mpi_lib, function)(tensor, output,
                                             name.encode() if name is not None else _NULL,
-                                            op, process_set.process_set_id)
+                                            op, process_set.process_set_id,
+                                            prescale_factor, postscale_factor)
     except RuntimeError as e:
         raise HorovodInternalError(e)
     _handle_map[handle] = (tensor, output)
     return handle
 
 
-def reducescatter_async(tensor, name=None, op=Average, process_set=global_process_set):
+def reducescatter_async(tensor, name=None, op=Average, process_set=global_process_set,
+                        prescale_factor=1.0, postscale_factor=1.0):
     """
     A function that performs asynchronous reduction of the input tensor over all the
     Horovod processes, then scatters the results across all Horovod processes. The
@@ -1052,35 +1055,44 @@ def reducescatter_async(tensor, name=None, op=Average, process_set=global_proces
             Defaults to Average.
         process_set: Process set object to limit this operation to a subset of
                      Horovod processes. Default is the global process set.
+        prescale_factor: Multiplicative factor to scale tensor before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensor after reducescatter.
 
     Returns:
         A handle to the reducescatter operation that can be used with `poll()` or
         `synchronize()`.
     """
     output = tensor.new()
-    return _reducescatter_async(tensor, output, name, op, process_set)
+    return _reducescatter_async(tensor, output, name, op, process_set,
+                                prescale_factor, postscale_factor)
 
 
 class HorovodReducescatter(torch.autograd.Function):
     """An autograd function that performs reducescatter on a tensor."""
 
     @staticmethod
-    def forward(ctx, tensor, name, op, process_set):
+    def forward(ctx, tensor, name, op, process_set, prescale_factor, postscale_factor):
         ctx.op = op
         ctx.process_set = process_set
-        handle = reducescatter_async(tensor, name, op, process_set)
+        ctx.prescale_factor = prescale_factor
+        ctx.postscale_factor = postscale_factor
+        handle = reducescatter_async(tensor, name, op, process_set, prescale_factor, postscale_factor)
         return synchronize(handle)
 
     @staticmethod
     def backward(ctx, grad_output):
         if ctx.op == Sum:
             grad_output *= ctx.process_set.size()
+        if ctx.prescale_factor != 1.0:
+            grad_output *= ctx.prescale_factor
+        if ctx.postscale_factor != 1.0:
+            grad_output *= ctx.postscale_factor
 
-        return allgather(grad_output, process_set=ctx.process_set), None, None, None
+        return allgather(grad_output, process_set=ctx.process_set), None, None, None, None, None
 
 
 def reducescatter(tensor, name=None, compression=Compression.none, op=Average,
-                  process_set=global_process_set):
+                  process_set=global_process_set, prescale_factor=1.0, postscale_factor=1.0):
     """
     A function that performs reduction of the input tensor over all the Horovod
     processes, then scatters the results across all Horovod processes. The input tensor
@@ -1101,6 +1113,8 @@ def reducescatter(tensor, name=None, compression=Compression.none, op=Average,
             Defaults to Average.
         process_set: Process set object to limit this operation to a subset of
                      Horovod processes. Default is the global process set.
+        prescale_factor: Multiplicative factor to scale tensor before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensor after reducescatter.
 
 
     Returns:
@@ -1109,7 +1123,8 @@ def reducescatter(tensor, name=None, compression=Compression.none, op=Average,
         divided across the different Horovod processes.
     """
     tensor_compressed, ctx = compression.compress(tensor)
-    reduced_tensor_compressed = HorovodReducescatter.apply(tensor_compressed, name, op, process_set)
+    reduced_tensor_compressed = HorovodReducescatter.apply(tensor_compressed, name, op, process_set,
+                                                           prescale_factor, postscale_factor)
     return compression.decompress(reduced_tensor_compressed, ctx)
 
 
@@ -1117,19 +1132,22 @@ def _grouped_reducescatter_function_factory(tensor):
     return 'horovod_torch_grouped_reducescatter_async_' + tensor.type().replace('.', '_')
 
 
-def _grouped_reducescatter_async(tensors, outputs, name, op, process_set: ProcessSet):
+def _grouped_reducescatter_async(tensors, outputs, name, op, process_set: ProcessSet,
+                                 prescale_factor, postscale_factor):
     function = _check_function(_grouped_reducescatter_function_factory, tensors[0])
     try:
         handle = getattr(mpi_lib, function)(tensors, outputs,
                                             name.encode() if name is not None else _NULL,
-                                            op, process_set.process_set_id)
+                                            op, process_set.process_set_id,
+                                            prescale_factor, postscale_factor)
     except RuntimeError as e:
         raise HorovodInternalError(e)
     _handle_map[handle] = (tuple(tensors), tuple(outputs))
     return handle
 
 
-def grouped_reducescatter_async(tensors, name=None, op=Average, process_set=global_process_set):
+def grouped_reducescatter_async(tensors, name=None, op=Average, process_set=global_process_set,
+                                prescale_factor=1.0, postscale_factor=1.0):
     """
     A function that performs asynchronous reduction of a list of input tensors over all the
     Horovod processes, then scatters the results across all Horovod processes. The
@@ -1151,35 +1169,46 @@ def grouped_reducescatter_async(tensors, name=None, op=Average, process_set=glob
             Defaults to Average.
         process_set: Process set object to limit this operation to a subset of
                      Horovod processes. Default is the global process set.
+        prescale_factor: Multiplicative factor to scale tensors before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensors after reducescatter.
 
     Returns:
         A handle to the group reducescatter operation that can be used with `poll()` or
         `synchronize()`.
     """
     outputs = [t.new() for t in tensors]
-    return _grouped_reducescatter_async(tensors, outputs, name, op, process_set)
+    return _grouped_reducescatter_async(tensors, outputs, name, op, process_set,
+                                        prescale_factor, postscale_factor)
 
 
 class HorovodGroupedReducescatter(torch.autograd.Function):
     """An autograd function that performs reducescatter on a list of tensors."""
 
     @staticmethod
-    def forward(ctx, name, op, process_set, *tensors):
+    def forward(ctx, name, op, process_set, prescale_factor, postscale_factor, *tensors):
         ctx.op = op
         ctx.process_set = process_set
-        handle = grouped_reducescatter_async(list(tensors), name, op, process_set)
+        ctx.prescale_factor = prescale_factor
+        ctx.postscale_factor = postscale_factor
+        handle = grouped_reducescatter_async(list(tensors), name, op, process_set,
+                                             prescale_factor, postscale_factor, )
         return synchronize(handle)
 
     @staticmethod
     def backward(ctx, *grad_output):
         if ctx.op == Sum:
             grad_output = [g * ctx.process_set.size() for g in grad_output]
+        if ctx.prescale_factor != 1.0:
+            grad_output = [ctx.prescale_factor * g for g in grad_output]
+        if ctx.postscale_factor != 1.0:
+            grad_output = [ctx.postscale_factor * g for g in grad_output]
 
-        return (None, None, None, *grouped_allgather(grad_output, process_set=ctx.process_set))
+        return (None, None, None, None, None,
+                *grouped_allgather(grad_output, process_set=ctx.process_set))
 
 
 def grouped_reducescatter(tensors, name=None, compression=Compression.none, op=Average,
-                          process_set=global_process_set):
+                          process_set=global_process_set, prescale_factor=1.0, postscale_factor=1.0):
     """
     A function that performs reduction of a list of input tensors over all the
     Horovod processes, then scatters the results across all Horovod processes. The
@@ -1200,6 +1229,8 @@ def grouped_reducescatter(tensors, name=None, compression=Compression.none, op=A
             Defaults to Average.
         process_set: Process set object to limit this operation to a subset of
                      Horovod processes. Default is the global process set.
+        prescale_factor: Multiplicative factor to scale tensors before reducescatter.
+        postscale_factor: Multiplicative factor to scale tensors after reducescatter.
 
 
     Returns:
@@ -1213,7 +1244,9 @@ def grouped_reducescatter(tensors, name=None, compression=Compression.none, op=A
         tensor_compressed, ctx = compression.compress(tensor)
         tensors_compressed.append(tensor_compressed)
         ctxs.append(ctx)
-    reduced_tensors_compressed = HorovodGroupedReducescatter.apply(name, op, process_set, *tensors_compressed)
+    reduced_tensors_compressed = HorovodGroupedReducescatter.apply(name, op, process_set,
+                                                                   prescale_factor, postscale_factor,
+                                                                   *tensors_compressed)
     return [compression.decompress(reduced_tensor_compressed, ctx)
             for reduced_tensor_compressed, ctx in zip(reduced_tensors_compressed, ctxs)]
 

--- a/test/parallel/base_test_mxnet.py
+++ b/test/parallel/base_test_mxnet.py
@@ -2138,8 +2138,8 @@ class MXTests:
                 # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
                 factor = factor.astype('float32' if dtype == 'float16' else
                                        'float64' if dtype in int_types else dtype)
-                tensor = [t.astype('float32' if dtype == 'float16' else
-                                   'float64' if dtype in int_types else dtype) for t in tensors]
+                tensors = [t.astype('float32' if dtype == 'float16' else
+                                    'float64' if dtype in int_types else dtype) for t in tensors]
 
             expected = [factor * t[rank * 4:(rank + 1) * 4] for t in tensors]
             expected = [e.astype(dtype) for e in expected]
@@ -2198,8 +2198,8 @@ class MXTests:
                 # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
                 factor = factor.astype('float32' if dtype == 'float16' else
                                        'float64' if dtype in int_types else dtype)
-                tensor = [t.astype('float32' if dtype == 'float16' else
-                                   'float64' if dtype in int_types else dtype) for t in tensors]
+                tensors = [t.astype('float32' if dtype == 'float16' else
+                                    'float64' if dtype in int_types else dtype) for t in tensors]
 
             expected = [t[rank * 4:(rank + 1) * 4] * size for t in tensors]
             expected = [e * factor for e in expected]

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -126,7 +126,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False)
+                summed = hvd.allreduce(tensor, op=hvd.Sum)
             multiplied = tensor * size
             difference = summed - multiplied
             difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
@@ -158,7 +158,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                averaged = hvd.allreduce(tensor, average=True)
+                averaged = hvd.allreduce(tensor, op=hvd.Average)
             # handle int8, uint8 overflows when allreduce sums up and averages the values
             tensor = tf.cast((tensor*size)/size, dtype=dtype)
             difference = tf.cast(averaged, dtype=dtype) - tensor
@@ -269,7 +269,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False)
+                summed = hvd.allreduce(tensor, op=hvd.Sum)
             multiplied = tensor * size
             difference = summed - multiplied
             difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
@@ -310,7 +310,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False,
+                summed = hvd.allreduce(tensor, op=hvd.Sum,
                                        prescale_factor=factor)
 
                 # Scaling done in FP64 math for integer types, FP32 math for FP16 on CPU
@@ -354,7 +354,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False,
+                summed = hvd.allreduce(tensor, op=hvd.Sum,
                                        postscale_factor=factor)
 
                 multiplied = tensor * size
@@ -636,7 +636,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False)
+                summed = hvd.allreduce(tensor, op=hvd.Sum)
             multiplied = tensor * size
             difference = summed - multiplied
             difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
@@ -678,7 +678,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                averaged = hvd.allreduce(tensor, average=True)
+                averaged = hvd.allreduce(tensor, op=hvd.Average)
             # handle int8, uint8 overflows when allreduce sums up and averages the values
             tensor = tf.cast((tensor*size)/size, dtype=dtype)
             difference = tf.cast(averaged, dtype=dtype) - tensor
@@ -829,7 +829,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False)
+                summed = hvd.allreduce(tensor, op=hvd.Sum)
             multiplied = tensor * size
             difference = summed - multiplied
             difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
@@ -885,7 +885,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False)
+                summed = hvd.allreduce(tensor, op=hvd.Sum)
             multiplied = tensor * size
             difference = summed - multiplied
             difference = tf.cast(difference, tf.int32) if dtype == tf.uint8 else difference
@@ -932,7 +932,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False,
+                summed = hvd.allreduce(tensor, op=hvd.Sum,
                                        prescale_factor=factor)
 
                 # Scaling done in FP64 math for integer types.
@@ -983,7 +983,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensor = self.random_uniform([17] * dim, minval, maxval)
                 tensor = tf.cast(tensor, dtype=dtype)
-                summed = hvd.allreduce(tensor, average=False,
+                summed = hvd.allreduce(tensor, op=hvd.Sum,
                                        postscale_factor=factor)
 
                 multiplied = tensor * size
@@ -1096,11 +1096,11 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensor = self.tfe.Variable(self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype))
                     with tf.GradientTape() as tape:
-                        summed = hvd.allreduce(tensor, average=False)
+                        summed = hvd.allreduce(tensor, op=hvd.Sum)
                 else:
                     tensor = self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype)
-                    summed = hvd.allreduce(tensor, average=False)
+                    summed = hvd.allreduce(tensor, op=hvd.Sum)
 
                 grad_ys = tf.ones([5] * dim)
                 if _executing_eagerly():
@@ -1130,11 +1130,11 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensor = self.tfe.Variable(self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype))
                     with tf.GradientTape() as tape:
-                        averaged = hvd.allreduce(tensor, average=True)
+                        averaged = hvd.allreduce(tensor, op=hvd.Average)
                 else:
                     tensor = self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype)
-                    averaged = hvd.allreduce(tensor, average=True)
+                    averaged = hvd.allreduce(tensor, op=hvd.Average)
 
                 grad_ys = tf.ones([5] * dim, dtype=dtype)
                 if _executing_eagerly():
@@ -1173,10 +1173,10 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensor = self.tfe.Variable(
                         self.random_uniform([5] * dim, -100, 100, dtype=dtype))
                     with tf.GradientTape() as tape:
-                        summed = hvd.allreduce(tensor, average=False)
+                        summed = hvd.allreduce(tensor, op=hvd.Sum)
                 else:
                     tensor = self.random_uniform([5] * dim, -100, 100, dtype=dtype)
-                    summed = hvd.allreduce(tensor, average=False)
+                    summed = hvd.allreduce(tensor, op=hvd.Sum)
 
                 grad_ys = tf.ones([5] * dim)
                 if _executing_eagerly():
@@ -1215,10 +1215,10 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensor = self.tfe.Variable(
                         self.random_uniform([5] * dim, -100, 100, dtype=dtype))
                     with tf.GradientTape() as tape:
-                        averaged = hvd.allreduce(tensor, average=True)
+                        averaged = hvd.allreduce(tensor, op=hvd.Average)
                 else:
                     tensor = self.random_uniform([5] * dim, -100, 100, dtype=dtype)
-                    averaged = hvd.allreduce(tensor, average=True)
+                    averaged = hvd.allreduce(tensor, op=hvd.Average)
 
                 grad_ys = tf.ones([5] * dim, dtype=dtype)
                 if _executing_eagerly():
@@ -1245,7 +1245,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensors = [tf.cast(self.random_uniform(
                     [17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
-                summed = hvd.grouped_allreduce(tensors, average=False)
+                summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
             multiplied = [tensor * size for tensor in tensors]
             differences = [t1 - t2 for t1, t2 in zip(summed, multiplied)]
             differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
@@ -1657,7 +1657,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 minval = -maxval if dtype not in [tf.uint8] else 0
                 tensors = [tf.cast(self.random_uniform(
                     [17] * dim, minval, maxval), dtype=dtype) for _ in range(5)]
-                summed = hvd.grouped_allreduce(tensors, average=False)
+                summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
             multiplied = [tensor * size for tensor in tensors]
             differences = [t1 - t2 for t1, t2 in zip(summed, multiplied)]
             differences = [tf.cast(diff, tf.int32) if dtype == tf.uint8 else diff for diff in differences]
@@ -2091,11 +2091,11 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensors = [self.tfe.Variable(self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype)) for _ in range(5)]
                     with tf.GradientTape(persistent=True) as tape:
-                        summed = hvd.grouped_allreduce(tensors, average=False)
+                        summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
                 else:
                     tensors = [self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype) for _ in range(5)]
-                    summed = hvd.grouped_allreduce(tensors, average=False)
+                    summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
 
                 grads_ys = [tf.ones([5] * dim, dtype=dtype) for _ in range(5)]
                 if _executing_eagerly():
@@ -2135,11 +2135,11 @@ class TensorFlowTests(BaseTensorFlowTests):
                     tensors = [self.tfe.Variable(self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype)) for _ in range(5)]
                     with tf.GradientTape(persistent=True) as tape:
-                        summed = hvd.grouped_allreduce(tensors, average=False)
+                        summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
                 else:
                     tensors = [self.random_uniform(
                         [5] * dim, -100, 100, dtype=dtype) for _ in range(5)]
-                    summed = hvd.grouped_allreduce(tensors, average=False)
+                    summed = hvd.grouped_allreduce(tensors, op=hvd.Sum)
 
                 grads_ys = [tf.ones([5] * dim, dtype=dtype) for _ in range(5)]
                 if _executing_eagerly():
@@ -4055,7 +4055,7 @@ class TensorFlowTests(BaseTensorFlowTests):
                 if local_rank == first_join_rank:
                     ret = self.evaluate(hvd.join())
                 else:
-                    summed = hvd.allreduce(tensor, average=False)
+                    summed = hvd.allreduce(tensor, op=hvd.Sum)
                     multiplied = tensor * (size-1)
                     max_difference = tf.reduce_max(tf.abs(summed - multiplied))
 

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -3610,6 +3610,130 @@ class TorchTests(unittest.TestCase):
             max_difference = averaged.data.sub(expected).max()
             assert max_difference <= threshold, 'hvd.reducescatter produces incorrect results'
 
+    def test_horovod_reducescatter_prescale(self):
+        """Test that reducescatter correctly sums and scatters 1D, 2D, 3D tensors with prescaling."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
+                                              torch.FloatTensor, torch.DoubleTensor,
+                                              torch.HalfTensor])
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+        half_types = [torch.HalfTensor, torch.cuda.HalfTensor]
+        dims = [1, 2, 3]
+        np.random.seed(12345)
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            factor = np.random.uniform()
+            tensor = torch.FloatTensor(*([size * 4] * dim)).random_(-100, 100)
+            tensor = self.cast_and_place(tensor, dtype)
+            summed = hvd.reducescatter(tensor, op=hvd.Sum, prescale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+              # For integer types, scaling done in FP64
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float64 if dtype in int_types else dtype)
+            else:
+              # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+
+            multiplied = factor * tensor
+            multiplied = multiplied.type(dtype)
+
+            multiplied, summed = self.convert_cpu_fp16_to_fp32(multiplied, summed)
+            expected = multiplied[rank * 4:(rank + 1) * 4] * size
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in int_types:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert list(summed.shape) == list(expected.shape)
+            max_difference = summed.data.sub(expected).max()
+            assert max_difference <= threshold, 'hvd.reducescatter produces incorrect results'
+
+    def test_horovod_reducescatter_postscale(self):
+        """Test that reducescatter correctly sums and scatters 1D, 2D, 3D tensors with postscaling."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
+                                              torch.FloatTensor, torch.DoubleTensor,
+                                              torch.HalfTensor])
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+        half_types = [torch.HalfTensor, torch.cuda.HalfTensor]
+        dims = [1, 2, 3]
+        np.random.seed(12345)
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            factor = np.random.uniform()
+            tensor = torch.FloatTensor(*([size * 4] * dim)).random_(-100, 100)
+            tensor = self.cast_and_place(tensor, dtype)
+            summed = hvd.reducescatter(tensor, op=hvd.Sum, postscale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+              # For integer types, scaling done in FP64
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float64 if dtype in int_types else dtype)
+            else:
+              # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensor = tensor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+
+            multiplied = size * tensor
+            multiplied = multiplied * factor
+            multiplied = multiplied.type(dtype)
+            multiplied, summed = self.convert_cpu_fp16_to_fp32(multiplied, summed)
+            expected = multiplied[rank * 4:(rank + 1) * 4]
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in int_types:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert list(summed.shape) == list(expected.shape)
+            max_difference = summed.data.sub(expected).max()
+            assert max_difference <= threshold, 'hvd.reducescatter produces incorrect results'
+
     def test_horovod_reducescatter_scalar_error(self):
         if hvd.ccl_built():
             self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
@@ -4059,6 +4183,131 @@ class TorchTests(unittest.TestCase):
 
             assert all([torch.allclose(t1, t2, threshold) for t1, t2 in zip(expected, averaged)]), \
                 'hvd.grouped_reducescatter produces incorrect results for average'
+
+    def test_horovod_grouped_reducescatter_prescale(self):
+        """Test that grouped reducescatter correctly sums and scatters 1D, 2D, 3D tensors with prescaling."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
+                                              torch.FloatTensor, torch.DoubleTensor,
+                                              torch.HalfTensor])
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+        half_types = [torch.HalfTensor, torch.cuda.HalfTensor]
+        dims = [1, 2, 3]
+        np.random.seed(12345)
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            factor = np.random.uniform()
+            tensors = [torch.FloatTensor(*([size * 4] * dim)).random_(-100, 100) for _ in range(5)]
+            tensors = [self.cast_and_place(tensor, dtype) for tensor in tensors]
+            summed_list = hvd.grouped_reducescatter(tensors, op=hvd.Sum, prescale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+              # For integer types, scaling done in FP64
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensors = [tensor.type(torch.float64 if dtype in int_types else dtype) for tensor in tensors]
+            else:
+              # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensors = [tensor.type(torch.float32 if dtype in half_types else
+                                     torch.float64 if dtype in int_types else dtype) for tensor in tensors]
+
+            multiplied_list = [factor * tensor for tensor in tensors]
+            multiplied_list = [multiplied.type(dtype) for multiplied in multiplied_list]
+
+            multiplied_list, summed_list = zip(*[self.convert_cpu_fp16_to_fp32(multiplied, summed)
+                                                 for multiplied, summed in zip(multiplied_list, summed_list)])
+            expected = [multiplied[rank * 4:(rank + 1) * 4] * size for multiplied in multiplied_list]
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in int_types:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert all([torch.allclose(t1, t2, threshold) for t1, t2 in zip(expected, summed_list)]), \
+                'hvd.grouped_reducescatter produces incorrect results'
+
+    def test_horovod_grouped_reducescatter_postscale(self):
+        """Test that grouped reducescatter correctly sums and scatters 1D, 2D, 3D tensors with postscaling."""
+        if hvd.ccl_built():
+            self.skipTest("Reducescatter is not supported yet with oneCCL operations.")
+        if _is_mac and hvd.gloo_built() and not hvd.mpi_built():
+            self.skipTest("ReducescatterGloo is not supported on macOS")
+        hvd.init()
+        rank = hvd.rank()
+        size = hvd.size()
+        dtypes = self.filter_supported_types([torch.IntTensor, torch.LongTensor,
+                                              torch.FloatTensor, torch.DoubleTensor,
+                                              torch.HalfTensor])
+        if torch.cuda.is_available():
+            dtypes += [torch.cuda.IntTensor, torch.cuda.LongTensor,
+                       torch.cuda.FloatTensor, torch.cuda.DoubleTensor,
+                       torch.cuda.HalfTensor]
+        int_types = [torch.IntTensor, torch.LongTensor,
+                     torch.cuda.IntTensor, torch.cuda.LongTensor]
+        half_types = [torch.HalfTensor, torch.cuda.HalfTensor]
+        dims = [1, 2, 3]
+        np.random.seed(12345)
+        for dtype, dim in itertools.product(dtypes, dims):
+            torch.manual_seed(1234)
+            factor = np.random.uniform()
+            tensors = [torch.FloatTensor(*([size * 4] * dim)).random_(-100, 100) for _ in range(5)]
+            tensors = [self.cast_and_place(tensor, dtype) for tensor in tensors]
+            summed_list = hvd.grouped_reducescatter(tensors, op=hvd.Sum, postscale_factor=factor)
+
+            factor = torch.tensor(factor, dtype=torch.float64)
+            factor = factor.cuda(hvd.local_rank()) if dtype.is_cuda else factor
+            if dtype.is_cuda and not int(os.environ.get('HOROVOD_MIXED_INSTALL', 0)):
+              # For integer types, scaling done in FP64
+              factor = factor.type(torch.float64 if dtype in int_types else dtype)
+              tensors = [tensor.type(torch.float64 if dtype in int_types else dtype) for tensor in tensors]
+            else:
+              # For integer types, scaling done in FP64, FP32 math for FP16 on CPU
+              factor = factor.type(torch.float32 if dtype in half_types else
+                                   torch.float64 if dtype in int_types else dtype)
+              tensors = [tensor.type(torch.float32 if dtype in half_types else
+                                     torch.float64 if dtype in int_types else dtype) for tensor in tensors]
+
+            multiplied_list = [factor * (size * tensor) for tensor in tensors]
+            multiplied_list = [multiplied.type(dtype) for multiplied in multiplied_list]
+
+            multiplied_list, summed_list = zip(*[self.convert_cpu_fp16_to_fp32(multiplied, summed)
+                                                 for multiplied, summed in zip(multiplied_list, summed_list)])
+            expected = [multiplied[rank * 4:(rank + 1) * 4] for multiplied in multiplied_list]
+
+            # Threshold for floating point equality depends on number of
+            # ranks, since we're comparing against precise multiplication.
+            if size <= 3 or dtype in int_types:
+                threshold = 0
+            elif size < 10:
+                threshold = 1e-4
+            elif size < 15:
+                threshold = 5e-4
+            else:
+                break
+
+            assert all([torch.allclose(t1, t2, threshold) for t1, t2 in zip(expected, summed_list)]), \
+                'hvd.grouped_reducescatter produces incorrect results'
+
 
     def test_horovod_grouped_reducescatter_scalar_error(self):
         if hvd.ccl_built():


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This adds support for the `prescale_factor` and `postscale_factor` arguments to the Reducescatter op. They are equivalent to the arguments of the same name for the Allreduce op. Averaging is now implemented via postscaling with a factor of `1. / process_set.size()`.

In contrast to Allreduce, we can't do the prescaling on the buffer allocated for the output tensor. This is because with Reducescatter the output tensor is smaller than the input tensor, but all input elements need to be prescaled. To avoid an extra temporary allocation, I decided to use the fusion buffer to do this scaling even for unfused tensors (at least with MPI and NCCL; with Gloo we already use a temporary buffer and I haven't updated that part). Of course, this requires the user to enable a sufficiently large fusion buffer if they want to use Reducescatter with prescaling -- even if they do not actually use tensor fusion. I would be open to discussing alternative approaches if we have concerns about this.

Support implemented for:
- [x] TensorFlow
- [x] PyTorch
- [x] MXNet

Resolves #3708.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
