### PR TITLE
Fix for issue #3861

### DIFF
--- a/horovod/tensorflow/mpi_ops.cc
+++ b/horovod/tensorflow/mpi_ops.cc
@@ -1104,7 +1104,7 @@ private:
     {
       Var* var;
       mutex* mu = GetTrainingVariableMutex<Device, T>(context, tensor_index,
-                                                      sparse, &var);
+                                                      &var);
       std::vector<Var*> vars;
       if (var) {
         vars.reserve(1);


### PR DESCRIPTION
This PR fixes `horovod` install issue for nightly TensorFlow as described in #3861 
Here are the steps to get a passing install:

```bash
git clone https://github.com/horovod/horovod.git
cd horovod

export HOROVOD_WITHOUT_PYTORCH=1
export HOROVOD_WITHOUT_MXNET=1
export HOROVOD_WITH_TENSORFLOW=1
export HOROVOD_VERSION=b1d0ce8f7fe66c690916ca4a318dd5ded77005a2

git reset --hard ${HOROVOD_VERSION}
git submodule update --init --recursive
```
Then apply the patch provided by this PR and run the installation as below:

```bash
python3 -m pip install --no-cache-dir -v -e .
```

I've only tested this on the following configuration:

- Ubuntu 20.04.5 LTS
- gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
- cmake version 3.16.3
- Python 3.9.16
- mpirun (Open MPI) 4.0.3