### PR TITLE
add hip suffix to adapter_v2.cc when building with pytorch rocm

### DIFF
--- a/horovod/torch/CMakeLists.txt
+++ b/horovod/torch/CMakeLists.txt
@@ -74,7 +74,7 @@ list(APPEND PYTORCH_SOURCES "${PROJECT_SOURCE_DIR}/horovod/torch/handle_manager.
                             "${PROJECT_SOURCE_DIR}/horovod/torch/ready_event_hip.cc"
                             "${PROJECT_SOURCE_DIR}/horovod/torch/hip_util.cc"
                             "${PROJECT_SOURCE_DIR}/horovod/torch/mpi_ops_v2_hip.cc"
-                            "${PROJECT_SOURCE_DIR}/horovod/torch/adapter_v2.cc")
+                            "${PROJECT_SOURCE_DIR}/horovod/torch/adapter_v2_hip.cc")
 else()
 list(APPEND PYTORCH_SOURCES "${PROJECT_SOURCE_DIR}/horovod/torch/handle_manager.cc"
                             "${PROJECT_SOURCE_DIR}/horovod/torch/ready_event.cc"


### PR DESCRIPTION
Signed-off-by: Lang Xu xulang7@gmail.com

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Added `hip` suffix to adapter_v2.cc when building with pytorch rocm

Fixes #3837

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
