### PR TITLE
Docs: Fix invalid link to local section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,12 +39,10 @@ mocks.instrument()
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.autosectionlabel',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
     'nbsphinx',
 ]
-autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,10 +39,12 @@ mocks.instrument()
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
     'nbsphinx',
 ]
+autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -61,7 +61,7 @@ multiprocessing issues that Open MPI has with RDMA which typically results in se
 does not have noticeable performance impact since most of the heavy communication is done by NCCL, which will use RDMA
 via RoCE or InfiniBand if they're available (see `Horovod on GPU <gpus.rst>`_).  Notable exceptions from this rule are
 models that heavily use ``hvd.broadcast()`` and ``hvd.allgather()`` operations.  To make those operations use RDMA,
-read the :ref:`Open MPI with RDMA<open-mpi-with-rdma>` section below.
+read the :ref:`Open MPI with RDMA` section below.
 
 With the ``-x`` option you can specify (``-x NCCL_DEBUG=INFO``) or copy (``-x LD_LIBRARY_PATH``) an environment variable to
 all the workers.
@@ -82,8 +82,6 @@ Specify custom SSH ports with ``-mca plm_rsh_args "-p <port>"`` as follows:
         python train.py
 
 This is frequently useful in the case of `running Horovod in Docker environment <docker.rst>`_.
-
-.. _open-mpi-with-rdma:
 
 Open MPI with RDMA
 ~~~~~~~~~~~~~~~~~~

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -61,7 +61,7 @@ multiprocessing issues that Open MPI has with RDMA which typically results in se
 does not have noticeable performance impact since most of the heavy communication is done by NCCL, which will use RDMA
 via RoCE or InfiniBand if they're available (see `Horovod on GPU <gpus.rst>`_).  Notable exceptions from this rule are
 models that heavily use ``hvd.broadcast()`` and ``hvd.allgather()`` operations.  To make those operations use RDMA,
-read the :ref:`Open MPI with RDMA` section below.
+read the **Open MPI with RDMA** section below.
 
 With the ``-x`` option you can specify (``-x NCCL_DEBUG=INFO``) or copy (``-x LD_LIBRARY_PATH``) an environment variable to
 all the workers.

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -61,7 +61,7 @@ multiprocessing issues that Open MPI has with RDMA which typically results in se
 does not have noticeable performance impact since most of the heavy communication is done by NCCL, which will use RDMA
 via RoCE or InfiniBand if they're available (see `Horovod on GPU <gpus.rst>`_).  Notable exceptions from this rule are
 models that heavily use ``hvd.broadcast()`` and ``hvd.allgather()`` operations.  To make those operations use RDMA,
-read the `Open MPI with RDMA <#open-mpi-with-rdma>`_ section below.
+read the :ref:`Open MPI with RDMA<open-mpi-with-rdma>` section below.
 
 With the ``-x`` option you can specify (``-x NCCL_DEBUG=INFO``) or copy (``-x LD_LIBRARY_PATH``) an environment variable to
 all the workers.

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -83,6 +83,8 @@ Specify custom SSH ports with ``-mca plm_rsh_args "-p <port>"`` as follows:
 
 This is frequently useful in the case of `running Horovod in Docker environment <docker.rst>`_.
 
+.. _open-mpi-with-rdma:
+
 Open MPI with RDMA
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -61,7 +61,7 @@ multiprocessing issues that Open MPI has with RDMA which typically results in se
 does not have noticeable performance impact since most of the heavy communication is done by NCCL, which will use RDMA
 via RoCE or InfiniBand if they're available (see `Horovod on GPU <gpus.rst>`_).  Notable exceptions from this rule are
 models that heavily use ``hvd.broadcast()`` and ``hvd.allgather()`` operations.  To make those operations use RDMA,
-read the **Open MPI with RDMA** section below.
+read the `Open MPI with RDMA <#id1>`_ section below.
 
 With the ``-x`` option you can specify (``-x NCCL_DEBUG=INFO``) or copy (``-x LD_LIBRARY_PATH``) an environment variable to
 all the workers.


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Fix (warning in) readthedocs build.

A warning appeared regarding an invalid label, which started to fail the build. I couldn't figure out easily how to fix the link without introducing extra duplicate label warnings (seem to be related to the nested file structure with `mpi.rst` and `mpi_include.rst`), so I just removed it. In the latest or stable docs the link currently doesn't work at all anyway.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
