### PR TITLE
Upgrade CI test frameworks and fix linking NCCL 2.12+

### DIFF
--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1"
+baseline="test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -22,19 +22,19 @@ code_files=$(python "$dir/get_changed_code_files.py" || echo failure)
 tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-}" ]] || [[ -n "$code_files" ]] ); then
   # we vary the baseline along the Python dimension and PySpark together
   # run_gloo_integration expects these to have Gloo mpi kind to run 'Elastic Spark * Tests'
-  printf "test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark2_4_8 "
-  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_2_3 "
+  printf "test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8 "
+  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3 "
   # our baseline
   printf "$baseline "
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -46,7 +46,7 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   printf "test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_1 "
   printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
   printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
@@ -62,13 +62,13 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
   printf "test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1 "
   printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
   printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2"
+baseline="test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -25,18 +25,18 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # we deviate from baseline here because PySpark 2.4 requires Python 3.7 and
   # Tensorflow 2.11.0 is the last version that supports that Python
   printf "test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8 "
-  printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3 "
+  printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
   # our baseline
   printf "$baseline "
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -44,12 +44,12 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # Python 3.7 is only available on Ubuntu 18.04
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
-  printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
-  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2 "
-  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
+  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0 "
+  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
@@ -60,17 +60,17 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # there is no mxnet-1.6.0.post0 and mxnet-1.6.0 does not work with horovod
   # https://github.com/apache/incubator-mxnet/issues/16193
   # so we test with mxnet 1.5.1
