### PR TITLE
Re-enabling new keras optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improved reducescatter performance by allocating output tensors before enqueuing the operation. ([#3824](https://github.com/horovod/horovod/pull/3824))
 - Force tf.logical_and in hvd allreduce condition running on CPU. ([#3885](https://github.com/horovod/horovod/pull/3885))
+- Support TF Keras 2.11+ optimizers. ([#3860](https://github.com/horovod/horovod/pull/3860))
 
 ### Deprecated
 

--- a/examples/tensorflow2/tensorflow2_keras_mnist.py
+++ b/examples/tensorflow2/tensorflow2_keras_mnist.py
@@ -20,11 +20,6 @@ import tensorflow as tf
 import horovod
 import horovod.tensorflow.keras as hvd
 
-from packaging import version
-if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tensorflow.keras import optimizers
-else:
-    from tensorflow.keras.optimizers import legacy as optimizers
 
 def main():
     # Horovod: initialize Horovod.
@@ -59,7 +54,7 @@ def main():
 
     # Horovod: adjust learning rate based on number of GPUs.
     scaled_lr = 0.001 * hvd.size()
-    opt = optimizers.Adam(scaled_lr)
+    opt = tf.optimizers.Adam(scaled_lr)
 
     # Horovod: add Horovod DistributedOptimizer.
     opt = hvd.DistributedOptimizer(

--- a/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
+++ b/examples/tensorflow2/tensorflow2_mnist_data_service_train_fn_compute_side_dispatcher.py
@@ -21,11 +21,6 @@ from filelock import FileLock
 import horovod.tensorflow.keras as hvd
 from horovod.tensorflow.data.compute_service import TfDataServiceConfig
 
-from packaging import version
-if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tensorflow.keras import optimizers
-else:
-    from tensorflow.keras.optimizers import legacy as optimizers
 
 # arguments reuse_dataset and round_robin only used when single dispatcher is present
 def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, round_robin: bool = False):
@@ -69,7 +64,7 @@ def train_fn(compute_config: TfDataServiceConfig, reuse_dataset: bool = False, r
 
     # Horovod: adjust learning rate based on number of GPUs.
     scaled_lr = 0.001 * hvd.size()
-    opt = optimizers.Adam(scaled_lr)
+    opt = tf.optimizers.Adam(scaled_lr)
 
     # Horovod: add Horovod DistributedOptimizer.
     opt = hvd.DistributedOptimizer(

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -281,10 +281,11 @@ def reducescatter(backend, value, name, op):
     return _eval(backend, hvd.reducescatter(tf.constant(value, name=name), op=op))
 
 
-def load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects):
-    keras_subclasses = keras.optimizers.Optimizer.__subclasses__()
-    if hasattr(keras.optimizers, 'legacy'):
-        keras_subclasses.extend(keras.optimizers.legacy.Optimizer.__subclasses__())
+def load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects, legacy_opts=False):
+    if legacy_opts:
+        keras_subclasses = keras.optimizers.legacy.Optimizer.__subclasses__()
+    else:
+        keras_subclasses = keras.optimizers.Optimizer.__subclasses__()
 
     horovod_objects = {
         subclass.__name__.lower(): wrap_optimizer(subclass)

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -37,7 +37,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
         _HAS_AGGREGATE_GRAD = True
 
         def __init__(self, **kwargs):
-            super().__init__(**kwargs)
+            super(self.__class__, self).__init__(**kwargs)
 
             self._name = name or "Distributed%s" % self.__class__.__base__.__name__
             self._aggregated_gradients = False

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -21,23 +21,10 @@ import tensorflow as tf
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
 from horovod.tensorflow.gradient_aggregation_eager import LocalGradientAggregationHelperEager
 from horovod.tensorflow.mpi_ops import rank, size_op
-from horovod.common.util import support_non_legacy_keras_optimizers
+
 
 _PRE_TF_2_4_0 = version.parse(tf.__version__) < version.parse('2.4.0')
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
-
-
-def get_keras_optimizer_base_type(k):
-    if support_non_legacy_keras_optimizers(k):
-        return k.optimizers.Optimizer
-    else:
-        return tf.keras.optimizers.legacy.Optimizer
-
-
-def check_keras_optimizer_type(k, optimizer):
-    if not support_non_legacy_keras_optimizers(k):
-        if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
-            raise ValueError(f"Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
 
 
 def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sparse,
@@ -46,9 +33,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                  average_aggregated_gradients=False,
                                  groups=None, process_set=hvd.global_process_set,
                                  scale_local_gradients=True):
-    check_keras_optimizer_type(keras, optimizer)
-
-    class _DistributedOptimizer(get_keras_optimizer_base_type(keras)):
+    class _DistributedOptimizer(keras.optimizers.Optimizer):
         _HAS_AGGREGATE_GRAD = True
 
         def __init__(self, **kwargs):
@@ -279,7 +264,11 @@ def reducescatter(backend, value, name, op):
 
 
 def load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects):
-    keras_subclasses = get_keras_optimizer_base_type(keras).__subclasses__()
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+        keras_subclasses = keras.optimizers.Optimizer.__subclasses__()
+    else:
+        keras_subclasses = keras.optimizers.legacy.Optimizer.__subclasses__()
+
     horovod_objects = {
         subclass.__name__.lower(): wrap_optimizer(subclass)
         for subclass in keras_subclasses

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -37,7 +37,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
         _HAS_AGGREGATE_GRAD = True
 
         def __init__(self, **kwargs):
-            super(self.__class__, self).__init__(**kwargs)
+            super().__init__(**kwargs)
 
             self._name = name or "Distributed%s" % self.__class__.__base__.__name__
             self._aggregated_gradients = False

--- a/horovod/common/util.py
+++ b/horovod/common/util.py
@@ -23,7 +23,6 @@ import sysconfig
 import warnings
 
 from contextlib import contextmanager
-from packaging import version
 
 from horovod.common.exceptions import get_version_mismatch_message, HorovodVersionMismatchError
 
@@ -287,7 +286,3 @@ def is_version_greater_equal_than(ver, target):
                          "of: major.minor.patch. Received: {}".format(target))
 
     return version.parse(ver) >= version.parse(target)
-
-
-def support_non_legacy_keras_optimizers(k):
-    return version.parse(k.__version__.replace("-tf", "+tf")) < version.parse("2.11")

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -129,7 +129,7 @@ def PartialDistributedOptimizer(optimizer, name=None,
     Args:
         optimizer: Optimizer to use for computing gradients and applying updates.
         process_set: Gradients will only be reduced over Horovod processes belonging
-                   to this process set. Defaults to the global process set.  
+                   to this process set. Defaults to the global process set.
         local_layers: A collection of type tf.keras.layers.Layer local layers that their gradients need not
             to be synced accross ranks and is kept and applied locally.
             If not provided, the functionality of PartialDistributedOptimizer is
@@ -282,8 +282,4 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_modules = {keras.optimizers.Optimizer.__module__}
-    else:
-        optimizer_modules = {keras.optimizers.legacy.Optimizer.__module__}
-    return _impl.load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects)
+    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects)

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -249,7 +249,7 @@ def reducescatter(value, name=None, op=Average):
     return _impl.reducescatter(K, value, name, op)
 
 
-def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none):
+def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none, legacy_opts=False):
     """
     Loads a saved Keras model with a Horovod DistributedOptimizer.
 
@@ -272,6 +272,7 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
         compression: Compression algorithm used to reduce the amount of data
                      sent and received by each worker node.  Defaults to not
                      using compression.
+        legacy_opts: If True, model uses tf.keras.optimizers.legacy.* optimizers
 
     Returns:
         A Keras model instance.
@@ -282,4 +283,4 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects)
+    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects, legacy_opts)

--- a/horovod/keras/__init__.py
+++ b/horovod/keras/__init__.py
@@ -129,7 +129,7 @@ def PartialDistributedOptimizer(optimizer, name=None,
     Args:
         optimizer: Optimizer to use for computing gradients and applying updates.
         process_set: Gradients will only be reduced over Horovod processes belonging
-                   to this process set. Defaults to the global process set.
+                   to this process set. Defaults to the global process set.  
         local_layers: A collection of type tf.keras.layers.Layer local layers that their gradients need not
             to be synced accross ranks and is kept and applied locally.
             If not provided, the functionality of PartialDistributedOptimizer is
@@ -282,5 +282,8 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    optimizer_modules = {_impl.get_keras_optimizer_base_type(keras).__module__}
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+        optimizer_modules = {keras.optimizers.Optimizer.__module__}
+    else:
+        optimizer_modules = {keras.optimizers.legacy.Optimizer.__module__}
     return _impl.load_model(keras, wrap_optimizer, optimizer_modules, filepath, custom_optimizers, custom_objects)

--- a/horovod/spark/keras/bare.py
+++ b/horovod/spark/keras/bare.py
@@ -76,7 +76,7 @@ def save_bare_keras_optimizer(optimizer, h5py_file):
             },
         }, default=get_json_type).encode('utf8')
 
-        symbolic_weights = getattr(optimizer, 'weights')
+        symbolic_weights = getattr(optimizer, 'variables')
         if symbolic_weights:
             optimizer_weights_group = h5py_file['optimizer_weights']
             weight_values = K.batch_get_value(symbolic_weights)

--- a/horovod/spark/keras/bare.py
+++ b/horovod/spark/keras/bare.py
@@ -76,7 +76,7 @@ def save_bare_keras_optimizer(optimizer, h5py_file):
             },
         }, default=get_json_type).encode('utf8')
 
-        symbolic_weights = getattr(optimizer, 'variables')
+        symbolic_weights = optimizer.variables()
         if symbolic_weights:
             optimizer_weights_group = h5py_file['optimizer_weights']
             weight_values = K.batch_get_value(symbolic_weights)

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -35,7 +35,6 @@ from horovod.spark.keras import remote
 from horovod.spark.keras.util import TFKerasUtil
 from horovod.spark.keras.datamodule import PetastormDataModule
 
-from horovod._keras import check_keras_optimizer_type
 
 class KerasEstimatorParamsWriter(HorovodParamsWriter):
     def saveImpl(self, path):
@@ -231,7 +230,12 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
             if isinstance(optimizer, str):
                 pass
             else:
-                check_keras_optimizer_type(tf.keras, optimizer)
+                if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+                    if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
+                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
+                else:
+                    if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
+                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
 
         return TFKerasUtil
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -80,10 +80,10 @@ class KerasEstimatorParamsReader(HorovodParamsReader):
         model_name = EstimatorParams.model.name
         if model_name in dict:
             model = _param_deserializer_fn(model_name, dict[model_name], TFKerasUtil, custom_objects)
-            dict[model_name] = model
+
         for key, val in dict.items():
             if key == model_name:
-                continue
+                dict[model_name] = model
             dict[key] = _param_deserializer_fn(key, val, TFKerasUtil, custom_objects, model)
         return dict
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -224,19 +224,6 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
             if not isinstance(model, tf.keras.Model):
                 raise ValueError(
                     "model has to be an instance of tensorflow.keras.Model")
-
-        optimizer = self.getOptimizer()
-        if optimizer:
-            if isinstance(optimizer, str):
-                pass
-            else:
-                if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-                    if not isinstance(optimizer, tf.keras.optimizers.Optimizer):
-                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.Optimizer before Keras 2.11: {type(optimizer).__name__}")
-                else:
-                    if not isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer):
-                        raise ValueError(f"optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: {type(optimizer).__name__}")
-
         return TFKerasUtil
 
     def setCustomObjects(self, value):

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -333,6 +333,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                       metrics=metrics)
 
         if optimizer_weight_values:
+            if hasattr(optimizer, 'build'):
+                model.optimizer.build(model.trainable_weights)
             model.optimizer.set_weights(optimizer_weight_values)
 
         return keras_utils.serialize_model(model)

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -319,7 +319,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
 
         metrics = self.getMetrics()
         gradient_compression = self.getGradientCompression()
-        optimizer_weight_values = optimizer.get_weights()
+        optimizer_weight_values = optimizer.variables()
 
         dist_optimizer_args = dict(optimizer=optimizer)
         if gradient_compression:

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -20,13 +20,15 @@ import h5py
 from packaging import version
 from horovod.runner.common.util import codec
 
-from horovod._keras import get_keras_optimizer_base_type
 
 def serialize_bare_keras_optimizer(x):
     import keras
     from horovod.spark.keras.bare import save_bare_keras_optimizer
 
-    optimizer_class = get_keras_optimizer_base_type(keras)
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+        optimizer_class = keras.optimizers.Optimizer
+    else:
+        optimizer_class = keras.optimizers.legacy.Optimizer
 
     return _serialize_keras_optimizer(x,
                                       optimizer_class=optimizer_class,
@@ -43,7 +45,10 @@ def serialize_tf_keras_optimizer(x):
     import tensorflow as tf
     from horovod.spark.keras.tensorflow import save_tf_keras_optimizer
 
-    optimizer_class = get_keras_optimizer_base_type(tf.keras)
+    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+        optimizer_class = tf.keras.optimizers.Optimizer
+    else:
+        optimizer_class = tf.keras.optimizers.legacy.Optimizer
 
     return _serialize_keras_optimizer(x,
                                       optimizer_class=optimizer_class,

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -39,10 +39,10 @@ def serialize_tf_keras_optimizer(x):
                                       save_optimizer_fn=save_tf_keras_optimizer)
 
 
-def deserialize_tf_keras_optimizer(x):
+def deserialize_tf_keras_optimizer(x, model=None):
     from horovod.spark.keras.tensorflow import load_tf_keras_optimizer
 
-    return _deserialize_keras_optimizer(x,
+    return _deserialize_keras_optimizer(x, model,
                                         load_keras_optimizer_fn=load_tf_keras_optimizer)
 
 
@@ -60,9 +60,9 @@ def is_string(obj):
     return isinstance(obj, str)
 
 
-def _deserialize_keras_optimizer(serialized_opt, load_keras_optimizer_fn):
+def _deserialize_keras_optimizer(serialized_opt, model, load_keras_optimizer_fn):
     if is_string(serialized_opt):
         return serialized_opt
     bio = io.BytesIO(serialized_opt)
     with h5py.File(bio, 'r') as f:
-        return load_keras_optimizer_fn(f)
+        return load_keras_optimizer_fn(f, model=model)

--- a/horovod/spark/keras/optimizer.py
+++ b/horovod/spark/keras/optimizer.py
@@ -22,16 +22,8 @@ from horovod.runner.common.util import codec
 
 
 def serialize_bare_keras_optimizer(x):
-    import keras
     from horovod.spark.keras.bare import save_bare_keras_optimizer
-
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_class = keras.optimizers.Optimizer
-    else:
-        optimizer_class = keras.optimizers.legacy.Optimizer
-
     return _serialize_keras_optimizer(x,
-                                      optimizer_class=optimizer_class,
                                       save_optimizer_fn=save_bare_keras_optimizer)
 
 
@@ -42,16 +34,8 @@ def deserialize_bare_keras_optimizer(x):
 
 
 def serialize_tf_keras_optimizer(x):
-    import tensorflow as tf
     from horovod.spark.keras.tensorflow import save_tf_keras_optimizer
-
-    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_class = tf.keras.optimizers.Optimizer
-    else:
-        optimizer_class = tf.keras.optimizers.legacy.Optimizer
-
     return _serialize_keras_optimizer(x,
-                                      optimizer_class=optimizer_class,
                                       save_optimizer_fn=save_tf_keras_optimizer)
 
 
@@ -62,17 +46,14 @@ def deserialize_tf_keras_optimizer(x):
                                         load_keras_optimizer_fn=load_tf_keras_optimizer)
 
 
-def _serialize_keras_optimizer(opt, optimizer_class, save_optimizer_fn):
+def _serialize_keras_optimizer(opt, save_optimizer_fn):
     if isinstance(opt, str):
         return opt
-    elif isinstance(opt, optimizer_class):
+    else:
         bio = io.BytesIO()
         with h5py.File(bio, 'w') as f:
             save_optimizer_fn(opt, f)
         return codec.dumps_base64(bio.getvalue())
-    else:
-        raise \
-            ValueError(f'Keras optimizer has to be an instance of str or {optimizer_class}')
 
 
 def is_string(obj):

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -59,7 +59,7 @@ def save_tf_keras_optimizer(optimizer, h5py_file):
             default=serialization.get_json_type).encode('utf8')
 
         # Save optimizer weights.
-        symbolic_weights = getattr(optimizer, 'weights')
+        symbolic_weights = getattr(optimizer, 'variables')
         if symbolic_weights:
             optimizer_weights_group = h5py_file.create_group('optimizer_weights')
             weight_values = K.batch_get_value(symbolic_weights)

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -125,7 +125,5 @@ def load_tf_keras_optimizer(h5py_file, custom_objects=None):
         optimizer_weight_values = [optimizer_weights_group[n].value for n in
                                    optimizer_weight_names]
     if optimizer_weight_values:
-        if hasattr(optimizer, 'build'):
-            model.optimizer.build(model.trainable_weights)
         optimizer.set_weights(optimizer_weight_values)
     return optimizer

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -79,7 +79,7 @@ def save_tf_keras_optimizer(optimizer, h5py_file):
     h5py_file.flush()
 
 
-def load_tf_keras_optimizer(h5py_file, custom_objects=None):
+def load_tf_keras_optimizer(h5py_file, custom_objects=None, model=None):
     if not custom_objects:
         custom_objects = {}
 
@@ -125,5 +125,7 @@ def load_tf_keras_optimizer(h5py_file, custom_objects=None):
         optimizer_weight_values = [optimizer_weights_group[n].value for n in
                                    optimizer_weight_names]
     if optimizer_weight_values:
+        if hasattr(optimizer, 'build'):
+            optimizer.build(model.trainable_weights)
         optimizer.set_weights(optimizer_weight_values)
     return optimizer

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -125,5 +125,7 @@ def load_tf_keras_optimizer(h5py_file, custom_objects=None):
         optimizer_weight_values = [optimizer_weights_group[n].value for n in
                                    optimizer_weight_names]
     if optimizer_weight_values:
+        if hasattr(optimizer, 'build'):
+            model.optimizer.build(model.trainable_weights)
         optimizer.set_weights(optimizer_weight_values)
     return optimizer

--- a/horovod/spark/keras/tensorflow.py
+++ b/horovod/spark/keras/tensorflow.py
@@ -59,7 +59,7 @@ def save_tf_keras_optimizer(optimizer, h5py_file):
             default=serialization.get_json_type).encode('utf8')
 
         # Save optimizer weights.
-        symbolic_weights = getattr(optimizer, 'variables')
+        symbolic_weights = optimizer.variables()
         if symbolic_weights:
             optimizer_weights_group = h5py_file.create_group('optimizer_weights')
             weight_values = K.batch_get_value(symbolic_weights)

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -695,7 +695,7 @@ if _LegacyOptimizer is not None:
         def register_local_var(self, var):
             """Registers a source/variable as worker local. Horovod will not perform any global
             operations on gradients corresponding to these sources and will instead return the local
-            gradient."""    
+            gradient."""
             if self._agg_helper:
                 self._agg_helper.register_local_var(var)
             elif _IS_TF2:
@@ -1004,7 +1004,7 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             process_set=process_set,
             scale_local_gradients=scale_local_gradients
         )
-    elif isinstance(optimizer, tf.keras.optimizers.Optimizer):
+    else:
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
 
@@ -1022,9 +1022,6 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             process_set=process_set,
             scale_local_gradients=scale_local_gradients
         )
-    else:
-        raise ValueError('Provided optimizer doesn\'t inherit from either legacy '
-                         'TensorFlow or Keras optimizer: %s' % optimizer)
 
 
 if hasattr(tf, 'GradientTape'):

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -43,7 +43,6 @@ from horovod.tensorflow.util import _executing_eagerly, _make_subgraph, _cache, 
 from horovod.tensorflow.mpi_ops import join
 from horovod.tensorflow.sync_batch_norm import SyncBatchNormalization
 from horovod.tensorflow.gradient_aggregation import LocalGradientAggregationHelper
-from horovod.common.util import support_non_legacy_keras_optimizers
 
 import tensorflow as tf
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
@@ -696,7 +695,7 @@ if _LegacyOptimizer is not None:
         def register_local_var(self, var):
             """Registers a source/variable as worker local. Horovod will not perform any global
             operations on gradients corresponding to these sources and will instead return the local
-            gradient."""
+            gradient."""    
             if self._agg_helper:
                 self._agg_helper.register_local_var(var)
             elif _IS_TF2:
@@ -1005,9 +1004,7 @@ def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='
             process_set=process_set,
             scale_local_gradients=scale_local_gradients
         )
-    elif (isinstance(optimizer, tf.keras.optimizers.Optimizer) or
-          (not support_non_legacy_keras_optimizers(tf.keras) and
-           isinstance(optimizer, tf.keras.optimizers.legacy.Optimizer))):
+    elif isinstance(optimizer, tf.keras.optimizers.Optimizer):
         if op == Adasum:
             raise ValueError('op == Adasum is not supported yet with Keras')
 

--- a/horovod/tensorflow/elastic.py
+++ b/horovod/tensorflow/elastic.py
@@ -140,7 +140,7 @@ class TensorFlowKerasState(ObjectState):
             self._saved_optimizer_state = [tf.identity(var) for var in self.optimizer.variables()]
         else:
             self._saved_model_state = self.model.get_weights()
-            self._saved_optimizer_state = self.optimizer.variables() if _IS_TF2 else self.optimizer.get_weights()
+            self._saved_optimizer_state = [var.numpy() for var in self.optimizer.variables()] if _IS_TF2 else self.optimizer.get_weights()
 
     def _load_model(self):
         if _executing_eagerly():

--- a/horovod/tensorflow/elastic.py
+++ b/horovod/tensorflow/elastic.py
@@ -140,7 +140,7 @@ class TensorFlowKerasState(ObjectState):
             self._saved_optimizer_state = [tf.identity(var) for var in self.optimizer.variables()]
         else:
             self._saved_model_state = self.model.get_weights()
-            self._saved_optimizer_state = self.optimizer.get_weights()
+            self._saved_optimizer_state = self.optimizer.variables()
 
     def _load_model(self):
         if _executing_eagerly():

--- a/horovod/tensorflow/elastic.py
+++ b/horovod/tensorflow/elastic.py
@@ -140,7 +140,7 @@ class TensorFlowKerasState(ObjectState):
             self._saved_optimizer_state = [tf.identity(var) for var in self.optimizer.variables()]
         else:
             self._saved_model_state = self.model.get_weights()
-            self._saved_optimizer_state = self.optimizer.variables()
+            self._saved_optimizer_state = self.optimizer.variables() if _IS_TF2 else self.optimizer.get_weights()
 
     def _load_model(self):
         if _executing_eagerly():

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -200,7 +200,7 @@ class LocalGradientAggregationHelperEager:
                 # We account for this by calling `_aggregate_gradients()` for steps where we do
                 # not call `apply_gradients()`.
                 transformed_grads_and_vars = optimizer._transform_unaggregated_gradients(
-                    args[0])
+                    args[0]) if hasattr(optimizer, '_transform_unaggregated_gradients') else args[0]
                 _ = optimizer._aggregate_gradients(transformed_grads_and_vars)
 
             return increment_optimizer_iteration()

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -191,7 +191,10 @@ class LocalGradientAggregationHelperEager:
             # property instead of the unsafe `_iterations`.
 
             if hasattr(optimizer, "iterations") and optimizer.iterations is not None:
-                return optimizer.iterations.assign_add(1).op
+                if hasattr(super(self.__class__, optimizer), '_compute_gradients'):
+                    return optimizer.iterations.assign_add(1).op
+                else:
+                    return optimizer.iterations.assign_add(1)
             return tf.no_op()
 
         def non_aggregation_step():

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -191,7 +191,7 @@ class LocalGradientAggregationHelperEager:
             # property instead of the unsafe `_iterations`.
 
             if hasattr(optimizer, "iterations") and optimizer.iterations is not None:
-                if hasattr(super(self.__class__, optimizer), '_compute_gradients'):
+                if hasattr(super(optimizer.__class__, optimizer), '_compute_gradients'):
                     return optimizer.iterations.assign_add(1).op
                 else:
                     return optimizer.iterations.assign_add(1)

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -231,7 +231,7 @@ def reducescatter(value, name=None, op=Average):
     return _impl.reducescatter(K, value, name, op)
 
 
-def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none):
+def load_model(filepath, custom_optimizers=None, custom_objects=None, compression=Compression.none, legacy_opts=False):
     """
     Loads a saved Keras model with a Horovod DistributedOptimizer.
 
@@ -254,6 +254,7 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
         compression: Compression algorithm used to reduce the amount of data
                      sent and received by each worker node.  Defaults to not
                      using compression.
+        legacy_opts: If True, model uses tf.keras.optimizers.legacy.* optimizers
 
     Returns:
         A Keras model instance.
@@ -264,4 +265,4 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects)
+    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects, legacy_opts)

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -46,20 +46,6 @@ import horovod._keras as _impl
 from horovod.tensorflow.keras import callbacks, elastic
 
 
