### PR TITLE
Reducescatter: Allocate output tensors before enqueuing the operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added `HOROVOD_SPARK_USE_LOCAL_RANK_GPU_INDEX` environment variable to ignore GPU device indices assigned by Spark and always use local rank GPU device in Spark estimators. ([#3737](https://github.com/horovod/horovod/pull/3737))
-
+ 
 - Reducescatter: Added support for prescale_factor and postscale_factor and moved averaging into Horovod backend. ([#3815](https://github.com/horovod/horovod/pull/3815))
 
 ### Changed
 
 - Improved NCCL performance for fused allgather operations through padding for better memory alignment. ([#3727](https://github.com/horovod/horovod/pull/3727))
 - Improved look-ahead tensor fusion buffer size estimates when allgather and other operations are mixed. ([#3727](https://github.com/horovod/horovod/pull/3727))
+- Improved reducescatter performance by allocating output tensors before enqueuing the operation. ([#3824](https://github.com/horovod/horovod/pull/3824))
 
 ### Deprecated
 

--- a/horovod/common/common.h
+++ b/horovod/common/common.h
@@ -365,8 +365,8 @@ struct TensorTableEntry {
   std::shared_ptr<Tensor> tensor;
   // Pre-allocated output tensor.
   std::shared_ptr<Tensor> output;
-  // Grouped Reducescatter or Allgather ops will need to allocate memory for
-  // a specific output_index >= 0.
+  // Grouped Allgather ops will need to allocate memory for a specific
+  // output_index >= 0.
   int32_t output_index = 0;
   // Identifier for the subset of Horovod processes partaking in this operation.
   int32_t process_set_id = 0;

--- a/horovod/common/operations.h
+++ b/horovod/common/operations.h
@@ -238,14 +238,15 @@ Status EnqueueTensorAlltoall(std::shared_ptr<OpContext> context,
 
 Status EnqueueTensorReducescatter(
     std::shared_ptr<OpContext> context, std::shared_ptr<Tensor> tensor,
-    ReadyEventList ready_event_list, const std::string& name, int device,
-    StatusCallback callback, ReduceOp reduce_op = ReduceOp::SUM,
-    int32_t process_set_id = 0, double prescale_factor = 1.0,
-    double postscale_factor = 1.0);
+    std::shared_ptr<Tensor> output, ReadyEventList ready_event_list,
+    const std::string& name, int device, StatusCallback callback,
+    ReduceOp reduce_op = ReduceOp::SUM, int32_t process_set_id = 0,
+    double prescale_factor = 1.0, double postscale_factor = 1.0);
 
 Status EnqueueTensorReducescatters(
     std::vector<std::shared_ptr<OpContext>>& contexts,
     std::vector<std::shared_ptr<Tensor>>& tensors,
+    std::vector<std::shared_ptr<Tensor>>& outputs,
     std::vector<ReadyEventList>& ready_event_lists,
     std::vector<std::string>& names, int device,
     std::vector<StatusCallback>& callbacks, ReduceOp reduce_op = ReduceOp::SUM,

--- a/horovod/common/ops/collective_operations.h
+++ b/horovod/common/ops/collective_operations.h
@@ -278,20 +278,16 @@ public:
                        const std::vector<TensorTableEntry>& entries,
                        const Response& response) const = 0;
 
-protected:
-  virtual TensorShape ComputeOutputShapeForRank(const TensorShape& tensor_shape,
-                                                int rank,
-                                                int global_size) const;
+  static TensorShape ComputeOutputShapeForRank(const TensorShape& tensor_shape,
+                                               int rank, int global_size);
 
+protected:
   virtual std::vector<std::vector<TensorShape>>
   ComputeOutputShapes(const std::vector<TensorTableEntry>& entries,
                       int global_size) const;
 
   virtual std::vector<int> ComputeReceiveCounts(
       const std::vector<std::vector<TensorShape>>& output_shapes) const;
-
-  virtual Status AllocateOutput(std::vector<TensorTableEntry>& entries,
-                                const std::vector<TensorShape>& output_shapes);
 
   virtual void MemcpyInFusionBuffer(
       const std::vector<TensorTableEntry>& entries,

--- a/horovod/common/ops/gloo_operations.cc
+++ b/horovod/common/ops/gloo_operations.cc
@@ -424,17 +424,9 @@ Status GlooReducescatter::Execute(std::vector<TensorTableEntry>& entries,
   void* buffer_data = nullptr;
   int num_elements = (int)NumElements(entries);
 
-  int global_rank = process_set.controller->GetRank();
   int global_size = process_set.controller->GetSize();
   auto output_shapes = ComputeOutputShapes(entries, global_size);
   std::vector<int> recvcounts = ComputeReceiveCounts(output_shapes);
-
-  timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, output_shapes[global_rank]);
-  if (!status.ok()) {
-    return status;
-  }
-  timeline.ActivityEndAll(entries);
 
   std::unique_ptr<IGlooAlgorithms> gloo_algos(
       GetAlgorithmsForType(first_entry.tensor->dtype(), &gloo_context));

--- a/horovod/common/ops/mpi_gpu_operations.cc
+++ b/horovod/common/ops/mpi_gpu_operations.cc
@@ -303,17 +303,9 @@ Status MPI_GPUReducescatter::Execute(std::vector<TensorTableEntry>& entries,
   const void* sendbuf = nullptr;
   void* recvbuf = nullptr;
 
-  int global_rank = process_set.controller->GetRank();
   int global_size = process_set.controller->GetSize();
   auto output_shapes = ComputeOutputShapes(entries, global_size);
   std::vector<int> recvcounts = ComputeReceiveCounts(output_shapes);
-
-  timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, output_shapes[global_rank]);
-  if (!status.ok()) {
-    return status;
-  }
-  timeline.ActivityEndAll(entries);
 
   // Copy memory into the fusion buffer. Execute prescaling op if necessary.
   if (entries.size() > 1 || prescale_factor != 1.0) {

--- a/horovod/common/ops/mpi_operations.cc
+++ b/horovod/common/ops/mpi_operations.cc
@@ -498,17 +498,9 @@ Status MPIReducescatter::Execute(std::vector<TensorTableEntry>& entries,
   const void* sendbuf = nullptr;
   void* recvbuf = nullptr;
 
-  int global_rank = process_set.controller->GetRank();
   int global_size = process_set.controller->GetSize();
   auto output_shapes = ComputeOutputShapes(entries, global_size);
   std::vector<int> recvcounts = ComputeReceiveCounts(output_shapes);
-
-  timeline.ActivityStartAll(entries, ALLOCATE_OUTPUT);
-  Status status = AllocateOutput(entries, output_shapes[global_rank]);
-  if (!status.ok()) {
-    return status;
-  }
-  timeline.ActivityEndAll(entries);
 
   // Copy memory into the fusion buffer. Execute prescaling op if necessary.
   if (entries.size() > 1 || prescale_factor != 1.0) {

--- a/horovod/common/ops/nccl_operations.h
+++ b/horovod/common/ops/nccl_operations.h
@@ -322,9 +322,6 @@ public:
                const Response& response) const override;
 
 protected:
-  Status AllocateOutput(std::vector<TensorTableEntry>& entries,
-                        const std::vector<TensorShape>& output_shapes) override;
-
   void WaitForData(std::vector<TensorTableEntry>& entries) override;
 
   NCCLContext* nccl_context_;

--- a/horovod/mxnet/mpi_ops.cc
+++ b/horovod/mxnet/mpi_ops.cc
@@ -16,9 +16,13 @@
 
 #include <atomic>
 
-#include "../common/operations.h"
 #include "cuda_util.h"
 #include "mpi_ops.h"
+
+// Undef LOG macro from MXNet
+#undef LOG
+#include "../common/operations.h"
+#include "../common/ops/collective_operations.h"
 
 #if MXNET_MAJOR >= 2 || MXNET_ASYNC_GPU_ENGINE_SUPPORTED
 #define MXNET_ASYNC_GPU_ENGINE_SUPPORTED 1
@@ -133,6 +137,29 @@ ReadyEventList FormReadyEventList(NDArray* input, NDArray* output) {
   return ready_event_list;
 }
 
+namespace {
+TensorShape
+GetReducescatterOutputShape(int process_set_id,
+                            const TensorShape& horovod_input_tensor_shape) {
+  if (horovod_input_tensor_shape.dims() == 0) {
+    throw std::invalid_argument("Reducescatter does not support scalar inputs");
+  }
+  int process_set_size = horovod_process_set_size(process_set_id);
+  if (process_set_size < 0) {
+    throw std::invalid_argument("Invalid process set id for this rank: " +
+                                std::to_string(process_set_id));
+  }
+  int process_set_rank = horovod_process_set_rank(process_set_id);
+  if (process_set_rank < 0) {
+    throw std::invalid_argument("Invalid process set id for this rank: " +
+                                std::to_string(process_set_id));
+  }
+  auto output_shape = ReducescatterOp::ComputeOutputShapeForRank(
+      horovod_input_tensor_shape, process_set_rank, process_set_size);
+  return output_shape;
+}
+} // namespace
+
 #if MXNET_ASYNC_GPU_ENGINE_SUPPORTED
 void DoHorovodOperation(void*, void* on_start_ptr, void* on_complete_ptr, void* param) {
   auto on_start = *static_cast<CallbackOnStart*>(on_start_ptr);
@@ -173,11 +200,9 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
     std::shared_ptr<MXOpContext> ctx;
-    if (ops_param->op_type == OperationType::ALLGATHER ||
-        ops_param->op_type == OperationType::REDUCESCATTER) {
-      // Grouped allgather and reducescatter operations will need to allocate
-      // the correct output tensor later on, therefore referring to all output
-      // tensors in context.
+    if (ops_param->op_type == OperationType::ALLGATHER) {
+      // Grouped allgather operations will need to allocate the correct output
+      // tensor later on, therefore referring to all output tensors in context.
       ctx = std::make_shared<MXOpContext>(device, ops_param->outputs);
     } else {
       ctx = std::make_shared<MXOpContext>(device, output);
@@ -187,13 +212,14 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
     }
     hvd_contexts.push_back(ctx);
     callbacks.emplace_back([on_complete, ops_param, callback_mutex, i](const Status& status) {
-      auto input_tensor = ops_param->input_tensors[i].get();
-      auto output_tensor = ops_param->output_tensors[i].get();
 #if HAVE_CUDA
       auto hvd_event = status.event;
       if (hvd_event.event) {
 #if MXNET_ASYNC_GPU_ENGINE_SUPPORTED
-        auto async_engine_enabled = dmlc::GetEnv("MXNET_ASYNC_GPU_ENGINE", false);
+        auto input_tensor = ops_param->input_tensors[i].get();
+        auto output_tensor = ops_param->output_tensors[i].get();
+        auto async_engine_enabled =
+            dmlc::GetEnv("MXNET_ASYNC_GPU_ENGINE", false);
         if (async_engine_enabled) {
           {
             auto &sync_obj = input_tensor->var()->sync_object;
@@ -296,12 +322,23 @@ void DoHorovodOperation(void*, void* on_complete_ptr, void* param) {
           ops_param->op_names[0], device, callbacks[0], process_set_id);
       break;
     }
-    case OperationType::REDUCESCATTER:
+    case OperationType::REDUCESCATTER: {
+      for (std::size_t i = 0; i < num_tensors; ++i) {
+        std::shared_ptr<Tensor> hvd_output =
+            std::make_shared<MXTensor>(ops_param->output_tensors[i].get());
+        auto output_shape = GetReducescatterOutputShape(
+            process_set_id, hvd_tensors[i]->shape());
+        hvd_contexts[i]->AllocateOutput(output_shape,
+                                        &hvd_output); // blocking
+        hvd_outputs.emplace_back(hvd_output);
+      }
+
       enqueue_result = EnqueueTensorReducescatters(
-          hvd_contexts, hvd_tensors, ready_event_lists, ops_param->op_names,
-          device, callbacks, reduce_op, process_set_id, prescale_factor,
-          postscale_factor);
+          hvd_contexts, hvd_tensors, hvd_outputs, ready_event_lists,
+          ops_param->op_names, device, callbacks, reduce_op, process_set_id,
+          prescale_factor, postscale_factor);
       break;
+    }
     default:
       throw std::logic_error("Unsupported Horovod operation type.");
   }
@@ -457,11 +494,9 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
     std::shared_ptr<MXOpContext> ctx;
-    if (ops_param->op_type == OperationType::ALLGATHER ||
-        ops_param->op_type == OperationType::REDUCESCATTER) {
-      // Grouped allgather and reducescatter operations will need to allocate
-      // the correct output tensor later on, therefore referring to all output
-      // tensors in context.
+    if (ops_param->op_type == OperationType::ALLGATHER) {
+      // Grouped allgather operations will need to allocate the correct output
+      // tensor later on, therefore referring to all output tensors in context.
       ctx = std::make_shared<MXOpContext>(device, outputs);
     } else {
       ctx = std::make_shared<MXOpContext>(device, output);
@@ -512,12 +547,24 @@ void DoHorovodOperationCudaOnCPU(void*, void* on_complete_ptr, void* param) {
         ops_param->op_names[0], device, callbacks[0], process_set_id);
     break;
   }
-  case OperationType::REDUCESCATTER:
+  case OperationType::REDUCESCATTER: {
+    std::vector<std::shared_ptr<Tensor>> hvd_outputs;
+    hvd_outputs.reserve(num_tensors);
+    for (std::size_t i = 0; i < num_tensors; ++i) {
+      std::shared_ptr<Tensor> hvd_output =
+          std::make_shared<MXTensor>(outputs[i]);
+      auto output_shape = GetReducescatterOutputShape(
+          process_set_id, hvd_cpu_buffers[i]->shape());
+      hvd_contexts[i]->AllocateOutput(output_shape,
+                                      &hvd_output); // blocking
+      hvd_outputs.emplace_back(hvd_output);
+    }
     enqueue_result = EnqueueTensorReducescatters(
-        hvd_contexts, hvd_cpu_buffers, ready_event_lists, ops_param->op_names,
-        device, callbacks, reduce_op, process_set_id, prescale_factor,
-        postscale_factor);
+        hvd_contexts, hvd_cpu_buffers, hvd_outputs, ready_event_lists,
+        ops_param->op_names, device, callbacks, reduce_op, process_set_id,
+        prescale_factor, postscale_factor);
     break;
+  }
   default:
     throw std::logic_error("Unsupported Horovod operation type.");
   }

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -1005,7 +1005,7 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
         cpu_tensor.options().merge_in(::torch::TensorOptions().memory_format(
             LEGACY_CONTIGUOUS_MEMORY_FORMAT)));
     auto hvd_context =
-        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs[i]);
+        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
     std::shared_ptr<common::Tensor> hvd_cpu_output =
         std::make_shared<TorchTensor>(cpu_output);
     TensorShape output_shape =

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -26,7 +26,10 @@
 #include <torch/extension.h>
 #include <torch/torch.h>
 
+// Undef LOG macro from Torch
+#undef LOG
 #include "../common/operations.h"
+#include "../common/ops/collective_operations.h"
 #include "adapter_v2.h"
 #include "cuda_util.h"
 #include "handle_manager.h"
@@ -709,6 +712,29 @@ int DoAlltoallCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor splits,
   return handle;
 }
 
+namespace {
+TensorShape
+GetReducescatterOutputShape(int process_set_id,
+                            const TensorShape& horovod_input_tensor_shape) {
+  if (horovod_input_tensor_shape.dims() == 0) {
+    throw std::invalid_argument("Reducescatter does not support scalar inputs");
+  }
+  int process_set_size = horovod_process_set_size(process_set_id);
+  if (process_set_size < 0) {
+    throw std::invalid_argument("Invalid process set id for this rank: " +
+                                std::to_string(process_set_id));
+  }
+  int process_set_rank = horovod_process_set_rank(process_set_id);
+  if (process_set_rank < 0) {
+    throw std::invalid_argument("Invalid process set id for this rank: " +
+                                std::to_string(process_set_id));
+  }
+  auto output_shape = ReducescatterOp::ComputeOutputShapeForRank(
+      horovod_input_tensor_shape, process_set_rank, process_set_size);
+  return output_shape;
+}
+} // namespace
+
 int DoReducescatter(::torch::Tensor tensor, ::torch::Tensor output,
                     const std::string& name, int reduce_op_int,
                     int process_set_id, double prescale_factor,
@@ -724,15 +750,25 @@ int DoReducescatter(::torch::Tensor tensor, ::torch::Tensor output,
 
   auto handle = handle_manager.AllocateHandle();
   auto device = GetDeviceID(tensor);
+  auto hvd_context = std::make_shared<TorchOpContext>(device, output);
+  std::shared_ptr<common::Tensor> hvd_output =
+      std::make_shared<TorchTensor>(output);
+  auto hvd_tensor = std::make_shared<TorchTensor>(tensor);
+  TensorShape output_shape =
+      GetReducescatterOutputShape(process_set_id, hvd_tensor->shape());
+
   common::ReadyEventList ready_event_list;
 #if HAVE_GPU
-  ready_event_list.AddReadyEvent(RecordReadyEvent(device));
-#endif
-  auto hvd_tensor = std::make_shared<TorchTensor>(tensor);
-  auto hvd_context = std::make_shared<TorchOpContext>(device, output);
+  std::shared_ptr<ReadyEvent> ready_event;
+  ThrowIfError(
+      hvd_context->AllocateOutput(output_shape, &hvd_output, &ready_event));
+  ready_event_list.AddReadyEvent(ready_event);
+#else
+  ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_output));
+#endif // HAVE_GPU
 
   auto enqueue_result = EnqueueTensorReducescatter(
-      hvd_context, hvd_tensor, ready_event_list,
+      hvd_context, hvd_tensor, hvd_output, ready_event_list,
       GetOpName("reducescatter", name, handle), device,
       [handle, reduce_op, output, device,
        process_set_id](const Status& status) mutable {
@@ -773,18 +809,30 @@ int DoReducescatterCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output,
   auto cpu_tensor =
       tensor.to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
-  common::ReadyEventList ready_event_list;
-#if HAVE_GPU
-  ready_event_list.AddReadyEvent(RecordReadyEvent(device));
-#endif
 
-  auto cpu_output = ::torch::empty_like(cpu_tensor);
+  auto cpu_output =
+      ::torch::empty({0}, cpu_tensor.options().merge_memory_format(
+                              LEGACY_CONTIGUOUS_MEMORY_FORMAT));
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
+  std::shared_ptr<common::Tensor> hvd_cpu_output =
+      std::make_shared<TorchTensor>(cpu_output);
+  TensorShape output_shape =
+      GetReducescatterOutputShape(process_set_id, hvd_cpu_tensor->shape());
+
+  common::ReadyEventList ready_event_list;
+#if HAVE_GPU
+  std::shared_ptr<ReadyEvent> ready_event;
+  ThrowIfError(
+      hvd_context->AllocateOutput(output_shape, &hvd_cpu_output, &ready_event));
+  ready_event_list.AddReadyEvent(ready_event);
+#else
+  ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_output));
+#endif // HAVE_GPU
 
   auto handle = handle_manager.AllocateHandle();
   auto enqueue_result = EnqueueTensorReducescatter(
-      hvd_context, hvd_cpu_tensor, ready_event_list,
+      hvd_context, hvd_cpu_tensor, hvd_cpu_output, ready_event_list,
       GetOpName("reducescatter", name, handle), CPU_DEVICE_ID,
       [handle, reduce_op, cpu_output, output, device,
        process_set_id](const Status& status) mutable {
@@ -825,12 +873,9 @@ int DoGroupedReducescatter(const std::vector<::torch::Tensor>& tensors,
 
   auto handle = handle_manager.AllocateHandle();
   auto device = GetDeviceID(tensors[0]);
-  common::ReadyEventList ready_event_list;
-#if HAVE_GPU
-  ready_event_list.AddReadyEvent(RecordReadyEvent(device));
-#endif
 
   std::vector<std::shared_ptr<Tensor>> hvd_tensors;
+  std::vector<std::shared_ptr<Tensor>> hvd_outputs;
   std::vector<std::shared_ptr<OpContext>> hvd_contexts;
   std::vector<common::ReadyEventList> ready_event_lists;
   std::vector<StatusCallback> callbacks;
@@ -838,6 +883,7 @@ int DoGroupedReducescatter(const std::vector<::torch::Tensor>& tensors,
 
   auto num_tensors = tensors.size();
   hvd_tensors.reserve(num_tensors);
+  hvd_outputs.reserve(num_tensors);
   hvd_contexts.reserve(num_tensors);
   ready_event_lists.reserve(num_tensors);
   names.reserve(num_tensors);
@@ -851,11 +897,25 @@ int DoGroupedReducescatter(const std::vector<::torch::Tensor>& tensors,
     if (GetDeviceID(tensors[i]) != device) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
-    hvd_tensors.emplace_back(std::make_shared<TorchTensor>(tensors[i]));
-    hvd_contexts.emplace_back(
-        std::make_shared<TorchOpContext>(device, outputs));
-    ready_event_lists.emplace_back(
-        ready_event_list); // Same for all tensors in group
+    auto hvd_context = std::make_shared<TorchOpContext>(device, outputs[i]);
+    std::shared_ptr<common::Tensor> hvd_output =
+        std::make_shared<TorchTensor>(outputs[i]);
+    auto hvd_tensor = std::make_shared<TorchTensor>(tensors[i]);
+    TensorShape output_shape =
+        GetReducescatterOutputShape(process_set_id, hvd_tensor->shape());
+    common::ReadyEventList ready_event_list;
+#if HAVE_GPU
+    std::shared_ptr<ReadyEvent> ready_event;
+    ThrowIfError(
+        hvd_context->AllocateOutput(output_shape, &hvd_output, &ready_event));
+    ready_event_list.AddReadyEvent(ready_event);
+#else
+    ThrowIfError(hvd_context->AllocateOutput((int)i, output_shape, &hvd_output));
+#endif // HAVE_GPU
+    hvd_tensors.emplace_back(hvd_tensor);
+    hvd_outputs.emplace_back(hvd_output);
+    hvd_contexts.emplace_back(hvd_context);
+    ready_event_lists.emplace_back(ready_event_list);
     names.emplace_back(base_name + "_" + std::to_string(i + 1) + "of" +
                        std::to_string(num_tensors));
     auto output = outputs[i];
@@ -883,8 +943,8 @@ int DoGroupedReducescatter(const std::vector<::torch::Tensor>& tensors,
   }
 
   auto enqueue_result = EnqueueTensorReducescatters(
-      hvd_contexts, hvd_tensors, ready_event_lists, names, device, callbacks,
-      request_op, process_set_id, prescale_factor, postscale_factor);
+      hvd_contexts, hvd_tensors, hvd_outputs, ready_event_lists, names, device,
+      callbacks, request_op, process_set_id, prescale_factor, postscale_factor);
   ThrowIfError(enqueue_result);
 
   return handle;
@@ -913,6 +973,7 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
 
   std::vector<std::shared_ptr<Tensor>> hvd_cpu_tensors;
   std::vector<::torch::Tensor> cpu_outputs;
+  std::vector<std::shared_ptr<Tensor>> hvd_cpu_outputs;
   std::vector<std::shared_ptr<OpContext>> hvd_contexts;
   std::vector<common::ReadyEventList> ready_event_lists;
   std::vector<StatusCallback> callbacks;
@@ -921,6 +982,7 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
   auto num_tensors = tensors.size();
   hvd_cpu_tensors.reserve(num_tensors);
   cpu_outputs.reserve(outputs.size());
+  hvd_cpu_outputs.reserve(outputs.size());
   hvd_contexts.reserve(num_tensors);
   ready_event_lists.reserve(num_tensors);
   names.reserve(num_tensors);
@@ -932,18 +994,39 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
     if (GetDeviceID(tensors[i]) != device) {
       throw std::logic_error("Tensors in list must be on same device.");
     }
-    // Make async copy of input tensor to CPU tensor and record completion
-    // event.
+    // Make async copy of input tensor to CPU tensor, allocate output tensor,
+    // and record completion event.
     auto cpu_tensor =
         tensors[i].to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
-    hvd_cpu_tensors.emplace_back(std::make_shared<TorchTensor>(cpu_tensor));
+    auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
+
+    auto cpu_output =
+        ::torch::empty({0}, cpu_tensor.options().merge_memory_format(
+                                LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+    auto hvd_context =
+        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs[i]);
+    std::shared_ptr<common::Tensor> hvd_cpu_output =
+        std::make_shared<TorchTensor>(cpu_output);
+    TensorShape output_shape =
+        GetReducescatterOutputShape(process_set_id, hvd_cpu_tensor->shape());
+
     common::ReadyEventList ready_event_list;
 #if HAVE_GPU
-    ready_event_list.AddReadyEvent(RecordReadyEvent(device));
-#endif
+    std::shared_ptr<ReadyEvent> ready_event;
+    ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_cpu_output,
+                                             &ready_event));
+    ready_event_list.AddReadyEvent(ready_event);
+#else
+    ThrowIfError(
+        hvd_context->AllocateOutput((int)i, output_shape, &hvd_output));
+#endif // HAVE_GPU
+
+    hvd_cpu_tensors.emplace_back(hvd_cpu_tensor);
+    cpu_outputs.emplace_back(cpu_output);
+    hvd_cpu_outputs.emplace_back(hvd_cpu_output);
+    hvd_contexts.emplace_back(
+        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs));
     ready_event_lists.emplace_back(ready_event_list);
-    cpu_outputs.emplace_back(
-        ::torch::empty_like(cpu_tensor, LEGACY_CONTIGUOUS_MEMORY_FORMAT));
     names.emplace_back(base_name + "_" + std::to_string(i + 1) + "of" +
                        std::to_string(num_tensors));
   }
@@ -951,8 +1034,6 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
   auto callback_mutex = std::make_shared<std::mutex>();
   auto callback_count = std::make_shared<std::size_t>(0);
   for (std::size_t i = 0; i < num_tensors; ++i) {
-    hvd_contexts.emplace_back(
-        std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs));
     auto output = outputs[i];
     auto cpu_output = cpu_outputs[i];
     callbacks.emplace_back([handle, reduce_op, cpu_output, output,
@@ -978,8 +1059,9 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
   }
 
   auto enqueue_result = EnqueueTensorReducescatters(
-      hvd_contexts, hvd_cpu_tensors, ready_event_lists, names, CPU_DEVICE_ID,
-      callbacks, request_op, process_set_id, prescale_factor, postscale_factor);
+      hvd_contexts, hvd_cpu_tensors, hvd_cpu_outputs, ready_event_lists, names,
+      CPU_DEVICE_ID, callbacks, request_op, process_set_id, prescale_factor,
+      postscale_factor);
   ThrowIfError(enqueue_result);
 
   return handle;

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -810,9 +810,9 @@ int DoReducescatterCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output,
       tensor.to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
   auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
 
-  auto cpu_output =
-      ::torch::empty({0}, cpu_tensor.options().merge_memory_format(
-                              LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+  auto cpu_output = ::torch::empty(
+      {0}, cpu_tensor.options().merge_in(::torch::TensorOptions().memory_format(
+               LEGACY_CONTIGUOUS_MEMORY_FORMAT)));
   auto hvd_context =
       std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_output);
   std::shared_ptr<common::Tensor> hvd_cpu_output =
@@ -1000,9 +1000,10 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
         tensors[i].to(::torch::Device(::torch::kCPU), /*non_blocking=*/true);
     auto hvd_cpu_tensor = std::make_shared<TorchTensor>(cpu_tensor);
 
-    auto cpu_output =
-        ::torch::empty({0}, cpu_tensor.options().merge_memory_format(
-                                LEGACY_CONTIGUOUS_MEMORY_FORMAT));
+    auto cpu_output = ::torch::empty(
+        {0},
+        cpu_tensor.options().merge_in(::torch::TensorOptions().memory_format(
+            LEGACY_CONTIGUOUS_MEMORY_FORMAT)));
     auto hvd_context =
         std::make_shared<TorchOpContext>(CPU_DEVICE_ID, cpu_outputs[i]);
     std::shared_ptr<common::Tensor> hvd_cpu_output =

--- a/horovod/torch/mpi_ops_v2.cc
+++ b/horovod/torch/mpi_ops_v2.cc
@@ -827,7 +827,7 @@ int DoReducescatterCudaOnCPU(::torch::Tensor tensor, ::torch::Tensor output,
       hvd_context->AllocateOutput(output_shape, &hvd_cpu_output, &ready_event));
   ready_event_list.AddReadyEvent(ready_event);
 #else
-  ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_output));
+  ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_cpu_output));
 #endif // HAVE_GPU
 
   auto handle = handle_manager.AllocateHandle();
@@ -910,7 +910,7 @@ int DoGroupedReducescatter(const std::vector<::torch::Tensor>& tensors,
         hvd_context->AllocateOutput(output_shape, &hvd_output, &ready_event));
     ready_event_list.AddReadyEvent(ready_event);
 #else
-    ThrowIfError(hvd_context->AllocateOutput((int)i, output_shape, &hvd_output));
+    ThrowIfError(hvd_context->AllocateOutput(output_shape, &hvd_output));
 #endif // HAVE_GPU
     hvd_tensors.emplace_back(hvd_tensor);
     hvd_outputs.emplace_back(hvd_output);
@@ -1018,7 +1018,7 @@ int DoGroupedReducescatterCudaOnCPU(const std::vector<::torch::Tensor>& tensors,
     ready_event_list.AddReadyEvent(ready_event);
 #else
     ThrowIfError(
-        hvd_context->AllocateOutput((int)i, output_shape, &hvd_output));
+        hvd_context->AllocateOutput(output_shape, &hvd_cpu_output));
 #endif // HAVE_GPU
 
     hvd_cpu_tensors.emplace_back(hvd_cpu_tensor);

--- a/test/parallel/test_torch.py
+++ b/test/parallel/test_torch.py
@@ -3742,7 +3742,7 @@ class TorchTests(unittest.TestCase):
         hvd.init()
         rank = hvd.rank()
         scalar = self.cast_and_place(torch.tensor(rank), torch.FloatTensor)
-        with self.assertRaises((torch.FatalError, RuntimeError, hvd.HorovodInternalError)):
+        with self.assertRaises((torch.FatalError, RuntimeError, hvd.HorovodInternalError, ValueError)):
             _ = hvd.reducescatter(scalar, op=hvd.Average)
 
     def test_horovod_reducescatter_adasum(self):
@@ -4318,7 +4318,7 @@ class TorchTests(unittest.TestCase):
         rank = hvd.rank()
         scalar = self.cast_and_place(torch.tensor(rank), torch.FloatTensor)
         tensor = self.cast_and_place(torch.zeros((3,1)), torch.FloatTensor)
-        with self.assertRaises((torch.FatalError, RuntimeError, hvd.HorovodInternalError)):
+        with self.assertRaises((torch.FatalError, RuntimeError, hvd.HorovodInternalError, ValueError)):
             _ = hvd.grouped_reducescatter([tensor, scalar])
 
     def test_horovod_grouped_reducescatter_process_sets(self):


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This change is motivated by the observations posted to discussion #3819: We can compute the shapes of the output tensors of (grouped) Reducescatter operations early, without any inter-process communication, even though the scattered tensors may not be distributed evenly. (Allgather behaves differently in this regard: There, each rank receives exactly the same output tensor, but Horovod cannot determine its size without communication.) We can take advantage of this fact and allocate memory for output tensors early, before the Horovod operation is enqueued, and without blocking the Horovod background thread.

This still happens in the C++ backend, but in framework-specific code. Allocations should be asynchronous with TensorFlow and PyTorch, but as far as I can tell the respective call is blocking with MXNet. In general I'm not closely familiar with the MXNet section of the code base. Probably it would be possible to be a bit smarter if `MXNET_ASYNC_GPU_ENGINE_SUPPORTED` is defined?