### PR TITLE
CI: Label log lines of tests run under MPI with process rank

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -104,7 +104,7 @@ RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
             cd /tmp && tar -zxf /tmp/openmpi-4.1.4-bin.tar.gz && \
             mkdir openmpi-4.1.4/build && cd openmpi-4.1.4/build && ../configure --prefix=/usr/local && \
             make -j all && make install && ldconfig && \
-            echo "mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot -mca mpi_abort_print_stack 1" > /mpirun_command; \
+            echo "mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot -mca mpi_abort_print_stack 1 -tag-output" > /mpirun_command; \
     elif [[ ${MPI_KIND} == "ONECCL" ]]; then \
         wget --progress=dot:mega -O /tmp/oneccl.tar.gz https://github.com/oneapi-src/oneCCL/archive/${CCL_PACKAGE}.tar.gz && \
             cd /tmp && tar -zxf oneccl.tar.gz && \
@@ -130,7 +130,7 @@ RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
             chmod +x /mpicc_oneccl; \
     elif [[ ${MPI_KIND} == "MPICH" ]]; then \
         apt-get update -qq && apt-get install -y mpich && \
-            echo "mpirun -np 2" > /mpirun_command; \
+            echo "mpirun -np 2 -l" > /mpirun_command; \
     fi
 
 # Install mpi4py.

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -108,10 +108,10 @@ RUN if [[ ${MPI_KIND} == "OpenMPI" ]]; then \
             cd /tmp && tar -zxf /tmp/openmpi-4.1.4-bin.tar.gz && \
             mkdir openmpi-4.1.4/build && cd openmpi-4.1.4/build && ../configure --prefix=/usr/local && \
             make -j all && make install && ldconfig && \
-            echo "mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot -mca mpi_abort_print_stack 1" > /mpirun_command; \
+            echo "mpirun -allow-run-as-root -np 2 -H localhost:2 -bind-to none -map-by slot -mca mpi_abort_print_stack 1 -tag-output" > /mpirun_command; \
     elif [[ ${MPI_KIND} == "MPICH" ]]; then \
         apt-get update -qq && apt-get install -y mpich && \
-            echo "mpirun -np 2" > /mpirun_command; \
+            echo "mpirun -np 2 -l" > /mpirun_command; \
     fi
 
 # Set default NCCL parameters


### PR DESCRIPTION
Parallel tests run through `horovodrun` already produce logs where the beginning of each output line is marked with the rank of the process that wrote it. For example:
```
[1]<stdout>:test_common.py::CommonTests::test_gloo_built PASSED
[1]<stdout>:test_common.py::CommonTests::test_mpi_built PASSED
[0]<stdout>:test_common.py::CommonTests::test_gloo_built PASSED
[0]<stdout>:test_common.py::CommonTests::test_mpi_built PASSED
```

This enables the same feature for tests run via `mpirun` under OpenMPI or MPICH.