### PR TITLE
Fix broken TF DistributedOptimizer with Keras 2.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed memory leak in MPI_GPUAllgather. ([#3727](https://github.com/horovod/horovod/pull/3727))
 - Handle tf.IndexedSlices types when scaling local gradients in TF. ([#3786](https://github.com/horovod/horovod/pull/3786))
 - Several fixes for allreduce and grouped allreduce handling of tf.IndexedSlices. ([#3813](https://github.com/horovod/horovod/pull/3813))
-
+- Fix broken TF DistributedOptimizer with Keras 2.11+, ([#3822](https://github.com/horovod/horovod/pull/3822))
 
 ## [v0.26.1] - 2022-10-14
 

--- a/examples/tensorflow2/tensorflow2_keras_mnist.py
+++ b/examples/tensorflow2/tensorflow2_keras_mnist.py
@@ -20,6 +20,11 @@ import tensorflow as tf
 import horovod
 import horovod.tensorflow.keras as hvd
 
+from packaging import version
+if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+    from tensorflow.keras import optimizers
+else:
+    from tensorflow.keras.optimizers import legacy as optimizers
 
 def main():
     # Horovod: initialize Horovod.
@@ -54,7 +59,7 @@ def main():
 
     # Horovod: adjust learning rate based on number of GPUs.
     scaled_lr = 0.001 * hvd.size()
-    opt = tf.optimizers.Adam(scaled_lr)
+    opt = optimizers.Adam(scaled_lr)
 
     # Horovod: add Horovod DistributedOptimizer.
     opt = hvd.DistributedOptimizer(

--- a/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
+++ b/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
@@ -21,6 +21,11 @@ from filelock import FileLock
 import horovod.tensorflow.keras as hvd
 from horovod.tensorflow.data.compute_service import TfDataServiceConfig
 
+from packaging import version
+if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+    from tf.keras.optimizers import Optimizer
+else:
+    from tf.keras.optimizers.legacy import Optimizer
 
 # arguments reuse_dataset and round_robin only used when single dispatcher is present
 def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, round_robin: bool = False):
@@ -64,7 +69,7 @@ def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, r
 
     # Horovod: adjust learning rate based on number of GPUs.
     scaled_lr = 0.001 * hvd.size()
-    opt = tf.optimizers.Adam(scaled_lr)
+    opt = Optimizer.Adam(scaled_lr)
 
     # Horovod: add Horovod DistributedOptimizer.
     opt = hvd.DistributedOptimizer(

--- a/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
+++ b/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
@@ -23,9 +23,9 @@ from horovod.tensorflow.data.compute_service import TfDataServiceConfig
 
 from packaging import version
 if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tf.keras.optimizers import Optimizer
+    from tensorflow.keras.optimizers import Optimizer
 else:
-    from tf.keras.optimizers.legacy import Optimizer
+    from tensorflow.keras.optimizers.legacy import Optimizer
 
 # arguments reuse_dataset and round_robin only used when single dispatcher is present
 def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, round_robin: bool = False):

--- a/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
+++ b/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
@@ -23,9 +23,9 @@ from horovod.tensorflow.data.compute_service import TfDataServiceConfig
 
 from packaging import version
 if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tensorflow.keras.optimizers import Optimizer
+    from tensorflow.keras import optimizers
 else:
-    from tensorflow.keras.optimizers.legacy import Optimizer
+    from tensorflow.keras.optimizers import legacy as optimizers
 
 # arguments reuse_dataset and round_robin only used when single dispatcher is present
 def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, round_robin: bool = False):
@@ -69,7 +69,7 @@ def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, r
 
     # Horovod: adjust learning rate based on number of GPUs.
     scaled_lr = 0.001 * hvd.size()
-    opt = Optimizer.Adam(scaled_lr)
+    opt = optimizers.Adam(scaled_lr)
 
     # Horovod: add Horovod DistributedOptimizer.
     opt = hvd.DistributedOptimizer(

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -27,13 +27,35 @@ _PRE_TF_2_4_0 = version.parse(tf.__version__) < version.parse('2.4.0')
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
 
 
+def support_non_legacy_keras_optimizers(keras):
+    return version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11")
+
+
+def get_keras_optimizer_base_type(keras):
+    if support_non_legacy_keras_optimizers(keras):
+        return keras.optimizers.Optimizer
+    else:
+        return keras.optimizers.legacy.Optimizer
+
+
+def check_keras_optimizer_type(keras, optimizer):
+    if support_non_legacy_keras_optimizers(keras):
+        if not isinstance(optimizer, keras.optimizers.Optimizer):
+            raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
+    else:
+        if not isinstance(optimizer, keras.optimizers.legacy.Optimizer):
+            raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
+
+
 def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
                                  compression, sparse_as_dense, gradient_predivide_factor,
                                  op, backward_passes_per_step=1,
                                  average_aggregated_gradients=False,
                                  groups=None, process_set=hvd.global_process_set,
                                  scale_local_gradients=True):
-    class _DistributedOptimizer(keras.optimizers.Optimizer):
+    check_keras_optimizer_type(keras, optimizer)
+
+    class _DistributedOptimizer(get_keras_optimizer_base_type(keras)):
         _HAS_AGGREGATE_GRAD = True
 
         def __init__(self, **kwargs):
@@ -264,11 +286,7 @@ def reducescatter(backend, value, name, op):
 
 
 def load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects):
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        keras_subclasses = keras.optimizers.Optimizer.__subclasses__()
-    else:
-        keras_subclasses = keras.optimizers.legacy.Optimizer.__subclasses__()
-
+    keras_subclasses = get_keras_optimizer_base_type(keras).__subclasses__()
     horovod_objects = {
         subclass.__name__.lower(): wrap_optimizer(subclass)
         for subclass in keras_subclasses

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -31,16 +31,12 @@ def get_keras_optimizer_base_type(k):
     if support_non_legacy_keras_optimizers(k):
         return k.optimizers.Optimizer
     else:
-        # Optimizers from both tf.keras and keras come from keras package
-        import keras
-        return keras.optimizers.optimizer_v2.optimizer_v2.OptimizerV2
+        return tf.keras.optimizers.legacy.Optimizer
 
 
 def check_keras_optimizer_type(k, optimizer):
     if not support_non_legacy_keras_optimizers(k):
-        # Optimizers from both tf.keras and keras come from keras package
-        import keras
-        if not isinstance(optimizer, keras.optimizers.optimizer_v2.optimizer_v2.OptimizerV2):
+        if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
             raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
 
 

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -37,10 +37,7 @@ def get_keras_optimizer_base_type(k):
 
 
 def check_keras_optimizer_type(k, optimizer):
-    if support_non_legacy_keras_optimizers(k):
-        if not isinstance(optimizer, k.optimizers.Optimizer):
-            raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
-    else:
+    if not support_non_legacy_keras_optimizers(k):
         # Optimizers from both tf.keras and keras come from keras package
         import keras
         if not isinstance(optimizer, keras.optimizers.optimizer_v2.optimizer_v2.OptimizerV2):

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -21,14 +21,10 @@ import tensorflow as tf
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
 from horovod.tensorflow.gradient_aggregation_eager import LocalGradientAggregationHelperEager
 from horovod.tensorflow.mpi_ops import rank, size_op
-
+from horovod.common.util import support_non_legacy_keras_optimizers
 
 _PRE_TF_2_4_0 = version.parse(tf.__version__) < version.parse('2.4.0')
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
-
-
-def support_non_legacy_keras_optimizers(k):
-    return version.parse(k.__version__.replace("-tf", "+tf")) < version.parse("2.11")
 
 
 def get_keras_optimizer_base_type(k):

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -27,23 +27,27 @@ _PRE_TF_2_4_0 = version.parse(tf.__version__) < version.parse('2.4.0')
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
 
 
-def support_non_legacy_keras_optimizers(keras):
-    return version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11")
+def support_non_legacy_keras_optimizers(k):
+    return version.parse(k.__version__.replace("-tf", "+tf")) < version.parse("2.11")
 
 
-def get_keras_optimizer_base_type(keras):
-    if support_non_legacy_keras_optimizers(keras):
-        return keras.optimizers.Optimizer
+def get_keras_optimizer_base_type(k):
+    if support_non_legacy_keras_optimizers(k):
+        return k.optimizers.Optimizer
     else:
-        return keras.optimizers.legacy.Optimizer
+        # Optimizers from both tf.keras and keras come from keras package
+        import keras
+        return keras.optimizers.optimizer_v2.optimizer_v2.OptimizerV2
 
 
-def check_keras_optimizer_type(keras, optimizer):
-    if support_non_legacy_keras_optimizers(keras):
-        if not isinstance(optimizer, keras.optimizers.Optimizer):
+def check_keras_optimizer_type(k, optimizer):
+    if support_non_legacy_keras_optimizers(k):
+        if not isinstance(optimizer, k.optimizers.Optimizer):
             raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
     else:
-        if not isinstance(optimizer, keras.optimizers.legacy.Optimizer):
+        # Optimizers from both tf.keras and keras come from keras package
+        import keras
+        if not isinstance(optimizer, keras.optimizers.optimizer_v2.optimizer_v2.OptimizerV2):
             raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
 
 

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -23,6 +23,7 @@ import sysconfig
 import warnings
 
 from contextlib import contextmanager
+from packaging import version
 
 from horovod.common.exceptions import get_version_mismatch_message, HorovodVersionMismatchError
 
@@ -286,3 +287,7 @@ def is_version_greater_equal_than(ver, target):
                          "of: major.minor.patch. Received: {}".format(target))
 
     return version.parse(ver) >= version.parse(target)
+
+
+def support_non_legacy_keras_optimizers(k):
+    return version.parse(k.__version__.replace("-tf", "+tf")) < version.parse("2.11")

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -129,7 +129,7 @@ def PartialDistributedOptimizer(optimizer, name=None,
     Args:
         optimizer: Optimizer to use for computing gradients and applying updates.
         process_set: Gradients will only be reduced over Horovod processes belonging
-                   to this process set. Defaults to the global process set.  
+                   to this process set. Defaults to the global process set.
         local_layers: A collection of type tf.keras.layers.Layer local layers that their gradients need not
             to be synced accross ranks and is kept and applied locally.
             If not provided, the functionality of PartialDistributedOptimizer is
@@ -282,8 +282,5 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_modules = {keras.optimizers.Optimizer.__module__}
-    else:
-        optimizer_modules = {keras.optimizers.legacy.Optimizer.__module__}
+    optimizer_modules = {_impl.get_keras_optimizer_base_type(keras).__module__}
     return _impl.load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects)

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -35,6 +35,7 @@ from horovod.spark.keras import remote
 from horovod.spark.keras.util import TFKerasUtil
 from horovod.spark.keras.datamodule import PetastormDataModule
 
+from horovod._keras import check_keras_optimizer_type
 
 class KerasEstimatorParamsWriter(HorovodParamsWriter):
     def saveImpl(self, path):
@@ -230,12 +231,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
             if isinstance(optimizer, str):
                 pass
             else:
-                if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-                    if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
-                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
-                else:
-                    if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
-                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
+                check_keras_optimizer_type(tf.keras, optimizer)
 
         return TFKerasUtil
 

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -20,15 +20,13 @@ import h5py
 from packaging import version
 from horovod.runner.common.util import codec
 
+from horovod._keras import get_keras_optimizer_base_type
 
 def serialize_bare_keras_optimizer(x):
     import keras
     from horovod.spark.keras.bare import save_bare_keras_optimizer
 
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_class = keras.optimizers.Optimizer
-    else:
-        optimizer_class = keras.optimizers.legacy.Optimizer
+    optimizer_class = get_keras_optimizer_base_type(keras)
 
     return _serialize_keras_optimizer(x,
                                       optimizer_class=optimizer_class,
@@ -45,10 +43,7 @@ def serialize_tf_keras_optimizer(x):
     import tensorflow as tf
     from horovod.spark.keras.tensorflow import save_tf_keras_optimizer
 
-    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_class = tf.keras.optimizers.Optimizer
-    else:
-        optimizer_class = tf.keras.optimizers.legacy.Optimizer
+    optimizer_class = get_keras_optimizer_base_type(tf.keras)
 
     return _serialize_keras_optimizer(x,
                                       optimizer_class=optimizer_class,

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -43,7 +43,7 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache, 
 from horovod.tensorflow.mpi_ops import join
 from horovod.tensorflow.sync_batch_norm import SyncBatchNormalization
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
-from horovod._keras import support_non_legacy_keras_optimizers
+from horovod.common.util import support_non_legacy_keras_optimizers
 
 import tensorflow as tf
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -43,6 +43,7 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache, 
 from horovod.tensorflow.mpi_ops import join
 from horovod.tensorflow.sync_batch_norm import SyncBatchNormalization
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
+from horovod._keras import get_keras_optimizer_base_type
 
 import tensorflow as tf
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
@@ -667,7 +668,7 @@ if _LegacyOptimizer is not None:
         def register_local_var(self, var):
             """Registers a source/variable as worker local. Horovod will not perform any global
             operations on gradients corresponding to these sources and will instead return the local
-            gradient."""    
+            gradient."""
             if self._agg_helper:
                 self._agg_helper.register_local_var(var)
             elif _IS_TF2:
@@ -976,7 +977,7 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             process_set=process_set,
             scale_local_gradients=scale_local_gradients
         )
-    elif isinstance(optimizer, tf.keras.optimizers.Optimizer):
+    elif isinstance(optimizer, get_keras_optimizer_base_type(tf.keras)):
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -43,7 +43,6 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache, 
 from horovod.tensorflow.mpi_ops import join
 from horovod.tensorflow.sync_batch_norm import SyncBatchNormalization
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
-from horovod._keras import get_keras_optimizer_base_type
 
 import tensorflow as tf
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -977,7 +977,8 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             process_set=process_set,
             scale_local_gradients=scale_local_gradients
         )
-    elif isinstance(optimizer, get_keras_optimizer_base_type(tf.keras)):
+    elif (isinstance(optimizer, tf.keras.optimizers.Optimizer) or
+          isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer)):
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
 

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -43,6 +43,7 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache, 
 from horovod.tensorflow.mpi_ops import join
 from horovod.tensorflow.sync_batch_norm import SyncBatchNormalization
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
+from horovod._keras import support_non_legacy_keras_optimizers
 
 import tensorflow as tf
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
@@ -977,7 +978,8 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             scale_local_gradients=scale_local_gradients
         )
     elif (isinstance(optimizer, tf.keras.optimizers.Optimizer) or
-          isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer)):
+          (not support_non_legacy_keras_optimizers(tf.keras) and
+           isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer))):
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
 

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -49,10 +49,7 @@ from horovod.tensorflow.keras import callbacks, elastic
 try:
     # In later versions of TensorFlow, optimizers are spread across multiple modules. This set is used to distinguish
     # stock optimizers that come with tf.keras from custom optimizers that may need to be wrapped specially.
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_type = tf.keras.optimizers.Optimizer
-    else:
-        optimizer_type = keras.optimizers.legacy.Optimizer
+    optimizer_type = _impl.get_keras_optimizer_base_type(tf.keras)
 
     _OPTIMIZER_MODULES = set([obj.__module__ for name, obj in inspect.getmembers(tf.keras.optimizers)
                               if isinstance(obj, type(optimizer_type))])

--- a/test/integration/data/elastic_tensorflow2_main.py
+++ b/test/integration/data/elastic_tensorflow2_main.py
@@ -25,9 +25,9 @@ import horovod.tensorflow as hvd
 
 from packaging import version
 if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tf.keras.optimizers import Optimizer
+    from tensorflow.keras.optimizers import Optimizer
 else:
-    from tf.keras.optimizers.legacy import Optimizer
+    from tensorflow.keras.optimizers.legacy import Optimizer
 
 parser = argparse.ArgumentParser(description='TensorFlow 2 Elastic Test',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/test/integration/data/elastic_tensorflow2_main.py
+++ b/test/integration/data/elastic_tensorflow2_main.py
@@ -23,6 +23,12 @@ import tensorflow as tf
 
 import horovod.tensorflow as hvd
 
+from packaging import version
+if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+    from tf.keras.optimizers import Optimizer
+else:
+    from tf.keras.optimizers.legacy import Optimizer
+
 parser = argparse.ArgumentParser(description='TensorFlow 2 Elastic Test',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -58,7 +64,7 @@ target = tf.one_hot(indices, 2)
 
 lr = 0.001
 model = tf.keras.Sequential([tf.keras.layers.Dense(2, activation='softmax')])
-optimizer = tf.optimizers.SGD(lr * hvd.size())
+optimizer = Optimizer.SGD(lr * hvd.size())
 
 hostname = os.environ.get('HOROVOD_HOSTNAME')
 start_rank = int(os.environ.get('HOROVOD_RANK', 0))

--- a/test/integration/data/elastic_tensorflow2_main.py
+++ b/test/integration/data/elastic_tensorflow2_main.py
@@ -25,9 +25,9 @@ import horovod.tensorflow as hvd
 
 from packaging import version
 if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tensorflow.keras.optimizers import Optimizer
+    from tensorflow.keras import optimizers
 else:
-    from tensorflow.keras.optimizers.legacy import Optimizer
+    from tensorflow.keras.optimizers import legacy as optimizers
 
 parser = argparse.ArgumentParser(description='TensorFlow 2 Elastic Test',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -64,7 +64,7 @@ target = tf.one_hot(indices, 2)
 
 lr = 0.001
 model = tf.keras.Sequential([tf.keras.layers.Dense(2, activation='softmax')])
-optimizer = Optimizer.SGD(lr * hvd.size())
+optimizer = optimizers.SGD(lr * hvd.size())
 
 hostname = os.environ.get('HOROVOD_HOSTNAME')
 start_rank = int(os.environ.get('HOROVOD_RANK', 0))

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -43,9 +43,9 @@ import horovod.tensorflow.keras as hvd
 
 from packaging import version
 if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from keras.optimizers import Optimizer
+    from keras import optimizers
 else:
-    from keras.optimizers.legacy import Optimizer
+    from keras.optimizers import legacy as optimizers
 
 _PRE_TF_2_2_0 = version.parse(tf.__version__) < version.parse("2.2.0")
 
@@ -71,10 +71,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_train_model_lr_schedule(self):
         initial_lr = 0.1 * hvd.size()
-        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            opt = tf.keras.optimizers.Adam()
-        else:
-            opt = tf.keras.optimizers.legacy.Adam()
+        opt = optimizers.Adam()
         opt = hvd.DistributedOptimizer(opt)
 
         def linear_multiplier(epoch):
@@ -164,10 +161,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
     def test_sparse_as_dense_with_grad_aggregation(self):
         backward_passes_per_step = 2
-        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            opt = keras.optimizers.RMSprop(lr=0.0001)
-        else:
-            opt = keras.optimizers.legacy.RMSprop(lr=0.0001)
+        opt = optimizers.RMSprop(lr=0.0001)
         opt = hvd.DistributedOptimizer(
             opt,
             sparse_as_dense=True,
@@ -193,10 +187,7 @@ class Tf2KerasTests(tf.test.TestCase):
     def test_grad_aggregation_with_inf_grad(self):
         backward_passes_per_step = 2
         step_count = tf.Variable(0, trainable=False, dtype=tf.int32)
-        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            opt = tf.keras.optimizers.SGD()
-        else:
-            opt = tf.keras.optimizers.legacy.SGD()
+        opt = optimizers.SGD()
         opt = hvd.DistributedOptimizer(
             opt,
             backward_passes_per_step=backward_passes_per_step,
@@ -221,10 +212,7 @@ class Tf2KerasTests(tf.test.TestCase):
         assert tf.math.is_finite(grads_and_vars[0][0])
 
     def test_from_config(self):
-        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            opt = keras.optimizers.Adam()
-        else:
-            opt = keras.optimizers.legacy.Adam()
+        opt = optimizers.Adam()
         hopt = hvd.DistributedOptimizer(opt)
         cfg = hopt.get_config()
 
@@ -252,7 +240,7 @@ class Tf2KerasTests(tf.test.TestCase):
             [np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
              np.array([0.0, 0.0], dtype=np.float32)])
 
-        optimizer = Optimizer.Adam(0.001 * hvd.size())
+        optimizer = optimizers.Adam(0.001 * hvd.size())
 
         state = hvd.elastic.KerasState(
             model1,
@@ -543,10 +531,7 @@ class Tf2KerasTests(tf.test.TestCase):
             model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))
             model.add(tf.keras.layers.RepeatVector(3))
             model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(3, kernel_initializer=initializer, bias_initializer=initializer)))
-            if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-                opt = tf.keras.optimizers.Adam()
-            else:
-                opt = tf.keras.optimizers.legacy.Adam()
+            opt = optimizers.legacy.Adam()
             model.compile(loss=tf.keras.losses.MSE,
                             metrics=[tf.keras.metrics.categorical_accuracy])
 

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -145,7 +145,7 @@ class Tf2KerasTests(tf.test.TestCase):
         self.assertAllClose(expected_loss_metrics_tensor, loss_metrics_tensor)
 
     def test_sparse_as_dense(self):
-        opt = keras.optimizers.RMSprop(lr=0.0001)
+        opt = optimizers.RMSprop(lr=0.0001)
         opt = hvd.DistributedOptimizer(opt, sparse_as_dense=True)
 
         model = keras.models.Sequential()
@@ -531,7 +531,7 @@ class Tf2KerasTests(tf.test.TestCase):
             model.add(tf.keras.layers.Dense(2, input_shape=(3,), kernel_initializer=initializer, bias_initializer=initializer))
             model.add(tf.keras.layers.RepeatVector(3))
             model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(3, kernel_initializer=initializer, bias_initializer=initializer)))
-            opt = optimizers.legacy.Adam()
+            opt = optimizers.Adam()
             model.compile(loss=tf.keras.losses.MSE,
                             metrics=[tf.keras.metrics.categorical_accuracy])
 

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -41,6 +41,11 @@ else:
 import horovod.keras as hvd_keras
 import horovod.tensorflow.keras as hvd
 
+from packaging import version
+if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+    from keras.optimizers import Optimizer
+else:
+    from keras.optimizers.legacy import Optimizer
 
 _PRE_TF_2_2_0 = version.parse(tf.__version__) < version.parse("2.2.0")
 
@@ -247,7 +252,7 @@ class Tf2KerasTests(tf.test.TestCase):
             [np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
              np.array([0.0, 0.0], dtype=np.float32)])
 
-        optimizer = tf.optimizers.Adam(0.001 * hvd.size())
+        optimizer = Optimizer.Adam(0.001 * hvd.size())
 
         state = hvd.elastic.KerasState(
             model1,

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -43,9 +43,9 @@ import horovod.tensorflow.keras as hvd
 
 from packaging import version
 if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from keras import optimizers
+    from tensorflow.keras import optimizers
 else:
-    from keras.optimizers import legacy as optimizers
+    from tensorflow.keras.optimizers import legacy as optimizers
 
 _PRE_TF_2_2_0 = version.parse(tf.__version__) < version.parse("2.2.0")
 


### PR DESCRIPTION
Signed-off-by: Nicolas Castet <ncastet@nvidia.com>

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Horovod was only checking for `tf.keras.optimizers.Optimizer` in  `DistributedOptimizer` but supported optimizers are under `tf.keras.optimizers.legacy.Optimizer` for Keras 2.11+.

