### PR TITLE
Build: Link CUDA runtime library statically by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed build with ROCm. ([#3839](https://github.com/horovod/horovod/pull/3839))
+- Fixed build with ROCm. ([#3839](https://github.com/horovod/horovod/pull/3839), [#3848](https://github.com/horovod/horovod/pull/3848))
+- Fixed build of Docker image horovod-nvtabular. ([#3851](https://github.com/horovod/horovod/pull/3851))
+- Fixed linking NCCL by defaulting CUDA runtime library linkage to static. ([#3867](https://github.com/horovod/horovod/pull/3867))
 
 
 ## [v0.27.0] - 2023-02-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,12 +180,6 @@ endif()
 macro(ADD_CUDA)
     find_package(CUDAToolkit REQUIRED)
     include_directories(SYSTEM ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-    string(TOLOWER "${CMAKE_CUDA_RUNTIME_LIBRARY}" lowercase_CMAKE_CUDA_RUNTIME_LIBRARY)
-    if (lowercase_CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "static")
-        list(APPEND LINKER_LIBS CUDA::cudart_static)
-    elseif (lowercase_CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "shared")
-        list(APPEND LINKER_LIBS CUDA::cudart)
-    endif()
     list(APPEND SOURCES "${PROJECT_SOURCE_DIR}/horovod/common/ops/cuda_operations.cc"
                         "${PROJECT_SOURCE_DIR}/horovod/common/ops/gpu_operations.cc")
     # CUDA + MPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 # CUDA and ROCM
 set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
 if(NOT DEFINED CMAKE_CUDA_RUNTIME_LIBRARY)
-    set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared")  # Set to "Static" or "Shared"
+    set(CMAKE_CUDA_RUNTIME_LIBRARY "Static")  # Set to "Static" or "Shared", effective from CMake 3.17
 endif()
 if(DEFINED ENV{HOROVOD_CUDA_HOME})
     set(CMAKE_CUDA_COMPILER "$ENV{HOROVOD_CUDA_HOME}/bin/nvcc")
@@ -229,6 +229,13 @@ if(HOROVOD_GPU_ALLREDUCE STREQUAL "N" OR HOROVOD_GPU_ALLGATHER STREQUAL "N" OR H
         find_package(NCCL REQUIRED)
         if (NCCL_MAJOR_VERSION LESS "2")
             message(FATAL_ERROR "Horovod requires NCCL 2.0 or later version please upgrade.")
+        endif()
+        string(TOLOWER "${CMAKE_CUDA_RUNTIME_LIBRARY}" lowercase_CMAKE_CUDA_RUNTIME_LIBRARY)
+        get_filename_component(NCCL_LIBRARY_FILE_NAME ${NCCL_LIBRARIES} NAME)
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17
+            AND lowercase_CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "shared"
+            AND NCCL_LIBRARY_FILE_NAME MATCHES "static")
+            message(WARNING "Linking NCCL statically, but linking CUDA runtime library dynamically. This combination is not supported with typical builds of NCCL.")
         endif()
         include_directories(SYSTEM ${NCCL_INCLUDE_DIRS})
         list(APPEND LINKER_LIBS ${NCCL_LIBRARIES})

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -27,7 +27,8 @@ find_path(NCCL_INCLUDE_DIR
         HINTS ${HOROVOD_NCCL_INCLUDE} ${CUDAToolkit_INCLUDE_DIRS})
 
 set(HOROVOD_NCCL_LINK $ENV{HOROVOD_NCCL_LINK})
-if (HOROVOD_NCCL_LINK STREQUAL "SHARED")
+string(TOLOWER "${HOROVOD_NCCL_LINK}" lowercase_HOROVOD_NCCL_LINK)
+if (lowercase_HOROVOD_NCCL_LINK STREQUAL "shared")
     set(NCCL_LIBNAME "nccl")
     message(STATUS "Linking against shared NCCL library")
 else()
@@ -39,8 +40,9 @@ find_library(NCCL_LIBRARY
         NAMES ${NCCL_LIBNAME}
         HINTS ${HOROVOD_NCCL_LIB} ${CUDAToolkit_LIBRARY_DIR})
 
+string(TOLOWER "${CMAKE_CUDA_RUNTIME_LIBRARY}" lowercase_CMAKE_CUDA_RUNTIME_LIBRARY)
 if (NCCL_LIBRARY STREQUAL "NCCL_LIBRARY-NOTFOUND" AND NCCL_LIBNAME MATCHES "static" AND
-    NOT HOROVOD_NCCL_LINK STREQUAL "STATIC")
+    NOT lowercase_HOROVOD_NCCL_LINK STREQUAL "static")
     message(STATUS "Could not find static NCCL library. Trying to find shared lib instead.")
     find_library(NCCL_LIBRARY
             NAMES "nccl"
@@ -59,6 +61,13 @@ if (NCCL_FOUND)
         string (REGEX REPLACE "^[ \t]*#define[ \t]+NCCL_MAJOR[ \t]+" ""
                 NCCL_MAJOR_VERSION ${NCCL_MAJOR_VERSION_DEFINED})
         message(STATUS "NCCL_MAJOR_VERSION: ${NCCL_MAJOR_VERSION}")
+    endif()
+    file (STRINGS ${NCCL_HEADER_FILE} NCCL_VERSION_CODE_DEFINED
+        REGEX "^[ \t]*#define[ \t]+NCCL_VERSION_CODE[ \t]+[0-9]+.*$" LIMIT_COUNT 1)
+    if (NCCL_VERSION_CODE_DEFINED)
+        string (REGEX REPLACE "^[ \t]*#define[ \t]+NCCL_VERSION_CODE[ \t]+" ""
+                NCCL_VERSION_CODE ${NCCL_VERSION_CODE_DEFINED})
+        message(STATUS "NCCL_VERSION_CODE: ${NCCL_VERSION_CODE}")
     endif()
     set(NCCL_INCLUDE_DIRS ${NCCL_INCLUDE_DIR})
     set(NCCL_LIBRARIES ${NCCL_LIBRARY})


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This change follows the discussion in  #3831 to avoid the NCCL error "Cuda failure 'CUDA driver is a stub library'".

- `CMAKE_CUDA_RUNTIME_LIBRARY` setting is only effective with CMake 3.17+ (and there is no Horovod build environment variable to control it at this time); with CMake 3.13 the CUDA runtime library is always linked statically on my system. https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_RUNTIME_LIBRARY.html
- added warning if dynamic CUDA RT (non-default) is combined with static NCCL (default)
- added CMake status message printing full NCCL_VERSION_CODE (e.g., 21505)
- made build environment variable HOROVOD_NCCL_LINK case-insensitive

Related code in `add_cuda` macro that is meant to explicitly add libraries depending on `CMAKE_CUDA_RUNTIME_LIBRARY` may not actually have the intended effect (https://github.com/horovod/horovod/blob/b1d0ce8f7fe66c690916ca4a318dd5ded77005a2/CMakeLists.txt#L183-L188). At least I couldn't get it to change anything with CMake 3.13 -- the build would always link the CUDA runtime lib statically, regardless of what was appended to `LINKER_LIBS` there. Edit: Removed this in follow-up commit, see below.

Open question: Should we add a build environment variable `HOROVOD_CUDA_RUNTIME_LIBRARY` so users can easily change this setting when `pip` installing Horovod? Caveat is that it would only be effective with CMake 3.17+.

Fixes #3831, and hopefully should also help with CUDA 11.8 build problems seen in https://github.com/horovod/horovod/pull/3845
