### PR TITLE
Fix compilation errors when using GCC 14 and CUDA C++ 11

### DIFF
--- a/horovod/common/ops/cuda/CMakeLists.txt
+++ b/horovod/common/ops/cuda/CMakeLists.txt
@@ -8,6 +8,10 @@ MESSAGE(STATUS "HVD_NVCC_COMPILE_FLAGS = ${HVD_NVCC_COMPILE_FLAGS}")
 # the --std=c++... argument is passed multiple times.
 set(CMAKE_CUDA_STANDARD 11)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+# NVCC compilation errors with gcc-14 and c++11
+if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14")
+  set(CMAKE_CUDA_STANDARD 14)
+endif()
 
 add_library(horovod_cuda_kernels cuda_kernels.cu)
 target_compile_options(horovod_cuda_kernels PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:


### PR DESCRIPTION
Bump CUDA C++ standard to 14 for GCC>=14.

There have been some discussions in other repos:
- https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/issues/12
- https://github.com/NVIDIA/nccl/issues/1743