-try:
-    # In later versions of TensorFlow, optimizers are spread across multiple modules. This set is used to distinguish
-    # stock optimizers that come with tf.keras from custom optimizers that may need to be wrapped specially.
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer_type = tf.keras.optimizers.Optimizer
-    else:
-        optimizer_type = keras.optimizers.legacy.Optimizer
-
-    _OPTIMIZER_MODULES = set([obj.__module__ for name, obj in inspect.getmembers(tf.keras.optimizers)
-                              if isinstance(obj, type(optimizer_type))])
-except:
-    _OPTIMIZER_MODULES = set()
-
-
 def DistributedOptimizer(optimizer, name=None,
                          device_dense='', device_sparse='',
                          compression=Compression.none,
@@ -278,4 +264,4 @@ def load_model(filepath, custom_optimizers=None, custom_objects=None, compressio
     """
     def wrap_optimizer(cls):
         return lambda **kwargs: DistributedOptimizer(cls(**kwargs), compression=compression)
-    return _impl.load_model(keras, wrap_optimizer, _OPTIMIZER_MODULES, filepath, custom_optimizers, custom_objects)
+    return _impl.load_model(keras, wrap_optimizer, filepath, custom_optimizers, custom_objects)

--- a/horovod/tensorflow/keras/__init__.py
+++ b/horovod/tensorflow/keras/__init__.py
@@ -49,7 +49,10 @@ from horovod.tensorflow.keras import callbacks, elastic
 try:
     # In later versions of TensorFlow, optimizers are spread across multiple modules. This set is used to distinguish
     # stock optimizers that come with tf.keras from custom optimizers that may need to be wrapped specially.
-    optimizer_type = _impl.get_keras_optimizer_base_type(tf.keras)
+    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+        optimizer_type = tf.keras.optimizers.Optimizer
+    else:
+        optimizer_type = keras.optimizers.legacy.Optimizer
 
     _OPTIMIZER_MODULES = set([obj.__module__ for name, obj in inspect.getmembers(tf.keras.optimizers)
                               if isinstance(obj, type(optimizer_type))])

--- a/test/integration/data/elastic_tensorflow2_main.py
+++ b/test/integration/data/elastic_tensorflow2_main.py
@@ -23,12 +23,6 @@ import tensorflow as tf
 
 import horovod.tensorflow as hvd
 
-from packaging import version
-if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-    from tensorflow.keras import optimizers
-else:
-    from tensorflow.keras.optimizers import legacy as optimizers
-
 parser = argparse.ArgumentParser(description='TensorFlow 2 Elastic Test',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -64,7 +58,7 @@ target = tf.one_hot(indices, 2)
 
 lr = 0.001
 model = tf.keras.Sequential([tf.keras.layers.Dense(2, activation='softmax')])
-optimizer = optimizers.SGD(lr * hvd.size())
+optimizer = tf.optimizers.SGD(lr * hvd.size())
 
 hostname = os.environ.get('HOROVOD_HOSTNAME')
 start_rank = int(os.environ.get('HOROVOD_RANK', 0))

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -80,10 +80,7 @@ def get_mock_fit_fn():
 
 
 def get_sgd_optimizer():
-    if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-        optimizer = tf.keras.optimizers.SGD(lr=0.1)
-    else:
-        optimizer = tf.keras.optimizers.legacy.SGD(lr=0.1)
+    optimizer = tf.keras.optimizers.SGD(lr=0.1)
     return optimizer
 
 
@@ -212,10 +209,7 @@ class SparkKerasTests(tf.test.TestCase):
 
     def test_fit_model_multiclass(self):
         model = create_mnist_model()
-        if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            optimizer = tf.keras.optimizers.Adadelta(1.0)
-        else:
-            optimizer = tf.keras.optimizers.legacy.Adadelta(1.0)
+        optimizer = tf.keras.optimizers.Adadelta(1.0)
         loss = tf.keras.losses.categorical_crossentropy
 
         for num_cores in [2, constants.TOTAL_BUFFER_MEMORY_CAP_GIB + 1]:

--- a/test/parallel/test_keras.py
+++ b/test/parallel/test_keras.py
@@ -235,9 +235,9 @@ class KerasTests(tf.test.TestCase):
                 self.assertEqual(len(model.optimizer.weights), 5)
 
     def _check_optimizer_weights(self, opt, new_opt):
-        self.assertEqual(len(opt.get_weights()), len(new_opt.get_weights()))
-        for weights, new_weights in zip(opt.get_weights(),
-                                        new_opt.get_weights()):
+        self.assertEqual(len(opt.variables()), len(new_opt.variables()))
+        for weights, new_weights in zip(opt.variables(),
+                                        new_opt.variables()):
             if np.isscalar(weights):
                 self.assertEqual(weights, new_weights)
             else:

--- a/test/parallel/test_keras.py
+++ b/test/parallel/test_keras.py
@@ -104,7 +104,7 @@ class KerasTests(tf.test.TestCase):
     def test_load_model_custom_optimizers(self):
         class TestOptimizer(keras.optimizers.RMSprop):
             def __init__(self, **kwargs):
-                super(TestOptimizer, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
         with self.test_session(config=self.config) as sess:
             K.set_session(sess)
@@ -139,7 +139,7 @@ class KerasTests(tf.test.TestCase):
     def test_load_model_custom_objects(self):
         class TestOptimizer(keras.optimizers.RMSprop):
             def __init__(self, **kwargs):
-                super(TestOptimizer, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
         with self.test_session(config=self.config) as sess:
             K.set_session(sess)

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -325,9 +325,8 @@ class Tf2KerasTests(tf.test.TestCase):
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
 
-            # def update_step(self, gradient, variable):
-            #     lr = tf.cast(self.learning_rate, variable.dtype)
-            #     variable.assign_add(-gradient * lr)
+            def update_step(self, gradient, variable):
+                variable.assign_add(gradient)
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
@@ -437,9 +436,8 @@ class Tf2KerasTests(tf.test.TestCase):
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
 
-            # def update_step(self, gradient, variable):
-            #     lr = tf.cast(self.learning_rate, variable.dtype)
-            #     variable.assign_add(-gradient * lr)
+            def update_step(self, gradient, variable):
+                variable.assign_add(gradient)
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -32,7 +32,7 @@ if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
-        from tensorflow.keras.optimizers import Optimizer
+        from tensorflow.keras.optimizers import SGD as Optimizer
 else:
     from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
 
@@ -325,6 +325,10 @@ class Tf2KerasTests(tf.test.TestCase):
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
 
+            def update_step(self, gradient, variable):
+                lr = tf.cast(self.learning_rate, variable.dtype)
+                variable.assign_add(-gradient * lr)
+
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
             optimizer=TestingOptimizer("test"),
@@ -432,6 +436,10 @@ class Tf2KerasTests(tf.test.TestCase):
 
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
+
+            def update_step(self, gradient, variable):
+                lr = tf.cast(self.learning_rate, variable.dtype)
+                variable.assign_add(-gradient * lr)
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -30,11 +30,11 @@ from horovod.common.util import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
-        from keras.optimizer_v2 import optimizer_v2
+        from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
-        from keras.optimizers.optimizer_v2 import optimizer_v2
+        from tensorflow.keras.optimizers import Optimizer
 else:
-    from tensorflow.python.keras.optimizer_v2 import optimizer_v2
+    from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
 
 import horovod.keras as hvd_keras
 import horovod.tensorflow.keras as hvd
@@ -153,7 +153,7 @@ class Tf2KerasTests(tf.test.TestCase):
         model.train_on_batch(x, y)
 
     def test_legacy_optimizer(self):
-        if not (keras.optimizers, 'legacy'):
+        if not hasattr(keras.optimizers, 'legacy'):
             self.skipTest("Keras legacy optimizers not available")
 
         opt = keras.optimizers.legacy.Adam(lr=0.0001)
@@ -304,7 +304,7 @@ class Tf2KerasTests(tf.test.TestCase):
         [False]
     ])
     def test_gradient_aggregation(self, average_aggregated_gradients):
-        class TestingOptimizer(optimizer_v2.OptimizerV2):
+        class TestingOptimizer(Optimizer):
             """
             Custom optimizer we use for testing gradient aggregation.
             """
@@ -407,7 +407,7 @@ class Tf2KerasTests(tf.test.TestCase):
         [False]
     ])
     def test_gradient_aggregation_with_local_vars(self, average_aggregated_gradients):
-        class TestingOptimizer(optimizer_v2.OptimizerV2):
+        class TestingOptimizer(Optimizer):
             """
             Custom optimizer we use for testing gradient aggregation.
             """

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -32,7 +32,7 @@ if is_version_greater_equal_than(tf.__version__, "2.6.0"):
     if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
-        from tensorflow.keras.optimizers import SGD as Optimizer
+        from tensorflow.keras.optimizers import Optimizer
 else:
     from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
 
@@ -311,8 +311,8 @@ class Tf2KerasTests(tf.test.TestCase):
 
             def __init__(self, name, **kwargs):
                 super().__init__(name=name, **kwargs)
-                # if hasattr(self, '_build_learning_rate'):
-                #     self._learning_rate = self._build_learning_rate(0.1)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
                 config = super().get_config()
@@ -422,8 +422,8 @@ class Tf2KerasTests(tf.test.TestCase):
 
             def __init__(self, name, **kwargs):
                 super().__init__(name=name, **kwargs)
-                # if hasattr(self, '_build_learning_rate'):
-                #     self._learning_rate = self._build_learning_rate(0.1)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
                 config = super().get_config()
@@ -456,7 +456,7 @@ class Tf2KerasTests(tf.test.TestCase):
         X = [tf.Variable([x_0]) for x_0 in X_0]
         Y = [tf.Variable([y_0, y_1]) for y_0, y_1 in zip(Y_0, Y_1)]
         variables = [X, Y]
-
+        flatten_variables = [item for sublist in variables for item in sublist]
         for i in range(num_local_vars):
             x_var = X[i]
             y_var = Y[i]
@@ -528,7 +528,7 @@ class Tf2KerasTests(tf.test.TestCase):
         total_num_of_steps = 10
         for idx in range(total_num_of_steps):
             if _PRE_TF_2_2_0:
-                compute_and_apply_gradients_in_tf_function(var_list=variables)
+                compute_and_apply_gradients_in_tf_function(var_list=flatten_variables)
             else:
                 # In 2.2 and 2.3 the horovod optimizer sets `_HAS_AGGREGATE_GRAD = True`.
                 # This configures tf.keras to call `_aggregate_gradients()` outside of
@@ -536,7 +536,7 @@ class Tf2KerasTests(tf.test.TestCase):
                 # False when calling `apply_gradients()` to prevent it from calling
                 # `_aggregate_gradients()` again.
                 compute_and_apply_gradients_in_tf_function(
-                    var_list=variables,
+                    var_list=flatten_variables,
                     experimental_aggregate_gradients=False)
 
             expected_x, expected_y = compute_expected_value(idx)

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -310,7 +310,7 @@ class Tf2KerasTests(tf.test.TestCase):
             """
 
             def __init__(self, name, **kwargs):
-                super().__init__(name, **kwargs)
+                super().__init__(name=name, **kwargs)
                 # if hasattr(self, '_build_learning_rate'):
                 #     self._learning_rate = self._build_learning_rate(0.1)
 
@@ -422,7 +422,7 @@ class Tf2KerasTests(tf.test.TestCase):
             """
 
             def __init__(self, name, **kwargs):
-                super().__init__(name, **kwargs)
+                super().__init__(name=name, **kwargs)
                 # if hasattr(self, '_build_learning_rate'):
                 #     self._learning_rate = self._build_learning_rate(0.1)
 

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -311,8 +311,8 @@ class Tf2KerasTests(tf.test.TestCase):
 
             def __init__(self, name, **kwargs):
                 super().__init__(name, **kwargs)
-                if hasattr(self, '_build_learning_rate'):
-                    self._learning_rate = self._build_learning_rate(0.1)
+                # if hasattr(self, '_build_learning_rate'):
+                #     self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
                 config = super().get_config()
@@ -325,9 +325,9 @@ class Tf2KerasTests(tf.test.TestCase):
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
 
-            def update_step(self, gradient, variable):
-                lr = tf.cast(self.learning_rate, variable.dtype)
-                variable.assign_add(-gradient * lr)
+            # def update_step(self, gradient, variable):
+            #     lr = tf.cast(self.learning_rate, variable.dtype)
+            #     variable.assign_add(-gradient * lr)
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
@@ -423,8 +423,8 @@ class Tf2KerasTests(tf.test.TestCase):
 
             def __init__(self, name, **kwargs):
                 super().__init__(name, **kwargs)
-                if hasattr(self, '_build_learning_rate'):
-                    self._learning_rate = self._build_learning_rate(0.1)
+                # if hasattr(self, '_build_learning_rate'):
+                #     self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
                 config = super().get_config()
@@ -437,9 +437,9 @@ class Tf2KerasTests(tf.test.TestCase):
             def _resource_apply_dense(self, grad, var, apply_state=None):
                 return var.assign_add(grad)
 
-            def update_step(self, gradient, variable):
-                lr = tf.cast(self.learning_rate, variable.dtype)
-                variable.assign_add(-gradient * lr)
+            # def update_step(self, gradient, variable):
+            #     lr = tf.cast(self.learning_rate, variable.dtype)
+            #     variable.assign_add(-gradient * lr)
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -309,6 +309,9 @@ class Tf2KerasTests(tf.test.TestCase):
             Custom optimizer we use for testing gradient aggregation.
             """
 
+            def __init__(self, name, **kwargs):
+                super(self.__class__, self).__init__(name, **kwargs)
+
             def get_config(self):
                 config = super(TestingOptimizer, self).get_config()
                 return config
@@ -322,7 +325,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
-            optimizer=TestingOptimizer("test"),
+            optimizer=TestingOptimizer("test", lr=0.1),
             backward_passes_per_step=backward_passes_per_step,
             average_aggregated_gradients=average_aggregated_gradients,
             sparse_as_dense=True,
@@ -412,6 +415,9 @@ class Tf2KerasTests(tf.test.TestCase):
             Custom optimizer we use for testing gradient aggregation.
             """
 
+            def __init__(self, name, **kwargs):
+                super(self.__class__, self).__init__(name, **kwargs)
+
             def get_config(self):
                 config = super(TestingOptimizer, self).get_config()
                 return config
@@ -425,7 +431,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
-            optimizer=TestingOptimizer("test"),
+            optimizer=TestingOptimizer("test", lr=0.1),
             backward_passes_per_step=backward_passes_per_step,
             average_aggregated_gradients=average_aggregated_gradients,
             sparse_as_dense=True,

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -310,10 +310,12 @@ class Tf2KerasTests(tf.test.TestCase):
             """
 
             def __init__(self, name, **kwargs):
-                super(self.__class__, self).__init__(name, **kwargs)
+                super().__init__(name, **kwargs)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
-                config = super(TestingOptimizer, self).get_config()
+                config = super().get_config()
                 return config
 
             def _create_slots(self, var_list):
@@ -325,7 +327,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
-            optimizer=TestingOptimizer("test", lr=0.1),
+            optimizer=TestingOptimizer("test"),
             backward_passes_per_step=backward_passes_per_step,
             average_aggregated_gradients=average_aggregated_gradients,
             sparse_as_dense=True,
@@ -416,10 +418,12 @@ class Tf2KerasTests(tf.test.TestCase):
             """
 
             def __init__(self, name, **kwargs):
-                super(self.__class__, self).__init__(name, **kwargs)
+                super().__init__(name, **kwargs)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_config(self):
-                config = super(TestingOptimizer, self).get_config()
+                config = super().get_config()
                 return config
 
             def _create_slots(self, var_list):
@@ -431,7 +435,7 @@ class Tf2KerasTests(tf.test.TestCase):
 
         backward_passes_per_step = 4
         hvd_optimizer = hvd.DistributedOptimizer(
-            optimizer=TestingOptimizer("test", lr=0.1),
+            optimizer=TestingOptimizer("test"),
             backward_passes_per_step=backward_passes_per_step,
             average_aggregated_gradients=average_aggregated_gradients,
             sparse_as_dense=True,

--- a/test/parallel/test_tensorflow2_keras.py
+++ b/test/parallel/test_tensorflow2_keras.py
@@ -29,7 +29,7 @@ from tensorflow import keras
 from horovod.common.util import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
+    if version.parse(tf.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
         from tensorflow.keras.optimizers import Optimizer

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -82,6 +82,10 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 config = super().get_config()
                 return config
 
+            def update_step(self, gradient, variable):
+                lr = tf.cast(self.learning_rate, variable.dtype)
+                variable.assign_add(-gradient * lr)
+
         opt = TestOptimizer(name="TestOpti")
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)
 

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -80,7 +80,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 config = super(TestOptimizer, self).get_config()
                 return config
 
-        opt = TestOptimizer(name="TestOpti", learning_rate=0.1)
+        opt = TestOptimizer(name="TestOpti", lr=0.1)
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)
 
         variable = tf.Variable([0.0])

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -60,13 +60,13 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         if size == 1:
             self.skipTest("Only one worker available")
 
-        optimizer_class = keras.optimizers.Optimizer
+        optimizer_class = keras.optimizers.SGD  # .Optimizer
 
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
-                super().__init__(name, **kwargs)
-                if hasattr(self, '_build_learning_rate'):
-                    self._learning_rate = self._build_learning_rate(0.1)
+                super().__init__(name=name, **kwargs)
+                # if hasattr(self, '_build_learning_rate'):
+                #     self._learning_rate = self._build_learning_rate(0.1)
 
             def get_gradients(self, loss, params):
                 assert len(params) == 1
@@ -82,9 +82,9 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 config = super().get_config()
                 return config
 
-            def update_step(self, gradient, variable):
-                lr = tf.cast(self.learning_rate, variable.dtype)
-                variable.assign_add(-gradient * lr)
+            # def update_step(self, gradient, variable):
+            #     lr = tf.cast(self.learning_rate, variable.dtype)
+            #     variable.assign_add(-gradient * lr)
 
         opt = TestOptimizer(name="TestOpti")
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -82,9 +82,8 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 config = super().get_config()
                 return config
 
-            # def update_step(self, gradient, variable):
-            #     lr = tf.cast(self.learning_rate, variable.dtype)
-            #     variable.assign_add(-gradient * lr)
+            def update_step(self, gradient, variable):
+                variable.assign_add(gradient)
 
         opt = TestOptimizer(name="TestOpti")
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -64,7 +64,9 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
 
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
-                super(TestOptimizer, self).__init__(name, **kwargs)
+                super().__init__(name, **kwargs)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_gradients(self, loss, params):
                 assert len(params) == 1
@@ -77,10 +79,10 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 return var.assign_add(grad)
 
             def get_config(self):
-                config = super(TestOptimizer, self).get_config()
+                config = super().get_config()
                 return config
 
-        opt = TestOptimizer(name="TestOpti", lr=0.1)
+        opt = TestOptimizer(name="TestOpti")
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)
 
         variable = tf.Variable([0.0])

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -65,6 +65,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
                 super(TestOptimizer, self).__init__(name, **kwargs)
+                self.learning_rate = 0.1
 
             def get_gradients(self, loss, params):
                 assert len(params) == 1

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -60,13 +60,13 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         if size == 1:
             self.skipTest("Only one worker available")
 
-        optimizer_class = keras.optimizers.SGD  # .Optimizer
+        optimizer_class = keras.optimizers.Optimizer
 
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
                 super().__init__(name=name, **kwargs)
-                # if hasattr(self, '_build_learning_rate'):
-                #     self._learning_rate = self._build_learning_rate(0.1)
+                if hasattr(self, '_build_learning_rate'):
+                    self._learning_rate = self._build_learning_rate(0.1)
 
             def get_gradients(self, loss, params):
                 assert len(params) == 1

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -60,10 +60,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         if size == 1:
             self.skipTest("Only one worker available")
 
-        if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
-            optimizer_class = keras.optimizers.Optimizer
-        else:
-            optimizer_class = keras.optimizers.legacy.Optimizer
+        optimizer_class = keras.optimizers.Optimizer
 
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):

--- a/test/parallel/test_tensorflow2_keras_process_sets.py
+++ b/test/parallel/test_tensorflow2_keras_process_sets.py
@@ -65,7 +65,6 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
         class TestOptimizer(optimizer_class):
             def __init__(self, name, **kwargs):
                 super(TestOptimizer, self).__init__(name, **kwargs)
-                self.learning_rate = 0.1
 
             def get_gradients(self, loss, params):
                 assert len(params) == 1
@@ -81,7 +80,7 @@ class Tf2KerasProcessSetsTests(tf.test.TestCase):
                 config = super(TestOptimizer, self).get_config()
                 return config
 
-        opt = TestOptimizer(name="TestOpti")
+        opt = TestOptimizer(name="TestOpti", learning_rate=0.1)
         opt = hvd.DistributedOptimizer(opt, process_set=self.even_set)
 
         variable = tf.Variable([0.0])

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -29,16 +29,12 @@ from tensorflow import keras
 from horovod.common.util  import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
-    from keras import backend as K
-    if version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
-        from keras.optimizer_v2 import optimizer_v2
-    elif version.parse(keras.__version__.replace("-tf", "+tf")) < version.parse("2.12.0"):
-        from keras.optimizers.optimizer_v2 import optimizer_v2
+    if version.parse(tf.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
+        from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
-        from keras.optimizers.legacy import optimizer_v2
+        from tensorflow.keras.optimizers import Optimizer
 else:
-    from tensorflow.python.keras import backend as K
-    from tensorflow.python.keras.optimizer_v2 import optimizer_v2
+    from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
 
 import horovod.tensorflow.keras as hvd
 
@@ -373,7 +369,7 @@ class TfKerasTests(tf.test.TestCase):
     def test_gradient_aggregation(self):
         with self.test_session(config=self.config) as sess:
 
-            class TestingOptimizer(optimizer_v2.OptimizerV2):
+            class TestingOptimizer(Optimizer):
                 """
                 Custom optimizer we use for testing gradient aggregation.
                 """

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -29,11 +29,13 @@ from tensorflow import keras
 from horovod.common.util  import is_version_greater_equal_than
 
 if is_version_greater_equal_than(tf.__version__, "2.6.0"):
+    from keras import backend as K
     if version.parse(tf.__version__.replace("-tf", "+tf")) < version.parse("2.9.0"):
         from keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
     else:
         from tensorflow.keras.optimizers import Optimizer
 else:
+    from tensorflow.python.keras import backend as K
     from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as Optimizer
 
 import horovod.tensorflow.keras as hvd

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -288,9 +288,9 @@ class TfKerasTests(tf.test.TestCase):
                 self.assertEqual(len(model.optimizer.weights), 5)
 
     def _check_optimizer_weights(self, opt, new_opt):
-        self.assertEqual(len(opt.get_weights()), len(new_opt.get_weights()))
-        for weights, new_weights in zip(opt.get_weights(),
-                                        new_opt.get_weights()):
+        self.assertEqual(len(opt.variables()), len(new_opt.variables()))
+        for weights, new_weights in zip(opt.variables(),
+                                        new_opt.variables()):
             if np.isscalar(weights):
                 self.assertEqual(weights, new_weights)
             else:

--- a/test/parallel/test_tensorflow_keras.py
+++ b/test/parallel/test_tensorflow_keras.py
@@ -155,7 +155,7 @@ class TfKerasTests(tf.test.TestCase):
     def test_load_model_custom_optimizers(self):
         class TestOptimizer(keras.optimizers.RMSprop):
             def __init__(self, **kwargs):
-                super(TestOptimizer, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
         with self.test_session(config=self.config) as sess:
             K.set_session(sess)
@@ -190,7 +190,7 @@ class TfKerasTests(tf.test.TestCase):
     def test_load_model_custom_objects(self):
         class TestOptimizer(keras.optimizers.RMSprop):
             def __init__(self, **kwargs):
-                super(TestOptimizer, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
         with self.test_session(config=self.config) as sess:
             K.set_session(sess)
@@ -378,7 +378,7 @@ class TfKerasTests(tf.test.TestCase):
                 Custom optimizer we use for testing gradient aggregation.
                 """
                 def get_config(self):
-                    config = super(TestingOptimizer, self).get_config()
+                    config = super().get_config()
                     return config
 
                 def _create_slots(self, var_list):


### PR DESCRIPTION
## Description

Re-enabling TF Keras 2.11+ optimizers. ~Those and the legacy ones should work out the box with Horovod.~
Using new optimizers with `LossScaleOptimizer` is broken in 2.11 but fixed in 2.12.
See discussions at https://github.com/keras-team/keras/issues/17275
 and commit at https://github.com/keras-team/keras/commit/c98ea36b96f6036b1dec569e5e496aee06a44b29
 
 EDIT:
 They are quite a few changes in API between the 2 optimizer versions. But hopefully this PR properly integrates Horovod to the new ones while maintaining support for the old ones.