### PR TITLE
[CI] Move back to upstream buildkite trigger

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -530,7 +530,7 @@ def main():
                 f'    steps:\n'
                 f'      - name: Trigger Buildkite Pipeline\n'
                 f'        id: build\n'
-                f'        uses: EnricoMi/trigger-pipeline-action@master\n'
+                f'        uses: buildkite/trigger-pipeline-action@v1.3.0\n'
                 f'        env:\n'
                 f'          PIPELINE: "horovod/horovod"\n'
                 f'          # COMMIT is taken from GITHUB_SHA\n'

--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -530,7 +530,7 @@ def main():
                 f'    steps:\n'
                 f'      - name: Trigger Buildkite Pipeline\n'
                 f'        id: build\n'
-                f'        uses: buildkite/trigger-pipeline-action@v1.3.0\n'
+                f'        uses: buildkite/trigger-pipeline-action@v1.3.1\n'
                 f'        env:\n'
                 f'          PIPELINE: "horovod/horovod"\n'
                 f'          # COMMIT is taken from GITHUB_SHA\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4584,7 +4584,7 @@ jobs:
     steps:
       - name: Trigger Buildkite Pipeline
         id: build
-        uses: EnricoMi/trigger-pipeline-action@master
+        uses: buildkite/trigger-pipeline-action@v1.3.0
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA
@@ -4641,7 +4641,7 @@ jobs:
     steps:
       - name: Trigger Buildkite Pipeline
         id: build
-        uses: EnricoMi/trigger-pipeline-action@master
+        uses: buildkite/trigger-pipeline-action@v1.3.0
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4584,7 +4584,7 @@ jobs:
     steps:
       - name: Trigger Buildkite Pipeline
         id: build
-        uses: buildkite/trigger-pipeline-action@v1.3.0
+        uses: buildkite/trigger-pipeline-action@v1.3.1
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA
@@ -4641,7 +4641,7 @@ jobs:
     steps:
       - name: Trigger Buildkite Pipeline
         id: build
-        uses: buildkite/trigger-pipeline-action@v1.3.0
+        uses: buildkite/trigger-pipeline-action@v1.3.1
         env:
           PIPELINE: "horovod/horovod"
           # COMMIT is taken from GITHUB_SHA


### PR DESCRIPTION
Buildkite has merged my changes, so we can move back from my fork to the original trigger action.