### PR TITLE
fix keras optimizer initialization for example script

### DIFF
--- a/examples/tensorflow2/tensorflow2_keras_synthetic_benchmark.py
+++ b/examples/tensorflow2/tensorflow2_keras_synthetic_benchmark.py
@@ -21,6 +21,12 @@ import tensorflow as tf
 import horovod.tensorflow.keras as hvd
 from tensorflow.keras import applications
 
+from packaging import version
+if version.parse(tf.keras.__version__.replace("-tf", "+tf")) < version.parse("2.11"):
+    from tensorflow.keras import optimizers
+else:
+    from tensorflow.keras.optimizers import legacy as optimizers
+
 # Benchmark settings
 parser = argparse.ArgumentParser(description='TensorFlow Synthetic Benchmark',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -64,7 +70,7 @@ else:
 
 # Set up standard model.
 model = getattr(applications, args.model)(weights=None)
-opt = tf.optimizers.SGD(0.01)
+opt = optimizers.SGD(0.01)
 
 # Synthetic dataset
 data = tf.random.uniform([args.batch_size, 224, 224, 3])


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Running `tensorflow2_keras_synthetic_benchmark.py` script results in the below error
```
ValueError: Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11: SGD
```

Check was added as a part of #3822. This PR fixes the import for `optimizers` w.r.t. TF versions

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
