### PR TITLE
Fix data type in PartialDistributedGradientTape

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -182,7 +182,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv, rg in zip(rv, rg):
                             v2g[rv.ref()] = rg
@@ -195,7 +195,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                     if isinstance(grad, tf.IndexedSlices):
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= float(horovod_size)
+                                        grad /= horovod_size
                                     v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
@@ -211,7 +211,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                     if isinstance(grad, tf.IndexedSlices):
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= float(horovod_size)
+                                        grad /= horovod_size
                                     v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -182,7 +182,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv, rg in zip(rv, rg):
                             v2g[rv.ref()] = rg

--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -182,7 +182,7 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv, rg in zip(rv, rg):
                             v2g[rv.ref()] = rg
@@ -193,9 +193,9 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 if v_ref in self._local_vars and v2g[v_ref] is not None:
                                     grad = v2g[v_ref]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= horovod_size
+                                        grad /= float(horovod_size)
                                     v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
@@ -209,9 +209,9 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
                                 if v in self._local_vars and v2g[v] is not None:
                                     grad = v2g[v]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= horovod_size
+                                        grad /= float(horovod_size)
                                     v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -733,7 +733,7 @@ if _LegacyOptimizer is not None:
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv,rg in zip(rv, rg):
                             v2g[rv.ref()] = rg
@@ -746,7 +746,7 @@ if _LegacyOptimizer is not None:
                                     if isinstance(grad, tf.IndexedSlices):
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= float(horovod_size)
+                                        grad /= horovod_size
                                     v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
@@ -762,7 +762,7 @@ if _LegacyOptimizer is not None:
                                     if isinstance(grad, tf.IndexedSlices):
                                         grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= float(horovod_size)
+                                        grad /= horovod_size
                                     v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]
@@ -1074,7 +1074,7 @@ if hasattr(tf, 'GradientTape'):
 
             # Reduce grads
             rg = self._allreduce_grads(rg, rs, use_generic_names)
-            horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+            horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
             # Replace dict entries with reduced grads
             if _IS_TF2:
                 for rs, rg in zip(rs, rg):
@@ -1088,7 +1088,7 @@ if hasattr(tf, 'GradientTape'):
                             if isinstance(grad, tf.IndexedSlices):
                                 grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
-                                grad /= float(horovod_size)
+                                grad /= horovod_size
                             s2g[s_ref] = grad
 
                 return [s2g[s.ref()] for s in sources]
@@ -1104,7 +1104,7 @@ if hasattr(tf, 'GradientTape'):
                             if isinstance(grad, tf.IndexedSlices):
                                 grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
                             else:
-                                grad /= float(horovod_size)
+                                grad /= horovod_size
                             s2g[s] = grad
 
                 return [s2g[s] for s in sources]

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -733,7 +733,7 @@ if _LegacyOptimizer is not None:
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv,rg in zip(rv, rg):
                             v2g[rv.ref()] = rg
@@ -744,9 +744,9 @@ if _LegacyOptimizer is not None:
                                 if v_ref in self._local_vars and v2g[v_ref]:
                                     grad = v2g[v_ref]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= horovod_size
+                                        grad /= float(horovod_size)
                                     v2g[v_ref] = grad
 
                         return [v2g[rv.ref()] for rv in vars]
@@ -760,9 +760,9 @@ if _LegacyOptimizer is not None:
                                 if v in self._local_vars and v2g[v]:
                                     grad = v2g[v]
                                     if isinstance(grad, tf.IndexedSlices):
-                                        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                        grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                                     else:
-                                        grad /= horovod_size
+                                        grad /= float(horovod_size)
                                     v2g[v] = grad
 
                         return [v2g[rv] for rv in vars]
@@ -1074,7 +1074,7 @@ if hasattr(tf, 'GradientTape'):
 
             # Reduce grads
             rg = self._allreduce_grads(rg, rs, use_generic_names)
-            horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+            horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
             # Replace dict entries with reduced grads
             if _IS_TF2:
                 for rs, rg in zip(rs, rg):
@@ -1086,9 +1086,9 @@ if hasattr(tf, 'GradientTape'):
                         if s_ref in self._local_sources and s2g[s_ref] is not None:
                             grad = s2g[s_ref]
                             if isinstance(grad, tf.IndexedSlices):
-                                grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                             else:
-                                grad /= horovod_size
+                                grad /= float(horovod_size)
                             s2g[s_ref] = grad
 
                 return [s2g[s.ref()] for s in sources]
@@ -1102,9 +1102,9 @@ if hasattr(tf, 'GradientTape'):
                         if s in self._local_sources and s2g[s] is not None:
                             grad = s2g[s]
                             if isinstance(grad, tf.IndexedSlices):
-                                grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
+                                grad = tf.IndexedSlices(grad.values / float(horovod_size), grad.indices, grad.dense_shape)
                             else:
-                                grad /= horovod_size
+                                grad /= float(horovod_size)
                             s2g[s] = grad
 
                 return [s2g[s] for s in sources]

--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -733,7 +733,7 @@ if _LegacyOptimizer is not None:
                                 rg.append(grad)
 
                     rg = self._allreduce_grads(rg, rv)
-                    horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+                    horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
                     if _IS_TF2:
                         for rv,rg in zip(rv, rg):
                             v2g[rv.ref()] = rg
@@ -1074,7 +1074,7 @@ if hasattr(tf, 'GradientTape'):
 
             # Reduce grads
             rg = self._allreduce_grads(rg, rs, use_generic_names)
-            horovod_size = float(size_op(process_set_id=self.process_set.process_set_id)) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
+            horovod_size = tf.cast(size_op(process_set_id=self.process_set.process_set_id), tf.float32) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
             # Replace dict entries with reduced grads
             if _IS_TF2:
                 for rs, rg in zip(rs, rg):


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [ ] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description

In horovod elastic mode we are seeing 
```
[6]<stderr>:        gradients = tape.gradient(loss_value, self._model.trainable_weights)
[6]<stderr>:    File "/home/jobuser/.local/lib/python3.10/site-packages/horovod/tensorflow/__init__.py", line 1089, in gradient  *
[6]<stderr>:        grad = tf.IndexedSlices(grad.values / horovod_size, grad.indices, grad.dense_shape)
[6]<stderr>:
[6]<stderr>:    TypeError: `x` and `y` must have the same dtype, got tf.float32 != tf.int32.
```
which is a type mismatch from size_op and the gradient values. This PR fixes this issue.
## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
