### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/gen-workflow-ci.py
+++ b/.github/gen-workflow-ci.py
@@ -167,7 +167,7 @@ def main():
                '    runs-on: ubuntu-latest\n' \
                '    steps:\n' \
                '    - name: Upload\n' \
-               '      uses: actions/upload-artifact@v3\n' \
+               '      uses: actions/upload-artifact@v4\n' \
                '      with:\n' \
                '        name: Event File\n' \
                '        path: ${{ github.event_path }}\n' \
@@ -177,9 +177,9 @@ def main():
                '    runs-on: ubuntu-latest\n' \
                '    steps:\n' \
                '      - name: Checkout\n' \
-               '        uses: actions/checkout@v3\n' \
+               '        uses: actions/checkout@v4\n' \
                '      - name: Setup Python\n' \
-               '        uses: actions/setup-python@v4\n' \
+               '        uses: actions/setup-python@v5\n' \
                '        with:\n' \
                '          python-version: 3.8\n' \
                '      - name: Test setup.py\n' \
@@ -210,9 +210,9 @@ def main():
                 f'\n'
                 f'    steps:\n'
                 f'      - name: Checkout\n'
-                f'        uses: actions/checkout@v3\n'
+                f'        uses: actions/checkout@v4\n'
                 f'      - name: Setup Python\n'
-                f'        uses: actions/setup-python@v4\n'
+                f'        uses: actions/setup-python@v5\n'
                 f'        with:\n'
                 f'          python-version: 3.8\n'
                 f'      - name: Pip install dependencies\n'
@@ -287,7 +287,7 @@ def main():
                 f'          cat pr.json\n'
                 f'\n'
                 f'      - name: Upload PR meta\n'
-                f'        uses: actions/upload-artifact@v3\n'
+                f'        uses: actions/upload-artifact@v4\n'
                 f"        if: github.event_name == 'pull_request'\n"
                 f'        with:\n'
                 f'          name: PR Meta\n'
@@ -357,12 +357,12 @@ def main():
                 f'          echo ::endgroup::\n'
                 f'\n'
                 f'      - name: Checkout\n'
-                f'        uses: actions/checkout@v3\n'
+                f'        uses: actions/checkout@v4\n'
                 f'        with:\n'
                 f'          submodules: recursive\n'
                 f'\n'
                 f'      - name: Setup Python\n'
-                f'        uses: actions/setup-python@v4\n'
+                f'        uses: actions/setup-python@v5\n'
                 f'        with:\n'
                 f'          python-version: 3.8\n'
                 f'\n'
@@ -389,7 +389,7 @@ def main():
                            for attempt in range(1, attempts+1)]) +
                 f'\n'
                 f'      - name: Upload Test Results\n'
-                f'        uses: actions/upload-artifact@v3\n'
+                f'        uses: actions/upload-artifact@v4\n'
                 f'        if: always() && contains(matrix.image, \'-cpu-\')\n'
                 f'        with:\n'
                 f'          name: Unit Test Results - ${{{{ matrix.image }}}}\n'
@@ -446,7 +446,7 @@ def main():
                 f'\n'
                 f'    steps:\n'
                 f'      - name: Checkout\n'
-                f'        uses: actions/checkout@v3\n'
+                f'        uses: actions/checkout@v4\n'
                 f'        with:\n'
                 f'          submodules: recursive\n'
                 f'\n'
@@ -504,7 +504,7 @@ def main():
                            for attempt in range(1, attempts+1)]) +
                 f'\n'
                 f'      - name: Upload Test Results\n'
-                f'        uses: actions/upload-artifact@v3\n'
+                f'        uses: actions/upload-artifact@v4\n'
                 f'        if: always()\n'
                 f'        with:\n'
                 f'          name: Unit Test Results - ${{{{ matrix.image }}}}-macos\n'
@@ -557,7 +557,7 @@ def main():
                 f'          output_path: artifacts/Unit Test Results - {mode} on Builtkite\n'
                 f'\n'
                 f'      - name: Upload Test Results\n'
-                f'        uses: actions/upload-artifact@v3\n'
+                f'        uses: actions/upload-artifact@v4\n'
                 f'        if: always()\n'
                 f'        with:\n'
                 f'          name: Unit Test Results - {mode} on Builtkite\n'
@@ -637,13 +637,13 @@ def main():
                 f'\n'
                 f'    steps:\n'
                 f'      - name: Checkout\n'
-                f'        uses: actions/checkout@v3\n'
+                f'        uses: actions/checkout@v4\n'
                 f'        with:\n'
                 f'          submodules: \'recursive\'\n'
                 f'\n'
                 f'      - name: Docker meta\n'
                 f'        id: meta\n'
-                f'        uses: crazy-max/ghaction-docker-meta@v2\n'
+                f'        uses: crazy-max/ghaction-docker-meta@v5\n'
                 f'        with:\n'
                 f'          # list of Docker images to use as base name for tags\n'
                 f'          images: |\n'
@@ -659,13 +659,13 @@ def main():
                 f'            type=sha\n'
                 f'\n'
                 f'      - name: Set up Docker Buildx\n'
-                f'        uses: docker/setup-buildx-action@v2\n'
+                f'        uses: docker/setup-buildx-action@v3\n'
                 f'        with:\n'
                 f'          driver: docker\n'
                 f'\n'
                 f'      - name: Login to DockerHub\n'
                 f'        if: needs.docker-config.outputs.push == \'true\'\n'
