### PR TITLE
detect MPICH via `HYDRA`

### DIFF
--- a/horovod/runner/mpi_run.py
+++ b/horovod/runner/mpi_run.py
@@ -103,7 +103,7 @@ def _get_mpi_implementation(env=None):
             return _OMPI_IMPL
         elif 'IBM Spectrum MPI' in output:
             return _SMPI_IMPL
-        elif 'MPICH' in output:
+        elif 'MPICH' in output or 'HYDRA' in output:
             return _MPICH_IMPL
         elif 'Intel(R) MPI' in output:
             return _IMPI_IMPL

--- a/test/single/test_run.py
+++ b/test/single/test_run.py
@@ -668,9 +668,7 @@ class RunTests(unittest.TestCase):
 
         test("IBM Spectrum MPI", _SMPI_IMPL)
 
-        test(("HYDRA build details:\n"
-              "    Version:           3.3a2\n"
-              "    Configure options: 'MPICHLIB_CFLAGS=-g -O2'\n"), _MPICH_IMPL)
+        test(("HYDRA build details:\n"), _MPICH_IMPL)
 
         test("Intel(R) MPI", _IMPI_IMPL)
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Fixes #2761.

Horovod still uses `MPICH` in `mpirun --version` to detect MPICH. In the unittest, the test case has `MPICHLIB_CFLAGS` flag. However, not all MPICH builds has this flag. For example, on Ubuntu 22.04, the MPICH installed with `apt-get` has no `MPICH`.

Here is the way to reproduce it (using docker):
```docker
FROM ubuntu:22.04
RUN apt-get update && apt-install -y mpich && mpirun --version
```
The output is:
```
HYDRA build details:
    Version:                                 4.0
    Release Date:                            Fri Jan 21 10:42:29 CST 2022
    CC:                              gcc -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/build/mpich-0xgrG5/mpich-4.0=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security  -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -Wl,-z,relro 
    Configure options:                       '--with-hwloc-prefix=/usr' '--with-device=ch4:ofi' 'FFLAGS=-O2 -ffile-prefix-map=/build/mpich-0xgrG5/mpich-4.0=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -fallow-invalid-boz -fallow-argument-mismatch' '--prefix=/usr' 'CFLAGS=-g -O2 -ffile-prefix-map=/build/mpich-0xgrG5/mpich-4.0=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security' 'LDFLAGS=-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -Wl,-z,relro' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2'
    Process Manager:                         pmi
    Launchers available:                     ssh rsh fork slurm ll lsf sge manual persist
    Topology libraries available:            hwloc
    Resource management kernels available:   user slurm ll lsf sge pbs cobalt
    Demux engines available:                 poll select
```

Using `HYDRA` is safe, as it is hard-coded in the MPICH source code: https://github.com/pmodels/mpich/blob/673b348edf97753502438d6aa9030dcf76074177/src/pm/hydra/mpiexec/options.c#L1154

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
