### PR TITLE
Add support for disabling autotune parameter for batch prefetch

### DIFF
--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -103,7 +103,7 @@ class EstimatorParams(Params):
                               'functions that construct the transformation '
                               'function that applies custom transformations to '
                               'every batch before train and validation steps')
-    
+
     transformation_edit_fields = Param(Params._dummy(), 'transformation_edit_fields',
                                        'edit fields for petastorm TransformSpec that\'s applied to '
                                        'every batch, A list of 4-tuples with the following fields: '
@@ -133,12 +133,18 @@ class EstimatorParams(Params):
                     'https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_start_method.'
                     'This param defaults to None.',
                     typeConverter=TypeConverters.toString)
-    
+
     backward_passes_per_step = Param(Params._dummy(), 'backward_passes_per_step',
                                      'Number of backward passes to perform before calling hvd.allreduce. '
                                      'This allows accumulating updates over multiple mini-batches before reducing and applying them. '
                                      'This param defaults to 1.',
                                      typeConverter=TypeConverters.toInt)
+
+    disable_autotune_batch_prefetch = Param(Params._dummy(), 'disable_autotune_batch_prefetch',
+                                      'Whether to disable autotune batch prefetch in data module or not.'
+                                      'Setting this to True will prefetch only one batch.'
+                                      'Defaults to False.',
+                                      typeConverter=TypeConverters.toBoolean)
 
     def __init__(self):
         super(EstimatorParams, self).__init__()
@@ -182,7 +188,8 @@ class EstimatorParams(Params):
             inmemory_cache_all=False,
             use_gpu=True,
             mp_start_method=None,
-            backward_passes_per_step=1)
+            backward_passes_per_step=1,
+            disable_autotune_batch_prefetch=False)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -380,7 +387,7 @@ class EstimatorParams(Params):
 
     def getTransformationFn(self):
         return self.getOrDefault(self.transformation_fn)
-    
+
     def setTransformationEditFields(self, value):
         return self._set(transformation_edit_fields=value)
 
@@ -434,12 +441,18 @@ class EstimatorParams(Params):
 
     def getMpStartMethod(self):
         return self.getOrDefault(self.mp_start_method)
-    
+
     def setBackwardPassesPerStep(self, value):
         self._set(backward_passes_per_step=value)
 
     def getBackwardPassesPerStep(self):
         return self.getOrDefault(self.backward_passes_per_step)
+
+    def setDisableAutotuneBatchPrefetch(self, value):
+        self._set(disable_autotune_batch_prefetch=value)
+
+    def getDisableAutotuneBatchPrefetch(self):
+        return self.getOrDefault(self.disable_autotune_batch_prefetch)
 
 class ModelParams(HasOutputCols):
     history = Param(Params._dummy(), 'history', 'history')

--- a/horovod/spark/common/params.py
+++ b/horovod/spark/common/params.py
@@ -140,11 +140,10 @@ class EstimatorParams(Params):
                                      'This param defaults to 1.',
                                      typeConverter=TypeConverters.toInt)
 
-    disable_autotune_batch_prefetch = Param(Params._dummy(), 'disable_autotune_batch_prefetch',
-                                      'Whether to disable autotune batch prefetch in data module or not.'
-                                      'Setting this to True will prefetch only one batch.'
-                                      'Defaults to False.',
-                                      typeConverter=TypeConverters.toBoolean)
+    tensorflow_dataset_prefetch_buffer_size = Param(Params._dummy(), 'tensorflow_dataset_prefetch_buffer_size',
+                                      'The size of the prefetch buffer for the TensorFlow dataset. '
+                                      'This param defaults to 0.',
+                                      typeConverter=TypeConverters.toInt)
 
     def __init__(self):
         super(EstimatorParams, self).__init__()
@@ -189,7 +188,7 @@ class EstimatorParams(Params):
             use_gpu=True,
             mp_start_method=None,
             backward_passes_per_step=1,