-                f'        uses: docker/login-action@v2\n'
+                f'        uses: docker/login-action@v3\n'
                 f'        with:\n'
                 f'          username: ${{{{ secrets.DOCKERHUB_USERNAME }}}}\n'
                 f'          password: ${{{{ secrets.DOCKERHUB_TOKEN }}}}\n'
@@ -698,7 +698,7 @@ def main():
                 f'\n'
                 f'      - name: Build image\n'
                 f'        id: build\n'
-                f'        uses: docker/build-push-action@v3\n'
+                f'        uses: docker/build-push-action@v5\n'
                 f'        timeout-minutes: 60\n'
                 f'        with:\n'
                 f'          context: .\n'
@@ -732,7 +732,7 @@ def main():
                 f'\n'
                 f'      - name: Push image\n'
                 f'        if: needs.docker-config.outputs.push == \'true\'\n'
-                f'        uses: docker/build-push-action@v3\n'
+                f'        uses: docker/build-push-action@v5\n'
                 f'        timeout-minutes: 60\n'
                 f'        with:\n'
                 f'          context: .\n'
@@ -781,7 +781,7 @@ def main():
                 f'\n'
                 f'    steps:\n'
                 f'      - name: Checkout\n'
-                f'        uses: actions/checkout@v3\n'
+                f'        uses: actions/checkout@v4\n'
                 f'\n'
                 f'      - name: Diffing ${{{{ matrix.left_file }}}} with ${{{{ matrix.right_file }}}}\n'
                 f'        env:\n'

--- a/.github/workflows/ci-results.yaml
+++ b/.github/workflows/ci-results.yaml
@@ -125,7 +125,7 @@ jobs:
           output_path: artifacts/Unit Test Results - GPU NON HEADS on Builtkite
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results - GPU NON HEADS on Builtkite
@@ -215,7 +215,7 @@ jobs:
           output_path: artifacts/Unit Test Results - GPU HEADS on Builtkite
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results - GPU HEADS on Builtkite
@@ -282,7 +282,7 @@ jobs:
           done
 
       - name: Download Buildkite Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Event File
         path: ${{ github.event_path }}
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Test setup.py
@@ -85,9 +85,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Pip install dependencies
@@ -162,7 +162,7 @@ jobs:
           cat pr.json
 
       - name: Upload PR meta
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request'
         with:
           name: PR Meta
@@ -433,12 +433,12 @@ jobs:
           echo ::endgroup::
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -2344,7 +2344,7 @@ jobs:
         shell: bash
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && contains(matrix.image, '-cpu-')
         with:
           name: Unit Test Results - ${{ matrix.image }}
@@ -2429,12 +2429,12 @@ jobs:
           echo ::endgroup::
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -4340,7 +4340,7 @@ jobs:
         shell: bash
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && contains(matrix.image, '-cpu-')
         with:
           name: Unit Test Results - ${{ matrix.image }}
@@ -4393,12 +4393,12 @@ jobs:
           echo ::endgroup::
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -4415,7 +4415,7 @@ jobs:
 
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && contains(matrix.image, '-cpu-')
         with:
           name: Unit Test Results - ${{ matrix.image }}
@@ -4466,7 +4466,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -4561,7 +4561,7 @@ jobs:
           ls test_*.py | gtimeout 10m xargs -n 1 horovodrun -np 2 /bin/bash ../../pytest.sh macos
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results - ${{ matrix.image }}-macos
@@ -4611,7 +4611,7 @@ jobs:
           output_path: artifacts/Unit Test Results - GPU NON HEADS on Builtkite
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results - GPU NON HEADS on Builtkite
@@ -4668,7 +4668,7 @@ jobs:
           output_path: artifacts/Unit Test Results - GPU HEADS on Builtkite
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Unit Test Results - GPU HEADS on Builtkite
@@ -4745,13 +4745,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
       - name: Docker meta
         id: meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: crazy-max/ghaction-docker-meta@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -4767,13 +4767,13 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver: docker
 
       - name: Login to DockerHub
         if: needs.docker-config.outputs.push == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -4806,7 +4806,7 @@ jobs:
 
       - name: Build image
         id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         timeout-minutes: 60
         with:
           context: .
@@ -4847,7 +4847,7 @@ jobs:
 
       - name: Push image
         if: needs.docker-config.outputs.push == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         timeout-minutes: 60
         with:
           context: .
@@ -4895,7 +4895,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Diffing ${{ matrix.left_file }} with ${{ matrix.right_file }}
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Python dependencies
       # install all `install_requires` dependencies but no `extras_require` dependencies
@@ -48,13 +48,13 @@ jobs:
         pip install $(head -n $(( $(grep -m 1 -n -e "^\[" horovod.egg-info/requires.txt | cut -d : -f 1) - 1 )) horovod.egg-info/requires.txt)
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: python
         setup-python-dependencies: false
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 
   analyze-cpp:
     name: Analyze C++
@@ -90,12 +90,12 @@ jobs:
         echo ::endgroup::
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: cpp
 
@@ -142,7 +142,7 @@ jobs:
         git diff
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
 
@@ -157,4 +157,4 @@ jobs:
         docker cp horovod:/home/runner/work/_temp/codeql_databases /home/runner/work/_temp/
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.7
 


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 
