### PR TITLE
Don't pass CUDA_VISIBLE_DEVICES

### DIFF
--- a/horovod/runner/common/util/env.py
+++ b/horovod/runner/common/util/env.py
@@ -21,7 +21,7 @@ from horovod.runner.common.util import secret
 LOG_LEVEL_STR = ['FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE']
 
 # List of regular expressions to ignore environment variables by.
-IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD', secret.HOROVOD_SECRET_KEY}
+IGNORE_REGEXES = {'BASH_FUNC_.*', 'OLDPWD', '.*CUDA_VISIBLE_DEVICES', secret.HOROVOD_SECRET_KEY}
 
 KUBEFLOW_MPI_EXEC = '/etc/mpi/kubexec.sh'
 


### PR DESCRIPTION
There is never a valid reason to pass CUDA_VISIBLE_DEVICES.  It may be configured with UUIDs, which aren't suitable for passing between nodes, or it may be configured with indicies, which also might be different between nodes.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
