### PR TITLE
Fix torch build on ROCm by avoiding dynamically loaded cuCtxGetDevice

### DIFF
--- a/horovod/torch/cuda_util.cc
+++ b/horovod/torch/cuda_util.cc
@@ -49,7 +49,6 @@ static void initialize_driver_api() {
   }
 }
 #endif
-#endif
 
 with_device::with_device(int device) {
   if (device == CPU_DEVICE_ID) {

--- a/horovod/torch/cuda_util.cc
+++ b/horovod/torch/cuda_util.cc
@@ -29,25 +29,27 @@
 namespace horovod {
 namespace torch {
 
+#ifndef __HIP_PLATFORM_HCC__
 #if HAVE_GPU
-typedef CUresult (CUDAAPI *PFN_cuCtxGetDevice)(CUdevice* device);
+typedef CUresult(CUDAAPI* PFN_cuCtxGetDevice)(CUdevice* device);
 static void* cudalib = nullptr;
 static PFN_cuCtxGetDevice pfn_cuCtxGetDevice = nullptr;
 
 static void initialize_driver_api() {
   // Clear previous errors
-  (void) dlerror();
+  (void)dlerror();
 
   cudalib = dlopen("libcuda.so", RTLD_LAZY);
   if (!cudalib) {
     throw std::logic_error("Internal error. Could not dlopen libcuda.so.");
   }
 
-  pfn_cuCtxGetDevice = (PFN_cuCtxGetDevice) dlsym(cudalib, "cuCtxGetDevice");
+  pfn_cuCtxGetDevice = (PFN_cuCtxGetDevice)dlsym(cudalib, "cuCtxGetDevice");
   if (!pfn_cuCtxGetDevice) {
     throw std::logic_error("Internal error. Could not load cuCtxGetDevice.");
   }
 }
+#endif
 #endif
 
 with_device::with_device(int device) {
@@ -55,20 +57,24 @@ with_device::with_device(int device) {
     restore_device_ = CPU_DEVICE_ID;
   } else {
 #if HAVE_GPU
-    if (!cudalib) initialize_driver_api();
+#ifndef __HIP_PLATFORM_HCC__
+    if (!cudalib)
+      initialize_driver_api();
     CUdevice cudev;
     auto err = pfn_cuCtxGetDevice(&cudev);
     if (err == CUDA_ERROR_NOT_INITIALIZED ||
         err == CUDA_ERROR_INVALID_CONTEXT) {
-       // If device has never been set on this thread,
-       // restore to supplied device.
-       restore_device_ = device;
-     } else if (err == CUDA_SUCCESS) {
-       restore_device_ = static_cast<int>(cudev);
-     } else {
-       throw std::logic_error("Internal error. cuCtxGetDevice returned error code " +
-                              std::to_string(err));
-     }
+      // If device has never been set on this thread,
+      // restore to supplied device.
+      restore_device_ = device;
+    } else if (err == CUDA_SUCCESS) {
+      restore_device_ = static_cast<int>(cudev);
+    } else {
+      throw std::logic_error(
+          "Internal error. cuCtxGetDevice returned error code " +
+          std::to_string(err));
+    }
+#endif
     C10_CUDA_CHECK(cudaSetDevice(device));
 #else
     throw std::logic_error("Internal error. Requested device context manager "

--- a/horovod/torch/cuda_util.cc
+++ b/horovod/torch/cuda_util.cc
@@ -29,8 +29,7 @@
 namespace horovod {
 namespace torch {
 
-#ifndef __HIP_PLATFORM_HCC__
-#if HAVE_GPU
+#if HAVE_GPU && !HAVE_ROCM
 typedef CUresult(CUDAAPI* PFN_cuCtxGetDevice)(CUdevice* device);
 static void* cudalib = nullptr;
 static PFN_cuCtxGetDevice pfn_cuCtxGetDevice = nullptr;

--- a/horovod/torch/cuda_util.cc
+++ b/horovod/torch/cuda_util.cc
@@ -55,7 +55,7 @@ with_device::with_device(int device) {
     restore_device_ = CPU_DEVICE_ID;
   } else {
 #if HAVE_GPU
-#ifndef __HIP_PLATFORM_HCC__
+#if !HAVE_ROCM
     if (!cudalib)
       initialize_driver_api();
     CUdevice cudev;


### PR DESCRIPTION
Macro testing on `__HIP_PLATFORM_HCC__` as workaround ROCm's not supporting PFN_cuCtxGetDevice (does support cuCtxGetDevice -> hipCtxGetDevice).

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fixes # (issue).
https://github.com/horovod/horovod/issues/3927
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
