### PR TITLE
CI: Use specific GPG keyserver to avoid GPG timeout

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -35,7 +35,10 @@ RUN env | sort
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+# Adding this repo may fail with "Error: retrieving gpg key timed out" using default keyserver, so adding an alternative keyserver first
+RUN mkdir -p ~/.gnupg/; \
+    echo "keyserver keyserver.ubuntu.com" >> ~/.gnupg/gpg.conf; \
+    add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Install essential packages.
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -43,7 +43,10 @@ RUN env | sort
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+# Adding this repo may fail with "Error: retrieving gpg key timed out" using default keyserver, so adding an alternative keyserver first
+RUN mkdir -p ~/.gnupg/; \
+    echo "keyserver keyserver.ubuntu.com" >> ~/.gnupg/gpg.conf; \
+    add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Install essential packages.
 RUN CUDNN_MAJOR=$(cut -d '.' -f 1 <<< "${CUDNN_VERSION}"); \


### PR DESCRIPTION
Recently, there have been a lot of GPG errors building our test docker images:

    "Error: retrieving gpg key timed out"

Using a different keyserver should mitigate this.