-            disable_autotune_batch_prefetch=False)
+            tensorflow_dataset_prefetch_buffer_size=0)
 
     def _check_params(self, metadata):
         model = self.getModel()
@@ -448,11 +447,11 @@ class EstimatorParams(Params):
     def getBackwardPassesPerStep(self):
         return self.getOrDefault(self.backward_passes_per_step)
 
-    def setDisableAutotuneBatchPrefetch(self, value):
-        self._set(disable_autotune_batch_prefetch=value)
+    def setTensorflowDatasetPrefetchBufferSize(self, value):
+        self._set(tensorflow_dataset_prefetch_buffer_size=value)
 
-    def getDisableAutotuneBatchPrefetch(self):
-        return self.getOrDefault(self.disable_autotune_batch_prefetch)
+    def getTensorflowDatasetPrefetchBufferSize(self):
+        return self.getOrDefault(self.tensorflow_dataset_prefetch_buffer_size)
 
 class ModelParams(HasOutputCols):
     history = Param(Params._dummy(), 'history', 'history')

--- a/horovod/spark/keras/datamodule.py
+++ b/horovod/spark/keras/datamodule.py
@@ -26,7 +26,7 @@ class PetastormDataModule(DataModule):
                        val_reader_worker_count: int=2,
                        make_dataset=None,
                        random_seed=0,
-                       disable_autotune_batch_prefetch=False,
+                       tensorflow_dataset_prefetch_buffer_size=0,
                        **kwargs):
         from petastorm import TransformSpec, make_reader, make_batch_reader
 
@@ -36,7 +36,7 @@ class PetastormDataModule(DataModule):
         self.val_reader_worker_count = val_reader_worker_count
         self.make_dataset = make_dataset
         self.random_seed = random_seed
-        self.disable_autotune_batch_prefetch = disable_autotune_batch_prefetch
+        self.tensorflow_dataset_prefetch_buffer_size = tensorflow_dataset_prefetch_buffer_size
 
         # In general, make_batch_reader is faster than make_reader for reading the dataset.
         # However, we found out that make_reader performs data transformations much faster than
@@ -96,11 +96,11 @@ class PetastormDataModule(DataModule):
 
     def train_data(self):
         return self.make_dataset(self.train_reader, self.train_batch_size,
-                                 self.is_batch_reader, shuffle=self.shuffle, cache=self.inmemory_cache_all, disable_autotune_batch_prefetch=self.disable_autotune_batch_prefetch)
+                                 self.is_batch_reader, shuffle=self.shuffle, cache=self.inmemory_cache_all, tensorflow_dataset_prefetch_buffer_size=self.tensorflow_dataset_prefetch_buffer_size)
 
     def val_data(self):
         return self.make_dataset(self.val_reader, self.val_batch_size,
-                                 self.is_batch_reader, shuffle=False, cache=self.inmemory_cache_all, disable_autotune_batch_prefetch=self.disable_autotune_batch_prefetch) if self.val_reader else None
+                                 self.is_batch_reader, shuffle=False, cache=self.inmemory_cache_all, tensorflow_dataset_prefetch_buffer_size=self.tensorflow_dataset_prefetch_buffer_size) if self.val_reader else None
 
 
 class NVTabularDataModule(DataModule):

--- a/horovod/spark/keras/datamodule.py
+++ b/horovod/spark/keras/datamodule.py
@@ -26,6 +26,7 @@ class PetastormDataModule(DataModule):
                        val_reader_worker_count: int=2,
                        make_dataset=None,
                        random_seed=0,
+                       disable_autotune_batch_prefetch=False,
                        **kwargs):
         from petastorm import TransformSpec, make_reader, make_batch_reader
 
@@ -35,6 +36,7 @@ class PetastormDataModule(DataModule):
         self.val_reader_worker_count = val_reader_worker_count
         self.make_dataset = make_dataset
         self.random_seed = random_seed
