### PR TITLE
Update message_generated.h to match flatbuffers schema

### DIFF
--- a/horovod/common/wire/message_generated.h
+++ b/horovod/common/wire/message_generated.h
@@ -98,9 +98,9 @@ enum ReduceOp : int8_t {
   ReduceOp_ADASUM = 2,
   ReduceOp_MIN_ = 3,
   ReduceOp_MAX_ = 4,
-  ReduceOp_PROD = 5,
+  ReduceOp_PRODUCT = 5,
   ReduceOp_MIN = ReduceOp_AVERAGE,
-  ReduceOp_MAX = ReduceOp_PROD
+  ReduceOp_MAX = ReduceOp_PRODUCT
 };
 
 inline const ReduceOp (&EnumValuesReduceOp())[6] {
@@ -110,7 +110,7 @@ inline const ReduceOp (&EnumValuesReduceOp())[6] {
     ReduceOp_ADASUM,
     ReduceOp_MIN_,
     ReduceOp_MAX_,
-    ReduceOp_PROD
+    ReduceOp_PRODUCT
   };
   return values;
 }
@@ -122,14 +122,14 @@ inline const char * const *EnumNamesReduceOp() {
     "ADASUM",
     "MIN_",
     "MAX_",
-    "PROD",
+    "PRODUCT",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameReduceOp(ReduceOp e) {
-  if (flatbuffers::IsOutRange(e, ReduceOp_AVERAGE, ReduceOp_PROD)) return "";
+  if (flatbuffers::IsOutRange(e, ReduceOp_AVERAGE, ReduceOp_PRODUCT)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesReduceOp()[index];
 }


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Here I've just run `flatc` on `horovod/common/wire/message_generated.fbs`. The generated header file was out of sync regarding one of the `ReduceOp` enum names (as pointed out in #3812). 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
