### PR TITLE
Fix missing -iface argument in generated mpirun command

### DIFF
--- a/horovod/runner/mpi_run.py
+++ b/horovod/runner/mpi_run.py
@@ -166,15 +166,13 @@ def mpi_run(settings, nics, env, command, stdout=None, stderr=None):
         joined_ssh_args = ' '.join(ssh_args)
         mpi_ssh_args = f'-bootstrap=ssh -bootstrap-exec-args \"{joined_ssh_args}\"' if impi_or_mpich else f'-mca plm_rsh_args \"{joined_ssh_args}\"'
 
-    if nics:
-        if impi_or_mpich:
-            if len(nics) > 1:
-                raise Exception('Intel MPI and MPICH do not support multiple interfaces.')
-            tcp_intf_arg = '-iface {nic}'.format(nic=list(nics)[0])
-        else:
-            tcp_intf_arg = '-mca btl_tcp_if_include {nics}'.format(nics=','.join(nics))
+    if settings.nics and impi_or_mpich:
+        if len(nics) > 1:
+            raise Exception('Intel MPI and MPICH do not support multiple interfaces.')
+        tcp_intf_arg = '-iface {nic}'.format(nic=list(nics)[0])
     else:
-        tcp_intf_arg = ''
+        tcp_intf_arg = '-mca btl_tcp_if_include {nics}'.format(
+            nics=','.join(nics)) if nics and not impi_or_mpich else ''
     nccl_socket_intf_arg = '-{opt} NCCL_SOCKET_IFNAME={nics}'.format(
         opt='genv' if impi_or_mpich else 'x',
         nics=','.join(nics)) if nics else ''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This pull request addresses GitHub issue #3933, which reports a missing `-iface` argument in the mpirun command generated by the Horovod runner. The omission of this argument can lead to errors in setups with MPICH and multiple servers.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
