### PR TITLE
CI: Constraint pytest to <8 to make skipif work for test classes

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -68,7 +68,7 @@ RUN if [[ ${PYTHON_VERSION} != "3.7" ]]; then \
         wget --progress=dot:mega https://bootstrap.pypa.io/pip/3.7/get-pip.py; \
     fi && python get-pip.py && rm get-pip.py
 
-RUN pip install --no-cache-dir -U --force requests pytest mock pytest-forked parameterized
+RUN pip install --no-cache-dir -U --force requests "pytest<8" mock pytest-forked parameterized
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -80,7 +80,7 @@ RUN if [[ ${PYTHON_VERSION} != "3.7" ]]; then \
         wget --progress=dot:mega https://bootstrap.pypa.io/pip/3.7/get-pip.py; \
     fi && python get-pip.py && rm get-pip.py
 
-RUN pip install --no-cache-dir -U --force requests pytest mock pytest-forked parameterized
+RUN pip install --no-cache-dir -U --force requests "pytest<8" mock pytest-forked parameterized
 
 # Add launch helper scripts
 RUN echo "env SPARK_HOME=/spark SPARK_DRIVER_MEM=512m PYSPARK_PYTHON=/usr/bin/python${PYTHON_VERSION} PYSPARK_DRIVER_PYTHON=/usr/bin/python${PYTHON_VERSION} \"\$@\"" > /spark_env.sh

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ dev_require_list = ['tensorflow-cpu==2.2.0',
 # torchvision 0.5.0 depends on torch==1.4.0
 
 # python packages required only to run tests
-test_require_list = ['mock', 'pytest', 'pytest-forked', 'pytest-subtests', 'parameterized']
+test_require_list = ['mock', 'pytest<8', 'pytest-forked', 'pytest-subtests', 'parameterized']
 
 # Skip cffi if pytorch extension explicitly disabled
 if not os.environ.get('HOROVOD_WITHOUT_PYTORCH'):


### PR DESCRIPTION
With pytest>=8, test class decoration `pytest.mark.skipif` is ignored. Using pytest<8 in CI.

Includes #4059