### PR TITLE
Use Python 3.8 to build docs as well

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,6 +28,6 @@ formats: []
 
 # Requirements for building docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Signed-off-by: Abolfazl Shahbazi <abolfazl.shahbazi@intel.com>
This is just to use `Python 3.8` everywhere since all GitHub actions are on that version also `3.7` end of life is approaching fast: https://endoflife.date/python