-  printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
+  printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2 "
-  printf "test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
+  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0 "
+  printf "test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)
@@ -384,7 +384,7 @@ run_gloo_integration() {
   # Elastic Horovod on Spark tests are very expensive (high timeout)
   # We only need to run this for our baseline test image, baseline with tensorflow1, and pyspark variations
   # *-gloo-* does intentionally not match -openmpi-gloo- here
-  if [[ ${test} == ${baseline} ]] || [[ ${test} == test-cpu-gloo-*-tf1_* ]] || [[ ${test} != *pyspark3_3_2* ]]; then
+  if [[ ${test} == ${baseline} ]] || [[ ${test} == test-cpu-gloo-*-tf1_* ]] || [[ ${test} != *pyspark3_4_0* ]]; then
     run_test "${test}" "${queue}" \
       ":factory: Elastic Spark TensorFlow Tests (${test})" \
       "bash -c \"cd /horovod/test/integration && /spark_env.sh HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.spark.tf.xml ${elastic_spark_tensorflow}\"" \
@@ -393,7 +393,7 @@ run_gloo_integration() {
 
   # Elastic Horovod on Spark tests are very expensive (high timeout)
   # We only need to run this for our baseline test image and pyspark variations
-  if [[ ${test} == ${baseline} ]] || [[ ${test} != *pyspark3_3_2* ]]; then
+  if [[ ${test} == ${baseline} ]] || [[ ${test} != *pyspark3_4_0* ]]; then
     run_test "${test}" "${queue}" \
       ":factory: Elastic Spark Torch Tests (${test})" \
       "bash -c \"cd /horovod/test/integration && /spark_env.sh HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.spark.torch.xml test_elastic_spark_torch.py\"" \

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1"
+baseline="test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -29,12 +29,12 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -42,12 +42,12 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # Python 3.7 is only available on Ubuntu 18.04
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
-  printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1 "
-  printf "test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_1 "
-  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1 "
+  printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
+# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
@@ -58,17 +58,17 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # there is no mxnet-1.6.0.post0 and mxnet-1.6.0 does not work with horovod
   # https://github.com/apache/incubator-mxnet/issues/16193
   # so we test with mxnet 1.5.1
-  printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1 "
+  printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  printf "test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1 "
-  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
-  printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1 "
+  printf "test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2 "
+  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)
@@ -382,7 +382,7 @@ run_gloo_integration() {
   # Elastic Horovod on Spark tests are very expensive (high timeout)
   # We only need to run this for our baseline test image, baseline with tensorflow1, and pyspark variations
   # *-gloo-* does intentionally not match -openmpi-gloo- here
-  if [[ ${test} == ${baseline} ]] || [[ ${test} == test-cpu-gloo-*-tf1_* ]] || [[ ${test} != *pyspark3_3_1* ]]; then
+  if [[ ${test} == ${baseline} ]] || [[ ${test} == test-cpu-gloo-*-tf1_* ]] || [[ ${test} != *pyspark3_3_2* ]]; then
     run_test "${test}" "${queue}" \
       ":factory: Elastic Spark TensorFlow Tests (${test})" \
       "bash -c \"cd /horovod/test/integration && /spark_env.sh HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.spark.tf.xml ${elastic_spark_tensorflow}\"" \
@@ -391,7 +391,7 @@ run_gloo_integration() {
 
   # Elastic Horovod on Spark tests are very expensive (high timeout)
   # We only need to run this for our baseline test image and pyspark variations
-  if [[ ${test} == ${baseline} ]] || [[ ${test} != *pyspark3_3_1* ]]; then
+  if [[ ${test} == ${baseline} ]] || [[ ${test} != *pyspark3_3_2* ]]; then
     run_test "${test}" "${queue}" \
       ":factory: Elastic Spark Torch Tests (${test})" \
       "bash -c \"cd /horovod/test/integration && /spark_env.sh HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.spark.torch.xml test_elastic_spark_torch.py\"" \

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -46,7 +46,7 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
   printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
   printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0 "
-  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
+  printf "test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
   # our baseline again
 # printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
   printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
@@ -63,7 +63,7 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
   printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0 "
-  printf "test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
+  printf "test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
   printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
   printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0"
+baseline="test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -24,19 +24,20 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # run_gloo_integration expects these to have Gloo mpi kind to run 'Elastic Spark * Tests'
   # we deviate from baseline here because PySpark 2.4 requires Python 3.7 and
   # Tensorflow 2.11.0 is the last version that supports that Python
+  # Torch 1.13.1 is the last version that supports that Python
   printf "test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8 "
-  printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_3_2 "
   # our baseline
   printf "$baseline "
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
-  printf "test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
-  printf "test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
-  printf "test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -45,10 +46,10 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
   printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
-  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0 "
-  printf "test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
+  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p2-pyspark3_4_0 "
+  printf "test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
   printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
@@ -62,15 +63,15 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # so we test with mxnet 1.5.1
   printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0 "
-  printf "test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0 "
+  printf "test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
   printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)

--- a/.buildkite/gen-pipeline.sh
+++ b/.buildkite/gen-pipeline.sh
@@ -12,7 +12,7 @@ gpux2_queue="2x-gpu-v5111"
 gpux4_queue="4x-gpu-v5111"
 
 # our baseline test is
-baseline="test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2"
+baseline="test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2"
 # in run_gloo_integration we run 'Elastic Spark * Tests' for this baseline
 # so it has to have Gloo mpi kind
 
@@ -22,19 +22,21 @@ code_files=$(python "$dir/get_changed_code_files.py" || echo failure)
 tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-}" ]] || [[ -n "$code_files" ]] ); then
   # we vary the baseline along the Python dimension and PySpark together
   # run_gloo_integration expects these to have Gloo mpi kind to run 'Elastic Spark * Tests'
+  # we deviate from baseline here because PySpark 2.4 requires Python 3.7 and
+  # Tensorflow 2.11.0 is the last version that supports that Python
   printf "test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8 "
-  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3 "
+  printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3 "
   # our baseline
   printf "$baseline "
 
   # then we vary the baseline along mpi kinds dimension
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
-  printf "test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
   # note: we test openmpi-gloo mpi kind in this variation in each of [cpu, gpu, mixed]
-  printf "test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
 
   # then we vary the baseline along the framework dimensions all together
   # run_gloo_integration expects tf1 to have Gloo mpi kind to run 'Elastic Spark * Tests'
@@ -43,10 +45,10 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
   printf "test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
-  printf "test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2 "
-  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2 "
+  printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
   # our baseline again
-# printf "test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+# printf "test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
   printf "test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-cpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
@@ -60,15 +62,15 @@ tests=$(if [[ -n "${PIPELINE_MODE:-}" ]] && ( [[ "${BUILDKITE_BRANCH:-}" == "${B
   # so we test with mxnet 1.5.1
   printf "test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2 "
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  printf "test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2 "
-  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
-  printf "test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2 "
+  printf "test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2 "
+  printf "test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
   printf "test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2 "
   # these are the lowest framework versions that Horovod compiles with, but they are not tested
   printf "test-gpu-openmpi-gloo-py3_7-tfmin-kerasmin-torchmin-mxnetmin-pysparkmin "
 
   # and one final test with mixed cpu+gpu
-  printf "test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
+  printf "test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2 "
 fi | if [[ "${PIPELINE_MODE:-}" == "GPU"* ]]; then sed -E "s/[^ ]*-cpu-[^ ]*//g"; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU HEADS" ]]; then sed -E "s/ /\n/g" | grep -e "-tfhead-keras_none-torchhead-mxnethead-" | paste -s -d " " -; else cat; fi \
    | if [[ "${PIPELINE_MODE:-}" == "GPU NON HEADS" ]]; then sed -E "s/[^ ]*-tfhead-keras_none-torchhead-mxnethead-[^ ]*//g"; else cat; fi)
@@ -247,7 +249,7 @@ run_mpi_integration() {
     fi
 
     # https://github.com/horovod/horovod/issues/3711
-    if [[ ${test} != *"tf2_11_"* ]] && [[ ${test} != *"tfhead"* ]]; then
+    if [[ ${test} == *tf2_?_* ]] || [[ ${test} == *tf2_10_* ]]; then
       run_test "${test}" "${queue}" \
         ":tensorflow: MPI TensorFlow 2.0 MNIST Data Service (${test})" \
         "bash -c \"${oneccl_env} horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --mpi python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json\""
@@ -321,7 +323,7 @@ run_gloo_integration() {
     fi
 
     # https://github.com/horovod/horovod/issues/3711
-    if [[ ${test} != *"tf2_11_"* ]] && [[ ${test} != *"tfhead"* ]]; then
+    if [[ ${test} == *tf2_?_* ]] || [[ ${test} == *tf2_10_* ]]; then
       run_test "${test}" "${queue}" \
         ":tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (${test})" \
         "bash -c \"horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json\""

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark2_4_8
+          - image: test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -251,7 +251,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_2_3
+          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -275,7 +275,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -322,7 +322,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -337,7 +337,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -370,7 +370,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -399,10 +399,10 @@ jobs:
           - image: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
             build_timeout: 40
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+          - image: test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -395,7 +395,7 @@ jobs:
           - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+          - image: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
             build_timeout: 40
 
           - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+          - image: test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
             Elastic_Spark_TensorFlow_Tests_2: true
             Elastic_Tests_2: true
             Gloo_Cluster_PyTests: true
@@ -228,7 +228,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -275,7 +275,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -299,7 +299,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_1
+          - image: test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -322,7 +322,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -337,7 +337,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -370,7 +370,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -390,19 +390,19 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+          - image: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             build_timeout: 40
 
     steps:
@@ -2363,7 +2363,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+          - image: test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet2_MNIST_api: true
@@ -2398,7 +2398,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+          - image: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
             build_timeout: 40
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+          - image: test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
             Elastic_Spark_TensorFlow_Tests_2: true
             Elastic_Tests_2: true
             Gloo_Cluster_PyTests: true
@@ -228,7 +228,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -251,31 +251,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
-            Elastic_Tests_1: true
-            Gloo_Cluster_PyTests: true
-            Gloo_MXNet_MNIST_horovodrun: true
-            Gloo_Parallel_PyTests: true
-            Gloo_PyTorch_MNIST_api: true
-            Gloo_PyTorch_MNIST_horovodrun: true
-            Gloo_Single_PyTests: true
-            Gloo_TensorFlow_2_0_Keras_MNIST_api: true
-            Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
-            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
-            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
-            Gloo_TensorFlow_2_0_MNIST_api: true
-            Gloo_TensorFlow_2_0_MNIST_horovodrun: true
-            Single_MXNet_MNIST: true
-            Single_PyTorch_MNIST: true
-            Spark_Lightning_MNIST: true
-            Spark_PyTests: true
-            Spark_TensorFlow_2_0_MNIST_Data_Service: true
-            Spark_Torch_MNIST: true
-            build_timeout: 30
-
-          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3
-            Elastic_Spark_TensorFlow_Tests_1: true
-            Elastic_Spark_Torch_Tests: true
+          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -321,7 +297,31 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+            Elastic_Spark_TensorFlow_Tests_1: true
+            Elastic_Spark_Torch_Tests: true
+            Elastic_Tests_1: true
+            Gloo_Cluster_PyTests: true
+            Gloo_MXNet_MNIST_horovodrun: true
+            Gloo_Parallel_PyTests: true
+            Gloo_PyTorch_MNIST_api: true
+            Gloo_PyTorch_MNIST_horovodrun: true
+            Gloo_Single_PyTests: true
+            Gloo_TensorFlow_2_0_Keras_MNIST_api: true
+            Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_api: true
+            Gloo_TensorFlow_2_0_MNIST_horovodrun: true
+            Single_MXNet_MNIST: true
+            Single_PyTorch_MNIST: true
+            Spark_Lightning_MNIST: true
+            Spark_PyTests: true
+            Spark_TensorFlow_2_0_MNIST_Data_Service: true
+            Spark_Torch_MNIST: true
+            build_timeout: 30
+
+          - image: test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -336,7 +336,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -369,7 +369,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -389,19 +389,19 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+          - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+          - image: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
             build_timeout: 40
 
     steps:
@@ -2362,7 +2362,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+          - image: test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet2_MNIST_api: true
@@ -2397,7 +2397,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+          - image: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
             build_timeout: 40
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -251,7 +251,29 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3
+          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+            Elastic_Tests_1: true
+            Gloo_Cluster_PyTests: true
+            Gloo_MXNet_MNIST_horovodrun: true
+            Gloo_Parallel_PyTests: true
+            Gloo_PyTorch_MNIST_api: true
+            Gloo_PyTorch_MNIST_horovodrun: true
+            Gloo_Single_PyTests: true
+            Gloo_TensorFlow_2_0_Keras_MNIST_api: true
+            Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
+            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
+            Gloo_TensorFlow_2_0_MNIST_api: true
+            Gloo_TensorFlow_2_0_MNIST_horovodrun: true
+            Single_MXNet_MNIST: true
+            Single_PyTorch_MNIST: true
+            Spark_Lightning_MNIST: true
+            Spark_PyTests: true
+            Spark_TensorFlow_2_0_MNIST_Data_Service: true
+            Spark_Torch_MNIST: true
+            build_timeout: 30
+
+          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -275,7 +297,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -299,30 +321,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2
-            Elastic_Tests_1: true
-            Gloo_Cluster_PyTests: true
-            Gloo_MXNet_MNIST_horovodrun: true
-            Gloo_Parallel_PyTests: true
-            Gloo_PyTorch_MNIST_api: true
-            Gloo_PyTorch_MNIST_horovodrun: true
-            Gloo_Single_PyTests: true
-            Gloo_TensorFlow_2_0_Keras_MNIST_api: true
-            Gloo_TensorFlow_2_0_Keras_MNIST_horovodrun: true
-            Gloo_TensorFlow_2_0_MNIST_Data_Service: true
-            Gloo_TensorFlow_2_0_MNIST_Elastic_api: true
-            Gloo_TensorFlow_2_0_MNIST_Elastic_horovodrun: true
-            Gloo_TensorFlow_2_0_MNIST_api: true
-            Gloo_TensorFlow_2_0_MNIST_horovodrun: true
-            Single_MXNet_MNIST: true
-            Single_PyTorch_MNIST: true
-            Spark_Lightning_MNIST: true
-            Spark_PyTests: true
-            Spark_TensorFlow_2_0_MNIST_Data_Service: true
-            Spark_Torch_MNIST: true
-            build_timeout: 30
-
-          - image: test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -337,7 +336,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -370,7 +369,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -393,16 +392,16 @@ jobs:
           - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+          - image: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
             build_timeout: 40
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0
+          - image: test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p2-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -251,7 +251,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+          - image: test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -273,7 +273,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_3_2
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -297,7 +297,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             Elastic_Spark_TensorFlow_Tests_1: true
             Elastic_Spark_Torch_Tests: true
             Elastic_Tests_1: true
@@ -321,7 +321,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -336,7 +336,7 @@ jobs:
             Single_PyTorch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             Elastic_Tests_1: true
             Gloo_Cluster_PyTests: true
             Gloo_MXNet_MNIST_horovodrun: true
@@ -369,7 +369,7 @@ jobs:
             Spark_Torch_MNIST: true
             build_timeout: 30
 
-          - image: test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             MPI_Cluster_PyTests: true
             MPI_MXNet_MNIST_horovodrun: true
             MPI_Parallel_PyTests: true
@@ -392,16 +392,16 @@ jobs:
           - image: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+          - image: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+          - image: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             build_timeout: 40
 
-          - image: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+          - image: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
             build_timeout: 40
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed build with ROCm. ([#3839](https://github.com/horovod/horovod/pull/3839), [#3848](https://github.com/horovod/horovod/pull/3848))
 - Fixed build of Docker image horovod-nvtabular. ([#3851](https://github.com/horovod/horovod/pull/3851))
-- Fixed linking NCCL by defaulting CUDA runtime library linkage to static. ([#3867](https://github.com/horovod/horovod/pull/3867))
+- Fixed linking recent NCCL by defaulting CUDA runtime library linkage to static and ensuring that weak symbols are overridden. ([#3867](https://github.com/horovod/horovod/pull/3867), [#3846](https://github.com/horovod/horovod/pull/3846))
 
 
 ## [v0.27.0] - 2023-02-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(HOROVOD_GPU_ALLREDUCE STREQUAL "N" OR HOROVOD_GPU_ALLGATHER STREQUAL "N" OR H
         include_directories(SYSTEM ${NCCL_INCLUDE_DIRS})
         list(APPEND LINKER_LIBS ${NCCL_LIBRARIES})
         if(NCCL_LIBRARY_FILE_NAME MATCHES "static" AND lowercase_CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "static")
-            # ensure that weak symbols from NCCL's enhcompat.cc are properly overwritten by symbols from libcudart_static.a
+            # ensure that weak symbols from NCCL's enhcompat.cc are properly overwritten by symbols from libcudart_static.a (https://github.com/horovod/horovod/pull/3846)
             list(APPEND LINKER_LIBS -Wl,--whole-archive cudart_static -Wl,--no-whole-archive)
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,10 @@ if(HOROVOD_GPU_ALLREDUCE STREQUAL "N" OR HOROVOD_GPU_ALLGATHER STREQUAL "N" OR H
         endif()
         include_directories(SYSTEM ${NCCL_INCLUDE_DIRS})
         list(APPEND LINKER_LIBS ${NCCL_LIBRARIES})
+        if(NCCL_LIBRARY_FILE_NAME MATCHES "static" AND lowercase_CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "static")
+            # ensure that weak symbols from NCCL's enhcompat.cc are properly overwritten by symbols from libcudart_static.a
+            list(APPEND LINKER_LIBS -Wl,--whole-archive cudart_static -Wl,--no-whole-archive)
+        endif()
     endif()
     list(APPEND SOURCES "${PROJECT_SOURCE_DIR}/horovod/common/ops/nccl_operations.cc")
     add_definitions(-DHAVE_NCCL=1)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -228,9 +228,9 @@ services:
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
-        PYTORCH_PACKAGE: torch==2.0.0+cu116
+        PYTORCH_PACKAGE: torch==2.0.0+cu118
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.15.1+cu116
+        TORCHVISION_PACKAGE: torchvision==0.15.1+cu118
         MXNET_PACKAGE: mxnet-cu112==1.9.1
   test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0:
     extends: test-gpu-base
@@ -276,9 +276,9 @@ services:
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
-        PYTORCH_PACKAGE: torch==2.0.0+cu116
+        PYTORCH_PACKAGE: torch==2.0.0+cu118
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.15.1+cu116
+        TORCHVISION_PACKAGE: torchvision==0.15.1+cu118
         MXNET_PACKAGE: mxnet-cu112==1.9.1
         HOROVOD_BUILD_FLAGS: ""
         HOROVOD_MIXED_INSTALL: 1

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -77,11 +77,11 @@ services:
         PYTORCH_PACKAGE: torch==1.11.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
         MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
+  test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.1
         KERAS_PACKAGE: keras==2.11.0
         PYTORCH_PACKAGE: torch==1.12.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
@@ -199,14 +199,14 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.12.0+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
+  test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.1
         KERAS_PACKAGE: keras==2.11.0
         PYTORCH_PACKAGE: torch==1.12.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -206,7 +206,8 @@ services:
         CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.1
+        # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
+        TENSORFLOW_PACKAGE: tensorflow==2.11.1
         KERAS_PACKAGE: keras==2.11.0
         PYTORCH_PACKAGE: torch==1.12.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
@@ -220,7 +221,8 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.12.0
+        # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
+        TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
         PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
@@ -267,7 +269,8 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.12.0
+        # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
+        TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
         PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,9 +11,9 @@ services:
         PYTHON_VERSION: 3.8
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.12.0
         KERAS_PACKAGE: keras==2.12.0
-        PYTORCH_PACKAGE: torch==1.13.1+cpu
+        PYTORCH_PACKAGE: torch==2.0.0+cpu
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
+        TORCHVISION_PACKAGE: torchvision==0.15.1+cpu
         MXNET_PACKAGE: mxnet==1.9.1
         PYSPARK_PACKAGE: pyspark==3.4.0
         SPARK_PACKAGE: spark-3.4.0/spark-3.4.0-bin-hadoop3.tgz
@@ -22,29 +22,29 @@ services:
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -68,23 +68,23 @@ services:
         PYTORCH_PACKAGE: torch==1.8.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.9.1+cpu
         MXNET_PACKAGE: mxnet==1.5.1.post0
-  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p2-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
-        PYTORCH_PACKAGE: torch==1.11.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
+        PYTORCH_PACKAGE: torch==1.12.1+cpu
+        TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
         MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
+  test-cpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.1
         KERAS_PACKAGE: keras==2.11.0
-        PYTORCH_PACKAGE: torch==1.12.1+cpu
-        TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
+        PYTORCH_PACKAGE: torch==1.13.1+cpu
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
         MXNET_PACKAGE: mxnet==1.8.0.post0
   # then our baseline again, omitted ...
   test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0:
@@ -117,6 +117,7 @@ services:
 
   # we deviate from baseline here because PySpark 2.4 requires Python 3.7 and
   # Tensorflow 2.11.0 is the last version that supports that Python
+  # Torch 1.13.1 is the last version that supports that Python
   test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8:
     extends: test-cpu-base
     build:
@@ -124,13 +125,16 @@ services:
         # PySpark 2.4.8 is only available for Python 3.7
         # Python 3.7 is only available on Ubuntu 18.04
         # Tensorflow 2.11.0 is the last version supporting that Python
+        # Torch 1.13.1 is the last version supporting that Python
         UBUNTU_VERSION: 18.04
         PYTHON_VERSION: 3.7
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
         KERAS_PACKAGE: keras==2.11.0
+        PYTORCH_PACKAGE: torch==1.13.1+cpu
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
         PYSPARK_PACKAGE: pyspark==2.4.8
         SPARK_PACKAGE: spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
-  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -185,7 +189,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.9.1+cu101
         MXNET_PACKAGE: mxnet-cu100==1.5.1.post0
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0:
+  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -195,11 +199,11 @@ services:
         NCCL_VERSION_OVERRIDE: 2.8.4-1+cuda10.2
         TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
-        PYTORCH_PACKAGE: torch==1.11.0+cu102
+        PYTORCH_PACKAGE: torch==1.12.1+cu102
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.12.0+cu102
+        TORCHVISION_PACKAGE: torchvision==0.13.1+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
+  test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -209,11 +213,11 @@ services:
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.11.1
         KERAS_PACKAGE: keras==2.11.0
-        PYTORCH_PACKAGE: torch==1.12.1+cu116
+        PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.13.1+cu116
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -224,9 +228,9 @@ services:
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
-        PYTORCH_PACKAGE: torch==1.13.1+cu116
+        PYTORCH_PACKAGE: torch==2.0.0+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
+        TORCHVISION_PACKAGE: torchvision==0.15.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
   test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0:
     extends: test-gpu-base
@@ -261,7 +265,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
+  test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -272,9 +276,9 @@ services:
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
         KERAS_PACKAGE: keras==2.12.0
-        PYTORCH_PACKAGE: torch==1.13.1+cu116
+        PYTORCH_PACKAGE: torch==2.0.0+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
+        TORCHVISION_PACKAGE: torchvision==0.15.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
         HOROVOD_BUILD_FLAGS: ""
         HOROVOD_MIXED_INSTALL: 1

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,9 +11,9 @@ services:
         PYTHON_VERSION: 3.8
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
         KERAS_PACKAGE: keras==2.11.0
-        PYTORCH_PACKAGE: torch==1.13.0+cpu
+        PYTORCH_PACKAGE: torch==1.13.1+cpu
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
         MXNET_PACKAGE: mxnet==1.9.1
         PYSPARK_PACKAGE: pyspark==3.3.1
         SPARK_PACKAGE: spark-3.3.1/spark-3.3.1-bin-hadoop2.tgz
@@ -22,29 +22,29 @@ services:
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-cpu-base
     build:
       args:
@@ -115,7 +115,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark2_4_8:
+  test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8:
     extends: test-cpu-base
     build:
       args:
@@ -125,7 +125,7 @@ services:
         PYTHON_VERSION: 3.7
         PYSPARK_PACKAGE: pyspark==2.4.8
         SPARK_PACKAGE: spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_2_3:
+  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3:
     extends: test-cpu-base
     build:
       args:
@@ -207,7 +207,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.13.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
@@ -217,9 +217,9 @@ services:
         MPI_KIND: OpenMPI
         TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
         KERAS_PACKAGE: keras==2.11.0
-        PYTORCH_PACKAGE: torch==1.13.0+cu116
+        PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.0+cu116
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
   test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1:
     extends: test-gpu-base
@@ -254,7 +254,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1:
+  test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
     extends: test-gpu-base
     build:
       args:
@@ -264,9 +264,9 @@ services:
         MPI_KIND: OpenMPI
         TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
         KERAS_PACKAGE: keras==2.11.0
-        PYTORCH_PACKAGE: torch==1.13.0+cu116
+        PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
-        TORCHVISION_PACKAGE: torchvision==0.14.0+cu116
+        TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
         HOROVOD_BUILD_FLAGS: ""
         HOROVOD_MIXED_INSTALL: 1

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -223,7 +223,7 @@ services:
       args:
         CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
         CUDNN_VERSION: 8.6.0.163-1+cuda11.8
-        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
+        NCCL_VERSION_OVERRIDE: 2.16.5-1+cuda11.8
         MPI_KIND: OpenMPI
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
@@ -238,7 +238,7 @@ services:
       args:
         CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
         CUDNN_VERSION: 8.6.0.163-1+cuda11.8
-        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
+        NCCL_VERSION_OVERRIDE: 2.16.5-1+cuda11.8
         MPI_KIND: OpenMPI
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: None
@@ -271,7 +271,7 @@ services:
       args:
         CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
         CUDNN_VERSION: 8.6.0.163-1+cuda11.8
-        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
+        NCCL_VERSION_OVERRIDE: 2.16.5-1+cuda11.8
         MPI_KIND: OpenMPI
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,8 +9,8 @@ services:
         GPP_VERSION: 7
         MPI_KIND: None
         PYTHON_VERSION: 3.8
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
-        KERAS_PACKAGE: keras==2.11.0
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.12.0
+        KERAS_PACKAGE: keras==2.12.0
         PYTORCH_PACKAGE: torch==1.13.1+cpu
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
@@ -22,29 +22,29 @@ services:
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -68,21 +68,21 @@ services:
         PYTORCH_PACKAGE: torch==1.8.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.9.1+cpu
         MXNET_PACKAGE: mxnet==1.5.1.post0
-  test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2:
-    extends: test-cpu-base
-    build:
-      args:
-        TENSORFLOW_PACKAGE: tensorflow-cpu==2.9.3
-        KERAS_PACKAGE: keras==2.9.0
-        PYTORCH_PACKAGE: torch==1.11.0+cpu
-        TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
-        MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         TENSORFLOW_PACKAGE: tensorflow-cpu==2.10.1
         KERAS_PACKAGE: keras==2.10.0
+        PYTORCH_PACKAGE: torch==1.11.0+cpu
+        TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
+        MXNET_PACKAGE: mxnet==1.7.0.post2
+  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
+    extends: test-cpu-base
+    build:
+      args:
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
+        KERAS_PACKAGE: keras==2.11.0
         PYTORCH_PACKAGE: torch==1.12.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
         MXNET_PACKAGE: mxnet==1.8.0.post0
@@ -115,17 +115,22 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
+  # we deviate from baseline here because PySpark 2.4 requires Python 3.7 and
+  # Tensorflow 2.11.0 is the last version that supports that Python
   test-cpu-gloo-py3_7-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark2_4_8:
     extends: test-cpu-base
     build:
       args:
-        # Tensorflow 1.15.5 is only available for Python 3.7
+        # PySpark 2.4.8 is only available for Python 3.7
         # Python 3.7 is only available on Ubuntu 18.04
+        # Tensorflow 2.11.0 is the last version supporting that Python
         UBUNTU_VERSION: 18.04
         PYTHON_VERSION: 3.7
+        TENSORFLOW_PACKAGE: tensorflow-cpu==2.11.0
+        KERAS_PACKAGE: keras==2.11.0
         PYSPARK_PACKAGE: pyspark==2.4.8
         SPARK_PACKAGE: spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3:
     extends: test-cpu-base
     build:
       args:
@@ -180,7 +185,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.9.1+cu101
         MXNET_PACKAGE: mxnet-cu100==1.5.1.post0
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2:
+  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -188,26 +193,26 @@ services:
         CUDA_DOCKER_VERSION: 10.1-devel-ubuntu18.04
         CUDNN_VERSION: 8.0.5.39-1+cuda10.1
         NCCL_VERSION_OVERRIDE: 2.8.4-1+cuda10.2
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.9.3
-        KERAS_PACKAGE: keras==2.9.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.1
+        KERAS_PACKAGE: keras==2.10.0
         PYTORCH_PACKAGE: torch==1.11.0+cu102
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.12.0+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
+  test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
         CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.10.1
-        KERAS_PACKAGE: keras==2.10.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
+        KERAS_PACKAGE: keras==2.11.0
         PYTORCH_PACKAGE: torch==1.12.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.13.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -215,8 +220,8 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
-        KERAS_PACKAGE: keras==2.11.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.12.0
+        KERAS_PACKAGE: keras==2.12.0
         PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
@@ -254,7 +259,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -262,8 +267,8 @@ services:
         CUDNN_VERSION: 8.4.1.50-1+cuda11.6
         NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
         MPI_KIND: OpenMPI
-        TENSORFLOW_PACKAGE: tensorflow-gpu==2.11.0
-        KERAS_PACKAGE: keras==2.11.0
+        TENSORFLOW_PACKAGE: tensorflow-gpu==2.12.0
+        KERAS_PACKAGE: keras==2.12.0
         PYTORCH_PACKAGE: torch==1.13.1+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cu116

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,36 +15,36 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
         MXNET_PACKAGE: mxnet==1.9.1
-        PYSPARK_PACKAGE: pyspark==3.3.1
-        SPARK_PACKAGE: spark-3.3.1/spark-3.3.1-bin-hadoop2.tgz
+        PYSPARK_PACKAGE: pyspark==3.3.2
+        SPARK_PACKAGE: spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz
         HOROVOD_BUILD_FLAGS: HOROVOD_WITH_GLOO=1
     privileged: true
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-mpich-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-oneccl-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-cpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -55,7 +55,7 @@ services:
   # Python 3.7 is only available on Ubuntu 18.04
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
-  test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1:
+  test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -68,7 +68,7 @@ services:
         PYTORCH_PACKAGE: torch==1.8.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.9.1+cpu
         MXNET_PACKAGE: mxnet==1.5.1.post0
-  test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -77,7 +77,7 @@ services:
         PYTORCH_PACKAGE: torch==1.11.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
         MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -87,7 +87,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
         MXNET_PACKAGE: mxnet==1.8.0.post0
   # then our baseline again, omitted ...
-  test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1:
+  test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
@@ -142,8 +142,8 @@ services:
         GPP_VERSION: 7
         MPI_KIND: None
         PYTHON_VERSION: 3.8
-        PYSPARK_PACKAGE: pyspark==3.3.1
-        SPARK_PACKAGE: spark-3.3.1/spark-3.3.1-bin-hadoop2.tgz
+        PYSPARK_PACKAGE: pyspark==3.3.2
+        SPARK_PACKAGE: spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz
         HOROVOD_BUILD_FLAGS: HOROVOD_GPU_OPERATIONS=NCCL
         HOROVOD_MIXED_INSTALL: 0
     runtime: nvidia
@@ -163,7 +163,7 @@ services:
   # there is no mxnet-1.6.0.post0 and mxnet-1.6.0 does not work with horovod
   # https://github.com/apache/incubator-mxnet/issues/16193
   # so we test with mxnet 1.5.1
-  test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1:
+  test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -180,7 +180,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.9.1+cu101
         MXNET_PACKAGE: mxnet-cu100==1.5.1.post0
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1:
+  test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -194,7 +194,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.12.0+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1:
+  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -207,7 +207,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.13.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -221,7 +221,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
-  test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1:
+  test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:
@@ -254,7 +254,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1:
+  test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-gpu-base
     build:
       args:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -221,9 +221,9 @@ services:
     extends: test-gpu-base
     build:
       args:
-        CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
-        CUDNN_VERSION: 8.4.1.50-1+cuda11.6
-        NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
+        CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
+        CUDNN_VERSION: 8.6.0.163-1+cuda11.8
+        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
         MPI_KIND: OpenMPI
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0
@@ -238,7 +238,7 @@ services:
       args:
         CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
         CUDNN_VERSION: 8.6.0.163-1+cuda11.8
-        NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
+        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
         MPI_KIND: OpenMPI
         TENSORFLOW_PACKAGE: tf-nightly
         KERAS_PACKAGE: None
@@ -269,9 +269,9 @@ services:
     extends: test-gpu-base
     build:
       args:
-        CUDA_DOCKER_VERSION: 11.6.1-devel-ubuntu20.04
-        CUDNN_VERSION: 8.4.1.50-1+cuda11.6
-        NCCL_VERSION_OVERRIDE: 2.11.4-1+cuda11.6
+        CUDA_DOCKER_VERSION: 11.8.0-devel-ubuntu20.04
+        CUDNN_VERSION: 8.6.0.163-1+cuda11.8
+        NCCL_VERSION_OVERRIDE: 2.15.1-1+cuda11.8
         MPI_KIND: OpenMPI
         # tensorflow package supports GPU from 2.11.1 and 2.12.0 on
         TENSORFLOW_PACKAGE: tensorflow==2.12.0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -220,7 +220,7 @@ services:
         PYTORCH_PACKAGE: torch==1.13.0+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.0+cu116
-        MXNET_PACKAGE: mxnet-cu112==1.9.0
+        MXNET_PACKAGE: mxnet-cu112==1.9.1
   test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1:
     extends: test-gpu-base
     build:
@@ -267,6 +267,6 @@ services:
         PYTORCH_PACKAGE: torch==1.13.0+cu116
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.0+cu116
-        MXNET_PACKAGE: mxnet-cu112==1.9.0
+        MXNET_PACKAGE: mxnet-cu112==1.9.1
         HOROVOD_BUILD_FLAGS: ""
         HOROVOD_MIXED_INSTALL: 1

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,36 +15,36 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cpu
         MXNET_PACKAGE: mxnet==1.9.1
-        PYSPARK_PACKAGE: pyspark==3.3.2
-        SPARK_PACKAGE: spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz
+        PYSPARK_PACKAGE: pyspark==3.4.0
+        SPARK_PACKAGE: spark-3.4.0/spark-3.4.0-bin-hadoop3.tgz
         HOROVOD_BUILD_FLAGS: HOROVOD_WITH_GLOO=1
     privileged: true
     shm_size: 8gb
 
   # our baseline first
-  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
 
   # permute MPI kinds
-  test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-mpich-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: MPICH
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-oneccl-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: ONECCL
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-openmpi-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
         MPI_KIND: OpenMPI
         HOROVOD_BUILD_FLAGS: HOROVOD_WITHOUT_GLOO=1
-  test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-cpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -55,7 +55,7 @@ services:
   # Python 3.7 is only available on Ubuntu 18.04
   # torch==1.8.1 is the latest we can test in this setup
   # see test-gpu-gloo-py3_7-tf1_15_5-... below why we have to test with mxnet 1.5.1 here
-  test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2:
+  test-cpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -68,7 +68,7 @@ services:
         PYTORCH_PACKAGE: torch==1.8.1+cpu
         TORCHVISION_PACKAGE: torchvision==0.9.1+cpu
         MXNET_PACKAGE: mxnet==1.5.1.post0
-  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p2-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -77,7 +77,7 @@ services:
         PYTORCH_PACKAGE: torch==1.11.0+cpu
         TORCHVISION_PACKAGE: torchvision==0.12.0+cpu
         MXNET_PACKAGE: mxnet==1.7.0.post2
-  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
+  test-cpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -87,7 +87,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.13.1+cpu
         MXNET_PACKAGE: mxnet==1.8.0.post0
   # then our baseline again, omitted ...
-  test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2:
+  test-cpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0:
     extends: test-cpu-base
     build:
       args:
@@ -130,13 +130,13 @@ services:
         KERAS_PACKAGE: keras==2.11.0
         PYSPARK_PACKAGE: pyspark==2.4.8
         SPARK_PACKAGE: spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
-  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_2_3:
+  test-cpu-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
     extends: test-cpu-base
     build:
       args:
         PYTHON_VERSION: 3.8
-        PYSPARK_PACKAGE: pyspark==3.2.3
-        SPARK_PACKAGE: spark-3.2.3/spark-3.2.3-bin-hadoop2.7.tgz
+        PYSPARK_PACKAGE: pyspark==3.3.2
+        SPARK_PACKAGE: spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz
   # then our baseline again, omitted ...
 
   test-gpu-base:
@@ -147,8 +147,8 @@ services:
         GPP_VERSION: 7
         MPI_KIND: None
         PYTHON_VERSION: 3.8
-        PYSPARK_PACKAGE: pyspark==3.3.2
-        SPARK_PACKAGE: spark-3.3.2/spark-3.3.2-bin-hadoop2.tgz
+        PYSPARK_PACKAGE: pyspark==3.4.0
+        SPARK_PACKAGE: spark-3.4.0/spark-3.4.0-bin-hadoop3.tgz
         HOROVOD_BUILD_FLAGS: HOROVOD_GPU_OPERATIONS=NCCL
         HOROVOD_MIXED_INSTALL: 0
     runtime: nvidia
@@ -168,7 +168,7 @@ services:
   # there is no mxnet-1.6.0.post0 and mxnet-1.6.0 does not work with horovod
   # https://github.com/apache/incubator-mxnet/issues/16193
   # so we test with mxnet 1.5.1
-  test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2:
+  test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -185,7 +185,7 @@ services:
         TORCHVISION_PACKAGE: torchvision==0.9.1+cu101
         MXNET_PACKAGE: mxnet-cu100==1.5.1.post0
   # here we deviate from mxnet==1.7.0.post2 as there is none for cu101, only post1
-  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2:
+  test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -199,7 +199,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.12.0+cu102
         MXNET_PACKAGE: mxnet-cu101==1.7.0.post1
-  test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2:
+  test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -212,7 +212,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.13.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.8.0.post0
-  test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -226,7 +226,7 @@ services:
         PYTORCH_LIGHTNING_PACKAGE: pytorch-lightning==1.5.9
         TORCHVISION_PACKAGE: torchvision==0.14.1+cu116
         MXNET_PACKAGE: mxnet-cu112==1.9.1
-  test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2:
+  test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:
@@ -259,7 +259,7 @@ services:
         PYSPARK_PACKAGE: pyspark==2.4.0
         SPARK_PACKAGE: spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
 
-  test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2:
+  test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0:
     extends: test-gpu-base
     build:
       args:

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -1,10 +1,10 @@
 steps:
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      build: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -17,14 +17,14 @@ steps:
     queue: cpu-v5111
 - wait
 - wait
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -35,14 +35,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -53,14 +53,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -71,14 +71,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -89,14 +89,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -107,14 +107,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -126,14 +126,14 @@ steps:
   agents:
     queue: 4x-gpu-v5111
 - wait
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -144,14 +144,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -162,14 +162,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -180,14 +180,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -198,14 +198,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -216,14 +216,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -234,14 +234,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -252,14 +252,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -270,14 +270,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -288,14 +288,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -306,14 +306,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -324,14 +324,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -342,14 +342,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -360,14 +360,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_heads_pipeline.yaml
@@ -1,10 +1,10 @@
 steps:
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      build: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -17,14 +17,14 @@ steps:
     queue: cpu-v5111
 - wait
 - wait
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -35,14 +35,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -53,14 +53,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -71,14 +71,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -89,14 +89,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -107,14 +107,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -126,14 +126,14 @@ steps:
   agents:
     queue: 4x-gpu-v5111
 - wait
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -144,14 +144,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -162,14 +162,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -180,14 +180,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -198,14 +198,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -216,14 +216,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -234,14 +234,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -252,14 +252,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -270,14 +270,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':muscle: MPI MXNet2 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -288,14 +288,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -306,14 +306,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -324,14 +324,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -342,14 +342,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -360,14 +360,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tfhead-keras_none-torchhead-mxnethead-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      build: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      build: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1502,14 +1502,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_0-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -1,10 +1,10 @@
 steps:
-- label: ':docker: Build test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2'
+- label: ':docker: Build test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      build: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -15,12 +15,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      build: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      build: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      build: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -97,14 +97,14 @@ steps:
     queue: cpu-v5111
 - wait
 - wait
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -115,14 +115,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -133,14 +133,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -151,14 +151,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -169,14 +169,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -187,14 +187,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -476,14 +476,14 @@ steps:
   agents:
     queue: 4x-gpu-v5111
 - wait
-- label: ':tensorflow: Gloo TensorFlow MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow/tensorflow_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -494,14 +494,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras/keras_mnist_advanced.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -512,14 +512,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -530,14 +530,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -548,14 +548,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow.py test_elastic_tensorflow_keras.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -566,14 +566,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -584,14 +584,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -602,14 +602,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -620,14 +620,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -638,14 +638,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -656,14 +656,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -674,14 +674,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -692,14 +692,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -710,14 +710,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -728,14 +728,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -746,14 +746,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -764,14 +764,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -782,14 +782,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -800,14 +800,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -818,14 +818,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,14 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -908,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -998,14 +998,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -15,12 +15,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      build: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      build: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      build: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -151,14 +151,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -169,14 +169,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -187,14 +187,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -656,14 +656,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -674,14 +674,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -692,14 +692,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -710,14 +710,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -728,14 +728,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -746,14 +746,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -764,14 +764,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -782,14 +782,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -800,14 +800,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -818,14 +818,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,32 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
-  command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
-  artifact_paths: "artifacts/**"
-  env:
-    COMPOSE_HTTP_TIMEOUT: 300
-  plugins:
-  - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
-      volumes: "./artifacts:/artifacts"
-      config: docker-compose.test.yml
-      pull-retries: 3
-  - ecr#v1.2.0:
-      login: true
-  timeout_in_minutes: 10
-  retry:
-    automatic: true
-  agents:
-    queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -998,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
+      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +998,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1502,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -15,12 +15,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      build: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      build: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      build: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -151,14 +151,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -169,14 +169,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -187,14 +187,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -656,14 +656,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -674,14 +674,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -692,14 +692,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -710,14 +710,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -728,14 +728,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -746,14 +746,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -764,14 +764,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -782,14 +782,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -800,14 +800,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -818,14 +818,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_7_0_p1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,14 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -908,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_13_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -998,14 +998,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-gpu-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch1_13_1-mxnet1_9_1-pyspark3_4_0
+      run: test-mixed-openmpi-gloo-py3_8-tf2_12_0-keras2_12_0-torch2_0_0-mxnet1_9_1-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      build: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,14 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -908,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
+      run: test-gpu-gloo-py3_8-tf2_11_1-keras2_11_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_4_0
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3

--- a/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
+++ b/test/single/data/expected_buildkite_gpu_non_heads_pipeline.yaml
@@ -1,10 +1,10 @@
 steps:
-- label: ':docker: Build test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1'
+- label: ':docker: Build test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      build: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -15,12 +15,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      build: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -31,12 +31,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1'
+- label: ':docker: Build test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      build: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -47,12 +47,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      build: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -79,12 +79,12 @@ steps:
     automatic: true
   agents:
     queue: cpu-v5111
-- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1'
+- label: ':docker: Build test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2'
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      build: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      build: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       image-repository: 823773083436.dkr.ecr.us-east-1.amazonaws.com/buildkite
       config: docker-compose.test.yml
       push-retries: 5
@@ -97,14 +97,14 @@ steps:
     queue: cpu-v5111
 - wait
 - wait
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -115,14 +115,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -133,14 +133,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -151,14 +151,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -169,14 +169,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -187,14 +187,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -205,14 +205,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -223,14 +223,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -241,14 +241,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -259,14 +259,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -277,14 +277,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -295,14 +295,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -313,14 +313,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -331,14 +331,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -349,14 +349,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -367,14 +367,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 horovodrun -np 2 -H localhost:2 --gloo /bin/bash /pytest.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -385,14 +385,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh gloo)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -403,14 +403,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: Gloo Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -421,14 +421,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Parallel PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/parallel && (ls -1 test_*.py | xargs -n 1 \$(cat /mpirun_command) /bin/bash /pytest.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -439,14 +439,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Single PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 cd /horovod/test/single && (ls -1 test_*.py | xargs -n 1 /bin/bash /pytest_standalone.sh mpi)"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -457,14 +457,14 @@ steps:
     automatic: true
   agents:
     queue: 4x-gpu-v5111
-- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':pytest: MPI Cluster PyTests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " HOROVOD_TEST_GPU=1 /etc/init.d/ssh start && cd /horovod/test/integration && pytest --forked -v --capture=fd --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.static.xml test_static_run.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -476,14 +476,14 @@ steps:
   agents:
     queue: 4x-gpu-v5111
 - wait
-- label: ':tensorflow: Gloo TensorFlow MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow/tensorflow_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -494,14 +494,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/keras/keras_mnist_advanced.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -512,14 +512,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -530,14 +530,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -548,14 +548,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow.py test_elastic_tensorflow_keras.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -566,14 +566,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':spark: Spark Keras Rossmann Run (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_run.py --num-proc 2 --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -584,14 +584,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':spark: Spark Keras Rossmann Estimator (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_rossmann_estimator.py --num-proc 2 --work-dir /work --data-dir file:///data --epochs 3 --sample-rate 0.1"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -602,14 +602,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':spark: Spark Keras MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/keras/keras_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -620,14 +620,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -638,14 +638,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_7-tf1_15_5-keras2_2_4-torch1_8_1-mxnet1_5_1_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -656,14 +656,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -674,14 +674,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -692,14 +692,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -710,14 +710,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -728,14 +728,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -746,14 +746,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -764,14 +764,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -782,14 +782,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -800,14 +800,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -818,14 +818,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_9_3-keras2_9_0-torch1_11_0-mxnet1_7_0_p1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -836,14 +836,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -854,14 +854,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -872,14 +872,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -890,14 +890,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "horovodrun -np 2 python -m horovod.tensorflow.data.compute_worker /tmp/compute.json & horovodrun -np 2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -908,14 +908,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -926,14 +926,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -944,14 +944,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -962,14 +962,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -980,14 +980,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -998,14 +998,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_1
+      run: test-gpu-gloo-py3_8-tf2_10_1-keras2_10_0-torch1_12_1-mxnet1_8_0_p0-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1016,14 +1016,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1034,14 +1034,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1052,14 +1052,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1070,14 +1070,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1088,14 +1088,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1106,14 +1106,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1124,14 +1124,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1142,14 +1142,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1160,14 +1160,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1178,14 +1178,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1196,14 +1196,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1214,14 +1214,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1232,14 +1232,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1250,14 +1250,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-gpu-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1268,14 +1268,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1286,14 +1286,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1304,14 +1304,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: Gloo TensorFlow 2.0 MNIST Elastic horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 --min-np 2 --max-np 2 -H localhost:2,127.0.0.1:2 --gloo python /horovod/examples/elastic/tensorflow2/tensorflow2_mnist_elastic.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1322,14 +1322,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: Gloo PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1340,14 +1340,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: Gloo MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: horovodrun -np 2 -H localhost:2 --gloo python /horovod/examples/mxnet/mxnet_mnist.py
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1358,14 +1358,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':factory: Elastic Tests (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test/integration && HOROVOD_LOG_LEVEL=DEBUG pytest --forked -v --log-cli-level 10 --log-cli-format '[%(asctime)-15s %(levelname)s %(filename)s:%(lineno)d %(funcName)s()] %(message)s' --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.gloo.elastic.xml test_elastic_torch.py test_elastic_tensorflow2.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1376,14 +1376,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':jupyter: Run PyTests test_interactiverun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/test && pytest -v --capture=no --continue-on-collection-errors --junit-xml=/artifacts/junit.mpi.integration.xml integration/test_interactiverun.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1394,14 +1394,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':fire: MPI PyTorch MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/pytorch/pytorch_mnist.py --data-dir /data/pytorch_datasets"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1412,14 +1412,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':muscle: MPI MXNet MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " OMP_NUM_THREADS=1 \$(cat /mpirun_command) python /horovod/examples/mxnet/mxnet_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1430,14 +1430,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1448,14 +1448,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':tensorflow: MPI TensorFlow 2.0 Keras MNIST horovodrun (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c " \$(cat /mpirun_command) python /horovod/examples/tensorflow2/tensorflow2_keras_mnist.py"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1466,14 +1466,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark TensorFlow 2.0 MNIST Data Service (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "cd /horovod/examples/spark/tensorflow2; spark-submit --master \"local[2]\" \"/horovod/horovod/spark/tensorflow/compute_worker.py\" /tmp/compute.json & OMP_NUM_THREADS=1 /spark_env.sh spark-submit --master \"local[2]\" --py-files tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py,tensorflow2_mnist_data_service_train_fn_training_side_dispatcher.py tensorflow2_mnist_data_service.py /tmp/compute.json"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1484,14 +1484,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Torch MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3
@@ -1502,14 +1502,14 @@ steps:
     automatic: true
   agents:
     queue: 2x-gpu-v5111
-- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1)'
+- label: ':spark: Spark Lightning MNIST (test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2)'
   command: bash -c "OMP_NUM_THREADS=1 /spark_env.sh python /horovod/examples/spark/pytorch/pytorch_lightning_spark_mnist.py --num-proc 2 --work-dir /work --data-dir /data --epochs 3"
   artifact_paths: "artifacts/**"
   env:
     COMPOSE_HTTP_TIMEOUT: 300
   plugins:
   - docker-compose#v3.10.0:
-      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_1
+      run: test-mixed-openmpi-gloo-py3_8-tf2_11_0-keras2_11_0-torch1_13_1-mxnet1_9_1-pyspark3_3_2
       volumes: "./artifacts:/artifacts"
       config: docker-compose.test.yml
       pull-retries: 3


### PR DESCRIPTION
Another round of upgrading tested frameworks:
- fix MXNet versions
- upgrade torch to 1.13.1
- upgrade pyspark to 3.3.2, add 3.4.0, remove 3.2.3
- add Tensorflow 2.12.0, remove 2.9.3, upgrade to 2.11.1