### PR TITLE
Revert "CI: Use specific GPG keyserver to avoid GPG timeout (#4059)"

### DIFF
--- a/Dockerfile.test.cpu
+++ b/Dockerfile.test.cpu
@@ -35,10 +35,7 @@ RUN env | sort
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-# Adding this repo may fail with "Error: retrieving gpg key timed out" using default keyserver, so adding an alternative keyserver first
-RUN mkdir -p ~/.gnupg/; \
-    echo "keyserver keyserver.ubuntu.com" >> ~/.gnupg/gpg.conf; \
-    add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Install essential packages.
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \

--- a/Dockerfile.test.gpu
+++ b/Dockerfile.test.gpu
@@ -43,10 +43,7 @@ RUN env | sort
 RUN apt-get update -qq && apt-get install -y --no-install-recommends software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-# Adding this repo may fail with "Error: retrieving gpg key timed out" using default keyserver, so adding an alternative keyserver first
-RUN mkdir -p ~/.gnupg/; \
-    echo "keyserver keyserver.ubuntu.com" >> ~/.gnupg/gpg.conf; \
-    add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Install essential packages.
 RUN CUDNN_MAJOR=$(cut -d '.' -f 1 <<< "${CUDNN_VERSION}"); \


### PR DESCRIPTION
This reverts commit b0a7edad7f8c0acbf8106144704f57be306c0537.

Reverting as the timeout still persists.