### PR TITLE
Pin cudf-cu11 and dask-cudf-cu11 for horovod-nvtabular docker build

### DIFF
--- a/docker/horovod-nvtabular/Dockerfile
+++ b/docker/horovod-nvtabular/Dockerfile
@@ -63,7 +63,7 @@ RUN CUDNN_MAJOR=$(cut -d '.' -f 1 <<< "${CUDNN_VERSION}"); \
 RUN ssh-keygen -f /root/.ssh/id_rsa -q -N ''
 RUN cp -v /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 
-RUN pip install --no-cache-dir cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
+RUN pip install --no-cache-dir cudf-cu11==23.04 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
 RUN pip install --no-cache-dir numba==0.56 nvidia-ml-py nvtabular
 RUN pip install --no-cache-dir -U --force requests pytest mock pytest-forked parameterized
 

--- a/docker/horovod-nvtabular/Dockerfile
+++ b/docker/horovod-nvtabular/Dockerfile
@@ -63,7 +63,8 @@ RUN CUDNN_MAJOR=$(cut -d '.' -f 1 <<< "${CUDNN_VERSION}"); \
 RUN ssh-keygen -f /root/.ssh/id_rsa -q -N ''
 RUN cp -v /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 
-RUN pip install --no-cache-dir cudf-cu11==23.04 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
+# Pinning older versions of cudf-cu11 and dask-cudf-cu11 for Python 3.8
+RUN pip install --no-cache-dir cudf-cu11==23.4.1 dask-cudf-cu11==23.4.1 --extra-index-url=https://pypi.nvidia.com
 RUN pip install --no-cache-dir numba==0.56 nvidia-ml-py nvtabular
 RUN pip install --no-cache-dir -U --force requests pytest mock pytest-forked parameterized
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

Work around install issue for `cudf-cu11` on Python 3.8: https://github.com/rapidsai/cudf/issues/13642

Also pinning related package `dask-cudf-cu11`.

Note: Command line to check available versions on Nvidia's package index: 
```
$ pip index versions cudf-cu11 --python-version 3.8 --index-url=https://pypi.nvidia.com
WARNING: pip index is currently an experimental command. It may be removed/changed in a future release without prior warning.
cudf-cu11 (23.4.1)
Available versions: 23.4.1, 23.4.0.1681363056, 23.4.0, 23.2.0, 22.12.0, 22.10.0
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
