### PR TITLE
Fix #4290: Doesn't Horovod support TensorFlow >= 2.16.1 ?

### DIFF
--- a/horovod/tensorflow/gradient_aggregation.py
+++ b/horovod/tensorflow/gradient_aggregation.py
@@ -3,6 +3,7 @@ import tensorflow as tf
 from packaging import version
 from horovod.tensorflow.mpi_ops import size_op
 from horovod.tensorflow.mpi_ops import global_process_set
+from horovod.tensorflow.util import _get_var_ref
 
 
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
@@ -82,7 +83,7 @@ class LocalGradientAggregationHelper:
         operations on gradients corresponding to these sources and will instead return the local
         gradient."""
         if _IS_TF2:
-            self._local_vars.add(var.ref())
+            self._local_vars.add(_get_var_ref(var))
         else:
             self._local_vars.add(var)
 
@@ -174,9 +175,9 @@ class LocalGradientAggregationHelper:
             rv = []
             rg = []
             if _IS_TF2:
-                v2g = {var.ref(): grad for var, grad in zip(vars, grads)}
+                v2g = {_get_var_ref(var): grad for var, grad in zip(vars, grads)}
                 for var, grad in zip(vars, grads):
-                    if var.ref() not in self._local_vars:
+                    if _get_var_ref(var) not in self._local_vars:
                         rv.append(var)
                         rg.append(grad)
             else:
@@ -190,7 +191,7 @@ class LocalGradientAggregationHelper:
             horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
             if _IS_TF2:
                 for rv, rg in zip(rv, rg):
-                    v2g[rv.ref()] = rg
+                    v2g[_get_var_ref(rv)] = rg
 
                 if self.scale_local_gradients and len(self._local_vars):
                     # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
@@ -198,7 +199,7 @@ class LocalGradientAggregationHelper:
                         if v_ref in self._local_vars and v2g[v_ref] is not None:
                             v2g[v_ref] /= float(horovod_size)
 
-                return [v2g[rv.ref()] for rv in vars]
+                return [v2g[_get_var_ref(rv)] for rv in vars]
             else:
                 for rv, rg in zip(rv, rg):
                     v2g[rv] = rg
@@ -208,7 +209,7 @@ class LocalGradientAggregationHelper:
                     for v in v2g:
                         if v in self._local_vars and v2g[v] is not None:
                             v2g[v] /= float(horovod_size)
-     
+
                 return [v2g[rv] for rv in vars]
 
         # Read in latest variables values.

--- a/horovod/tensorflow/gradient_aggregation_eager.py
+++ b/horovod/tensorflow/gradient_aggregation_eager.py
@@ -3,10 +3,12 @@ import tensorflow as tf
 from packaging import version
 from horovod.tensorflow.mpi_ops import size_op
 from horovod.tensorflow.mpi_ops import global_process_set
+from horovod.tensorflow.util import _get_var_ref
 
 
 _POST_TF_2_4_0 = version.parse(tf.__version__) >= version.parse('2.4.0')
 _IS_TF2 = version.parse(tf.__version__) >= version.parse('2.0.0')
+_POST_TF_2_16_1 = version.parse(tf.__version__) >= version.parse('2.16.1')
 
 
 class LocalGradientAggregationHelperEager:
@@ -56,7 +58,7 @@ class LocalGradientAggregationHelperEager:
         operations on gradients corresponding to these sources and will instead return the local
         gradient."""
         if _IS_TF2:
-            self._local_vars.add(var.ref())
+            self._local_vars.add(_get_var_ref(var))
         else:
             self._local_vars.add(var)
 
@@ -123,9 +125,9 @@ class LocalGradientAggregationHelperEager:
             rv = []
             rg = []
             if _IS_TF2:
-                v2g = {var.ref(): grad for var, grad in zip(vars, grads)}
+                v2g = {_get_var_ref(var): grad for var, grad in zip(vars, grads)}
                 for var, grad in zip(vars, grads):
-                    if var.ref() not in self._local_vars:
+                    if _get_var_ref(var) not in self._local_vars:
                         rv.append(var)
                         rg.append(grad)
             else:
@@ -139,7 +141,7 @@ class LocalGradientAggregationHelperEager:
             horovod_size = size_op(process_set_id=self.process_set.process_set_id) if int(os.environ.get("HOROVOD_ELASTIC", 0)) else self.process_set.size()
             if _IS_TF2:
                 for rv, rg in zip(rv, rg):
-                    v2g[rv.ref()] = rg
+                    v2g[_get_var_ref(rv)] = rg
 
                 if self.scale_local_gradients and len(self._local_vars):
                     # Scale local gradients by a size factor. See pull/3695 and discussions/3705 for context.
@@ -147,7 +149,7 @@ class LocalGradientAggregationHelperEager:
                         if v_ref in self._local_vars and v2g[v_ref] is not None:
                             v2g[v_ref] /= float(horovod_size)
 
-                return [v2g[rv.ref()] for rv in vars]
+                return [v2g[_get_var_ref(rv)] for rv in vars]
             else:
                 for rv, rg in zip(rv, rg):
                     v2g[rv] = rg

--- a/horovod/tensorflow/util.py
+++ b/horovod/tensorflow/util.py
@@ -14,9 +14,11 @@
 # ==============================================================================
 
 import tensorflow as tf
-
+from packaging import version
 
 from tensorflow.python.eager import context
+
+_POST_TF_2_16_1 = version.parse(tf.__version__) >= version.parse('2.16.1')
 
 
 def _executing_eagerly():
@@ -44,13 +46,37 @@ def _cache(f):
     return wrapper
 
 
+def _get_var_ref(var):
+    """Get a reference to a variable that can be used as a dict key or in a set.
+
+    In TensorFlow < 2.16.1, variables have a .ref() method that returns a reference.
+    In TensorFlow >= 2.16.1, variables are directly hashable.
+    """
+    if _POST_TF_2_16_1:
+        return var
+    else:
+        return var.ref()
+
+
+def _deref_var(ref):
+    """Convert a variable reference back to a variable.
+
+    In TensorFlow < 2.16.1, references have a .deref() method.
+    In TensorFlow >= 2.16.1, references are the variables themselves.
+    """
+    if _POST_TF_2_16_1:
+        return ref
+    else:
+        return ref.deref()
+
+
 def vars_to_refs(vars):
     if isinstance(vars, list):
         return tuple(vars_to_refs(v) for v in vars)
-    return vars.ref()
+    return _get_var_ref(vars)
 
 
 def refs_to_vars(refs):
     if isinstance(refs, tuple):
         return [refs_to_vars(r) for r in refs]
-    return refs.deref()
+    return _deref_var(refs)


### PR DESCRIPTION
Fixes #4290

## Summary
This PR fixes: Doesn't Horovod support TensorFlow >= 2.16.1 ?

## Changes
```
horovod/tensorflow/gradient_aggregation.py       | 13 +++++-----
 horovod/tensorflow/gradient_aggregation_eager.py | 12 +++++----
 horovod/tensorflow/util.py                       | 32 +++++++++++++++++++++---
 3 files changed, 43 insertions(+), 14 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).