### PR TITLE
fix: Select mpi_lib loading mode by default to adapt different platform

### DIFF
--- a/horovod/common/basics.py
+++ b/horovod/common/basics.py
@@ -31,7 +31,7 @@ class HorovodBasics(object):
 
     def __init__(self, pkg_path, *args):
         full_path = util.get_extension_full_path(pkg_path, *args)
-        self.MPI_LIB_CTYPES = ctypes.CDLL(full_path, mode=ctypes.RTLD_GLOBAL)
+        self.MPI_LIB_CTYPES = ctypes.CDLL(full_path)
 
         self.Average = self.MPI_LIB_CTYPES.horovod_reduce_op_average()
         self.Sum = self.MPI_LIB_CTYPES.horovod_reduce_op_sum()


### PR DESCRIPTION
## Checklist before submitting

- [ x ] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

This PR use default mode in ctypes.CDLL to adapt to different platform.

Fixes [#3936](https://github.com/horovod/horovod/issues/3963)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