+        self.disable_autotune_batch_prefetch = disable_autotune_batch_prefetch
 
         # In general, make_batch_reader is faster than make_reader for reading the dataset.
         # However, we found out that make_reader performs data transformations much faster than
@@ -94,11 +96,11 @@ class PetastormDataModule(DataModule):
 
     def train_data(self):
         return self.make_dataset(self.train_reader, self.train_batch_size,
-                                 self.is_batch_reader, shuffle=self.shuffle, cache=self.inmemory_cache_all)
+                                 self.is_batch_reader, shuffle=self.shuffle, cache=self.inmemory_cache_all, disable_autotune_batch_prefetch=self.disable_autotune_batch_prefetch)
 
     def val_data(self):
         return self.make_dataset(self.val_reader, self.val_batch_size,
-                                 self.is_batch_reader, shuffle=False, cache=self.inmemory_cache_all) if self.val_reader else None
+                                 self.is_batch_reader, shuffle=False, cache=self.inmemory_cache_all, disable_autotune_batch_prefetch=self.disable_autotune_batch_prefetch) if self.val_reader else None
 
 
 class NVTabularDataModule(DataModule):

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -161,7 +161,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                      2G min and max for libhdfs through petastorm
         use_gpu: Whether to use the GPU for training. Defaults to True.
         mp_start_method: The method to use to start multiprocessing. Defaults to None.
-        disable_autotune_batch_prefetch: Whether to disable prefetch batches using AutoTune. Default to False
+        tensorflow_dataset_prefetch_buffer_size: The size of the prefetch buffer for the TensorFlow dataset. Default to 0.
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -212,7 +212,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  backend_env=None,
                  use_gpu=True,
                  mp_start_method=None,
-                 disable_autotune_batch_prefetch=False):
+                 tensorflow_dataset_prefetch_buffer_size=0):
 
         super(KerasEstimator, self).__init__()
 

--- a/horovod/spark/keras/estimator.py
+++ b/horovod/spark/keras/estimator.py
@@ -161,6 +161,7 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                      2G min and max for libhdfs through petastorm
         use_gpu: Whether to use the GPU for training. Defaults to True.
         mp_start_method: The method to use to start multiprocessing. Defaults to None.
