### PR TITLE
Fix MXNet MNIST download url

### DIFF
--- a/examples/mxnet/mxnet2_mnist.py
+++ b/examples/mxnet/mxnet2_mnist.py
@@ -43,7 +43,7 @@ def main(args):
         data_dir = "data-%d" % rank
         if not os.path.isdir(data_dir):
             os.makedirs(data_dir)
-        zip_file_path = download('http://data.mxnet.io/mxnet/data/mnist.zip',
+        zip_file_path = download('https://horovod-datasets.s3.amazonaws.com/mnist.zip',
                                  dirname=data_dir)
         with zipfile.ZipFile(zip_file_path) as zf:
             zf.extractall(data_dir)

--- a/examples/mxnet/mxnet_mnist.py
+++ b/examples/mxnet/mxnet_mnist.py
@@ -43,7 +43,7 @@ def main(args):
         data_dir = "data-%d" % rank
         if not os.path.isdir(data_dir):
             os.makedirs(data_dir)
-        zip_file_path = download('http://data.mxnet.io/mxnet/data/mnist.zip',
+        zip_file_path = download('https://horovod-datasets.s3.amazonaws.com/mnist.zip',
                                  dirname=data_dir)
         with zipfile.ZipFile(zip_file_path) as zf:
             zf.extractall(data_dir)


### PR DESCRIPTION
The MNIST download url provided by MXNet is dead, added zip file to Horovod datasets S3 and use that.