### PR TITLE
Force tf.logical_and in hvd allreduce condition running on CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Improved reducescatter performance by allocating output tensors before enqueuing the operation. ([#3824](https://github.com/horovod/horovod/pull/3824))
+- Force tf.logical_and in hvd allreduce condition running on CPU. ([#3885](https://github.com/horovod/horovod/pull/3885))
 
 ### Deprecated
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Forces tf.logical_and and related ops during hvd allreduce condition check running on CPU.

Why?

tf.logical_and will be scheduled on GPU by default. However, other hvd control ops such as process_set_included_op or size_op and TF cond ops only run on CPU. It will end up doing a memory copy from host to device to compute the tf.logical_and and doing another device to host copy to compute tf.cond. The PR force all condition related ops running on CPU to avoid unnecessary host to device and device to host memory copy.

We see 10% performance improvement when memory copy resource is under contention in our internal workflow . 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