+        disable_autotune_batch_prefetch: Whether to disable prefetch batches using AutoTune. Default to False
     """
 
     custom_objects = Param(Params._dummy(), 'custom_objects', 'custom objects')
@@ -210,7 +211,8 @@ class KerasEstimator(HorovodEstimator, KerasEstimatorParamsReadable,
                  inmemory_cache_all=False,
                  backend_env=None,
                  use_gpu=True,
-                 mp_start_method=None):
+                 mp_start_method=None,
+                 disable_autotune_batch_prefetch=False):
 
         super(KerasEstimator, self).__init__()
 

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -63,6 +63,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     train_reader_worker_count = estimator.getTrainReaderNumWorker()
     val_reader_worker_count = estimator.getValReaderNumWorker()
     reader_pool_type = estimator.getReaderPoolType()
+    disable_autotune_batch_prefetch = estimator.getDisableAutotuneBatchPrefetch()
 
     # Model parameters
     input_shapes, output_shapes = estimator.get_model_shapes()
@@ -244,6 +245,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                 'steps_per_epoch_train': steps_per_epoch,
                 'steps_per_epoch_val': validation_steps,
                 'verbose': verbose,
+                'disable_autotune_batch_prefetch': disable_autotune_batch_prefetch,
                 # petastorm
                 'make_dataset': make_dataset,
                 'random_seed': random_seed,

--- a/horovod/spark/keras/remote.py
+++ b/horovod/spark/keras/remote.py
@@ -63,7 +63,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
     train_reader_worker_count = estimator.getTrainReaderNumWorker()
     val_reader_worker_count = estimator.getValReaderNumWorker()
     reader_pool_type = estimator.getReaderPoolType()
-    disable_autotune_batch_prefetch = estimator.getDisableAutotuneBatchPrefetch()
+    tensorflow_dataset_prefetch_buffer_size = estimator.getTensorflowDatasetPrefetchBufferSize()
 
     # Model parameters
     input_shapes, output_shapes = estimator.get_model_shapes()
@@ -245,7 +245,7 @@ def RemoteTrainer(estimator, metadata, keras_utils, run_id, dataset_idx):
                 'steps_per_epoch_train': steps_per_epoch,
                 'steps_per_epoch_val': validation_steps,
                 'verbose': verbose,
-                'disable_autotune_batch_prefetch': disable_autotune_batch_prefetch,
+                'tensorflow_dataset_prefetch_buffer_size': tensorflow_dataset_prefetch_buffer_size,
                 # petastorm
                 'make_dataset': make_dataset,
                 'random_seed': random_seed,

--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -61,7 +61,7 @@ class TFKerasUtil(object):
             has_sparse_col, sample_weight_col, feature_columns,
             label_columns, input_shapes, label_shapes, output_names)
 
-        def fn(reader, batch_size, is_batch_reader, shuffle=True, cache=False, disable_autotune_batch_prefetch=False):
+        def fn(reader, batch_size, is_batch_reader, shuffle=True, cache=False, tensorflow_dataset_prefetch_buffer_size=0):
             from petastorm.tf_utils import make_petastorm_dataset
 
             # Samples come from Petastorm reader are already shuffled if needed.
@@ -87,7 +87,9 @@ class TFKerasUtil(object):
                 dataset = dataset.batch(1).map(reshape)
 
             dataset = dataset.batch(batch_size).map(prep_data_tf_keras)
-            if not disable_autotune_batch_prefetch and hasattr(tf.data, 'AUTOTUNE'):
+            if tensorflow_dataset_prefetch_buffer_size > 0:
+                dataset = dataset.prefetch(tensorflow_dataset_prefetch_buffer_size)
+            elif hasattr(tf.data, 'AUTOTUNE'):
                 dataset = dataset.prefetch(tf.data.AUTOTUNE)
             else:
                 dataset = dataset.prefetch(1)

--- a/horovod/spark/keras/util.py
+++ b/horovod/spark/keras/util.py
@@ -61,7 +61,7 @@ class TFKerasUtil(object):
             has_sparse_col, sample_weight_col, feature_columns,
             label_columns, input_shapes, label_shapes, output_names)
 
-        def fn(reader, batch_size, is_batch_reader, shuffle=True, cache=False):
+        def fn(reader, batch_size, is_batch_reader, shuffle=True, cache=False, disable_autotune_batch_prefetch=False):
             from petastorm.tf_utils import make_petastorm_dataset
 
             # Samples come from Petastorm reader are already shuffled if needed.
@@ -87,7 +87,7 @@ class TFKerasUtil(object):
                 dataset = dataset.batch(1).map(reshape)
 
             dataset = dataset.batch(batch_size).map(prep_data_tf_keras)
-            if hasattr(tf.data, 'AUTOTUNE'):
+            if not disable_autotune_batch_prefetch and hasattr(tf.data, 'AUTOTUNE'):
                 dataset = dataset.prefetch(tf.data.AUTOTUNE)
             else:
                 dataset = dataset.prefetch(1)

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -243,6 +243,45 @@ class SparkKerasTests(tf.test.TestCase):
                     label_prob = row.label_prob.toArray().tolist()
                     assert label_prob[int(row.label_pred)] == max(label_prob)
 
+    def test_fit_model_with_disable_autotune_batch_prefetch(self):
+        model = create_xor_model()
+        optimizer = get_sgd_optimizer()
+        loss = 'binary_crossentropy'
+
+        with spark_session('test_fit_model_with_disable_autotune_batch_prefetch') as spark:
+            df = create_xor_data(spark)
+
+            with local_store() as store:
+                keras_estimator = hvd.KerasEstimator(
+                    num_proc=2,
+                    store=store,
+                    model=model,
+                    optimizer=optimizer,
+                    loss=loss,
+                    feature_cols=['features'],
+                    label_cols=['y'],
+                    batch_size=1,
+                    random_seed=1,
+                    epochs=3,
+                    verbose=2,
+                    use_gpu=False,
+                    mp_start_method='spawn',
+                    disable_autotune_batch_prefetch=True)
+
+                assert not keras_estimator.getUseGpu()
+                assert 'spawn' == keras_estimator.getMpStartMethod()
+
+                keras_estimator.setMpStartMethod('forkserver')
+                assert 'forkserver' == keras_estimator.getMpStartMethod()
+
+                keras_model = keras_estimator.fit(df)
+
+                trained_model = keras_model.getModel()
+                pred = trained_model.predict([np.ones([1, 2], dtype=np.float32)])
+                assert len(pred) == 1
+                assert pred.dtype == np.float32
+
+
     @mock.patch('horovod.spark.keras.remote._pin_gpu_fn')
     @mock.patch('horovod.spark.keras.util.TFKerasUtil.fit_fn')
     def test_restore_from_checkpoint(self, mock_fit_fn, mock_pin_gpu_fn):

--- a/test/integration/test_spark_keras.py
+++ b/test/integration/test_spark_keras.py
@@ -243,12 +243,12 @@ class SparkKerasTests(tf.test.TestCase):
                     label_prob = row.label_prob.toArray().tolist()
                     assert label_prob[int(row.label_pred)] == max(label_prob)
 
-    def test_fit_model_with_disable_autotune_batch_prefetch(self):
+    def test_fit_model_with_tensorflow_dataset_prefetch_buffer_size(self):
         model = create_xor_model()
         optimizer = get_sgd_optimizer()
         loss = 'binary_crossentropy'
 
-        with spark_session('test_fit_model_with_disable_autotune_batch_prefetch') as spark:
+        with spark_session('test_fit_model_with_tensorflow_dataset_prefetch_buffer_size') as spark:
             df = create_xor_data(spark)
 
             with local_store() as store:
@@ -266,7 +266,7 @@ class SparkKerasTests(tf.test.TestCase):
                     verbose=2,
                     use_gpu=False,
                     mp_start_method='spawn',
-                    disable_autotune_batch_prefetch=True)
+                    tensorflow_dataset_prefetch_buffer_size=1)
 
                 assert not keras_estimator.getUseGpu()
                 assert 'spawn' == keras_estimator.getMpStartMethod()


### PR DESCRIPTION
Add support for disabling autotune parameter for batch prefetch as it results into memory leak with ray.

tf.data.autotune prefetches more than one batch which cause a spiky increase in the memory. Adding an option to disable it will help configure the models which are OOMing because of high memory usage

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/horovod/horovod/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs?
- [x] Did you write any tests to validate this change?  
- [x] Did you update the [CHANGELOG](https://github.com/horovod/horovod/blob/master/CHANGELOG.md), if this change affects users?

## Description
Added additional param to disable the autotune batch prefetch behavior at the time of data loading such that models which can OOM due to high memory usage can configure it to disable. 
Many models in Uber are facing this issue.

Fixes # (issue).
OOM due to memory leak in Keras + horovod training.
<img width="948" height="342" alt="Screenshot 2025-07-24 at 3 51 40 PM" src="https://github.com/user-attachments/assets/02c601f7-6998-4f0e-8555-39259bd022aa" />
<img width="952" height="345" alt="Screenshot 2025-07-24 at 3 51 45 PM" src="https://github.com/user-attachments/assets/756b4570-346d-4b06-bc5c-c9f39c313b49" />

## Review process to land 

1. All tests and other checks must succeed.
2. At least one member of the [technical steering committee](https://github.com/horovod/horovod/blob/master/GOVERNANCE.md) must review and approve.
3. If any member of the technical steering committee requests changes, they must be addressed.
