### PR TITLE
TF: Add get_local_and_global_gradients() to PartialDistributedGradentTape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- TensorFlow: Added new `decoupled_gradient` to PartialDistributedGradientTape to retrieve local and non-local gradients separately. ([#3859](https://github.com/horovod/horovod/pull/3859))
+- TensorFlow: Added new `get_local_and_global_gradients` to PartialDistributedGradientTape to retrieve local and non-local gradients separately. ([#3859](https://github.com/horovod/horovod/pull/3859))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- TF: Added new `decoupled_gradient` to PartialDistributedGradientTape to retrieve local and non-local gradients separately. ([#3859](https://github.com/horovod/horovod/pull/3859))
+- TensorFlow: Added new `decoupled_gradient` to PartialDistributedGradientTape to retrieve local and non-local gradients separately. ([#3859](https://github.com/horovod/horovod/pull/3859))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- TF: Added new `decoupled_gradient` to PartialDistributedGradientTape to retrieve local and non-local gradients separately. ([#3859](https://github.com/horovod/horovod/pull/3859))
+
 ### Changed
 
 - Improved reducescatter performance by allocating output tensors before enqueuing the operation. ([#3824](https://github.com/horovod/horovod/pull/3824))
@@ -41,7 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ROCm: Fixed GPU MPI operations support in build. ([#3746](https://github.com/horovod/horovod/pull/3746))
 - PyTorch: Fixed linking order to avoid using Gloo from PyTorch dynamic libraries. ([#3750](https://github.com/horovod/horovod/pull/3750))
 - Fixed memory leak in `MPI_GPUAllgather`. ([#3727](https://github.com/horovod/horovod/pull/3727))
-- TensorFlow: Fixed deprecation warnings when building with TensorFlow 2.11. ([#3767](https://github.com/horovod/horovod/pull/3767)) 
+- TensorFlow: Fixed deprecation warnings when building with TensorFlow 2.11. ([#3767](https://github.com/horovod/horovod/pull/3767))
 - Keras: Added support for additional arguments to `SyncBatchNormalization._moments()`. ([#3775](https://github.com/horovod/horovod/pull/3775))
 - Fixed version number parsing with pypa/packaging 22.0. ([#3794](https://github.com/horovod/horovod/pull/3794))
 - TensorFlow: Fixed linking with nightly versions leading up to TensorFlow 2.12. ([#3755](https://github.com/horovod/horovod/pull/3755))

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1107,6 +1107,20 @@ if hasattr(tf, 'GradientTape'):
 
                 return [s2g[s] for s in sources]
 
+        def decoupled_gradient(self, target, sources, output_gradients=None, use_generic_names=False):
+            gradients = self.gradient(target=target, sources=sources, output_gradients=output_gradients, use_generic_names=use_generic_names)
+            # gradients are in the same order as sources.
+            local_vars_grads, global_vars_grads = [], []
+            for s, g in zip(sources, gradients):
+                is_local_source = s.ref() in self._local_sources if _IS_TF2 else s in self._local_sources
+                if is_local_source:
+                    local_vars_grads.append((s,g))
+                else:
+                    global_vars_grads.append((s,g))
+            del gradients
+            return local_vars_grads, global_vars_grads
+
+
     def DistributedGradientTape(gradtape, device_dense='', device_sparse='',
                                 compression=Compression.none, sparse_as_dense=False,
                                 op=Average, gradient_predivide_factor=1.0,

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1107,7 +1107,7 @@ if hasattr(tf, 'GradientTape'):
 
                 return [s2g[s] for s in sources]
 
-        def decoupled_gradient(self, target, sources, output_gradients=None, use_generic_names=False):
+        def get_local_and_global_gradients(self, target, sources, output_gradients=None, use_generic_names=False):
             gradients = self.gradient(target=target, sources=sources, output_gradients=output_gradients, use_generic_names=use_generic_names)
             # gradients are in the same order as sources.
             local_vars_grads, global_vars_grads = [], []

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -1120,7 +1120,6 @@ if hasattr(tf, 'GradientTape'):
             del gradients
             return local_vars_grads, global_vars_grads
 
-
     def DistributedGradientTape(gradtape, device_dense='', device_sparse='',
                                 compression=Compression.none, sparse_as_dense=False,
                                 op=Average, gradient_predivide_factor=1.0,

--- a/test/parallel/test_tensorflow.py
+++ b/test/parallel/test_tensorflow.py
@@ -5497,11 +5497,11 @@ class TensorFlowTests(BaseTensorFlowTests):
                 with tf.device("/gpu:%d" % local_rank):
                     tape = hvd.PartialDistributedGradientTape(tape, local_layers=local_layers)
                     allreduced_gradients = tape.gradient(l, model.trainable_weights)
-                    local_vars_grads, global_vars_grads = tape.decoupled_gradient(l, model.trainable_weights)
+                    local_vars_grads, global_vars_grads = tape.get_local_and_global_gradients(l, model.trainable_weights)
             else:
                 tape = hvd.PartialDistributedGradientTape(tape, local_layers=local_layers)
                 allreduced_gradients = tape.gradient(l, model.trainable_weights)
-                local_vars_grads, global_vars_grads = tape.decoupled_gradient(l, model.trainable_weights)
+                local_vars_grads, global_vars_grads = tape.get_local_and_global_gradients(l, model.trainable_weights)
 
             for var,grad in zip(model.trainable_weights, allreduced_gradients):
                 if _IS_TF2:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Adding a new `get_local_and_global_gradients()` method to the `PartialDistributedGradient` for use cases where the separation is needed.
*More context:* Following the discussions in [discussions/3705](https://github.com/horovod/horovod/discussions/3705) and #3643, in model parallelism use cases, each rank has two sets of gradients: local gradients and non-local gradients. The non-local gradients are allreduced and hence synced accross the ranks, but the local gradients remain specific to each rank.
Now for operations such as gradient norm calculation, it needs to be done on the local and non-local gradients separately otherwise the result on each rank will be different due to their local gradients.

This new method provides the decoupled gradients to be used for upstream operations such as gradient norm calculation.

