### PR TITLE
Reduce flakiness of Ray GPU tests that check CUDA_VISIBLE_DEVICES

### DIFF
--- a/test/single/test_ray.py
+++ b/test/single/test_ray.py
@@ -175,7 +175,7 @@ def test_gpu_ids(ray_start_4_cpus_4_gpus):
     all_envs = hjob.execute(lambda _: os.environ.copy())
     all_cudas = {ev["CUDA_VISIBLE_DEVICES"] for ev in all_envs}
     assert len(all_cudas) == 1, all_cudas
-    assert len(all_envs[0]["CUDA_VISIBLE_DEVICES"].split(",")) == 4, all_envs[0]["CUDA_VISIBLE_DEVICES"]
+    assert len(set(all_envs[0]["CUDA_VISIBLE_DEVICES"].split(","))) == 4, all_envs[0]["CUDA_VISIBLE_DEVICES"]
     hjob.shutdown()
 
 
@@ -191,13 +191,13 @@ def test_gpu_ids_num_workers(ray_start_4_cpus_4_gpus):
     all_cudas = {ev["CUDA_VISIBLE_DEVICES"] for ev in all_envs}
 
     assert len(all_cudas) == 1, all_cudas
-    assert len(all_envs[0]["CUDA_VISIBLE_DEVICES"].split(",")) == 4, all_envs[0]["CUDA_VISIBLE_DEVICES"]
+    assert len(set(all_envs[0]["CUDA_VISIBLE_DEVICES"].split(","))) == 4, all_envs[0]["CUDA_VISIBLE_DEVICES"]
 
     def _test(worker):
         import horovod.torch as hvd
         hvd.init()
         local_rank = str(hvd.local_rank())
-        return local_rank in os.environ["CUDA_VISIBLE_DEVICES"]
+        return local_rank in os.environ["CUDA_VISIBLE_DEVICES"].split(",")
 
     all_valid_local_rank = hjob.execute(_test)
     assert all(all_valid_local_rank)

--- a/test/single/test_ray_elastic.py
+++ b/test/single/test_ray_elastic.py
@@ -34,7 +34,7 @@ def ray_8_cpus():
 @pytest.fixture
 def ray_8_cpus_gpus():
     if "CUDA_VISIBLE_DEVICES" in os.environ:
-        if len(os.environ["CUDA_VISIBLE_DEVICES"].split(",")) < 8:
+        if len(set(os.environ["CUDA_VISIBLE_DEVICES"].split(","))) < 8:
             pytest.skip("Avoiding mismatched GPU machine.")
     ray.init(num_cpus=8, num_gpus=8, resources={
         f"node:host-{i}": 1 for i in range(10)})

--- a/test/single/test_ray_elastic_v2.py
+++ b/test/single/test_ray_elastic_v2.py
@@ -37,7 +37,7 @@ def ray_8_cpus():
 @pytest.fixture
 def ray_8_cpus_gpus():
     if "CUDA_VISIBLE_DEVICES" in os.environ:
-        if len(os.environ["CUDA_VISIBLE_DEVICES"].split(",")) < 8:
+        if len(set(os.environ["CUDA_VISIBLE_DEVICES"].split(","))) < 8:
             pytest.skip("Avoiding mismatched GPU machine.")
     ray.init(num_cpus=8, num_gpus=8, resources={
         f"node:host-{i}": 1 for i in range(10)})


### PR DESCRIPTION
On Buildkite these tests fail quite often with messages like

```
=================================== FAILURES ===================================
___________________________ test_gpu_ids_num_workers ___________________________
ray_start_4_cpus_4_gpus = {'metrics_export_port': 57818, 'node_id': 'e3703e1d4e6396f6233c7bb316d604fc15ca225757ff96036253ef6b', 'node_ip_address': '172.16.32.2', 'object_store_address': '/tmp/ray/session_2023-01-27_12-44-34_471603_3376/sockets/plasma_store', ...}
 
    @pytest.mark.skipif(
        torch.cuda.device_count() < 4, reason="GPU test requires 4 GPUs")
    @pytest.mark.skipif(
        not torch.cuda.is_available(), reason="GPU test requires CUDA.")
    def test_gpu_ids_num_workers(ray_start_4_cpus_4_gpus):
        setting = RayExecutor.create_settings(timeout_s=30)
        hjob = RayExecutor(setting, num_workers=4, use_gpu=True)
        hjob.start()
        all_envs = hjob.execute(lambda _: os.environ.copy())
        all_cudas = {ev["CUDA_VISIBLE_DEVICES"] for ev in all_envs}
 
        assert len(all_cudas) == 1, all_cudas
>       assert len(all_envs[0]["CUDA_VISIBLE_DEVICES"].split(",")) == 4, all_envs[0]["CUDA_VISIBLE_DEVICES"]
E       AssertionError: 0,3,1,2,1,2,0,3
E       assert 8 == 4
E        +  where 8 = len(['0', '3', '1', '2', '1', '2', ...])
E        +    where ['0', '3', '1', '2', '1', '2', ...] = <built-in method split of str object at 0x7fb0095ba170>(',')
E        +      where <built-in method split of str object at 0x7fb0095ba170> = '0,3,1,2,1,2,0,3'.split
```
Taken from https://buildkite.com/horovod/horovod/builds/8886, where it failed 3x in a row on one instance.

So `CUDA_VISIBLE_DEVICES` contains four distinct GPU IDs `0,1,2,3`, however, each of them appears twice and they are not ordered. That shouldn't matter, though, as long as they are all valid GPU IDs accessible by the running job. So let's make the tests more permissive.

Not sure if the unusual value of that env variable is caused by Ray or Buildkite.